### PR TITLE
dialogData content overlapping when TOP not specified

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogContent.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogContent.kt
@@ -81,7 +81,7 @@ fun DialogContent(
                             val topAnchor = if (data.topAnchor != null) {
                                 refs[data.topAnchor]?.bottom ?: parent.top
                             } else if (dataTop == null) {
-                                lastRef?.top ?: parent.top
+                                lastRef?.bottom ?: parent.top
                             } else {
                                 parentSkin?.top ?: parent.top
                             }


### PR DESCRIPTION
When building a dialogData content window, it tracks the previous element's `position` but sets the new element's `top` to match previous element's `top`, causing an overlap. It should be setting the new element's `top' to the previous element's `bottom`

Steps to recreate: 
1) Download the Gemstone Lich script: `targetwindow.lic`
2) run `;targetwindow window`
3) open the window
4) manually seed the window with: `;e puts("<dialogData id='TargetWindow' clear='t'><link id='total' value='Total Targets: 3' cmd='target next' echo='target next' justify='3' top='3' left='0' height='15' width='195'/><link id='484965563' value=' Rolton' cmd='target #484965563' echo='target #484965563'  justify='3' left='0' height='15' width='195'/><link id='484903078' value=' Rolton' cmd='target #484903078' echo='target #484903078'  justify='3' left='0' height='15' width='195'/><link id='484833811' value=' Rolton' cmd='target #484833811' echo='target #484833811'  justify='3' left='0' height='15' width='195'/></dialogData>")`