### PR TITLE
Make repeatCommand work with macros

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -526,8 +526,7 @@ class GameViewModel(
     suspend fun repeatCommand(index: Int) {
         val command = sendHistory.getOrNull(index)
         if (command != null) {
-            entryText.setTextAndPlaceCursorAtEnd(command)
-            submit()
+            commandHandler(command)
         }
     }
 


### PR DESCRIPTION
When doing repeatCommand send the command via entryText instead of directly from the client so macros will execute correctly.