### PR TITLE
fix version number in releases

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -72,6 +72,7 @@ nucleus.application {
 
     // SQLite calls a restricted method
     jvmArgs += "--enable-native-access=ALL-UNNAMED"
+    jvmArgs += "-Dwarlock.release.version=$releaseVersion"
 
     nativeDistributions {
 

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -100,7 +100,9 @@ import kotlin.io.path.inputStream
 import kotlin.system.exitProcess
 import kotlin.time.Duration.Companion.seconds
 
-private val version = NucleusApp.version
+private val version =
+    System.getProperty("warlock.release.version")?.takeIf { it.isNotBlank() }
+        ?: NucleusApp.version
 
 private class WarlockCommand : CliktCommand() {
     val port: Int? by option("-p", "--port", help = "Port to connect to").int()


### PR DESCRIPTION
Mac and Windows have the -beta part of the version removed which breaks channel upgrades