### PR TITLE
SGE login robustness, DB snapshot hardening, and dev debug logging

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -2,6 +2,8 @@ package warlockfe.warlock3.compose
 
 import androidx.room.RoomDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.execSQL
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -262,4 +264,28 @@ fun openPrefsDatabase(
                 .addMigrations(MIGRATION_10_11, MIGRATION_14_16)
                 .build()
         },
+        checkpoint = { dbPath -> checkpointDatabase(dbPath, fileSystem) },
     )
+
+private val snapshotLogger = Logger.withTag("DatabaseSnapshot")
+
+/**
+ * Fold a source database's write-ahead log into its main `.db` file (via
+ * `PRAGMA wal_checkpoint(TRUNCATE)`) so that copying the main file alone captures all committed
+ * data. Best-effort: a non-WAL database makes this a no-op, and any failure is logged rather than
+ * aborting startup.
+ */
+private fun checkpointDatabase(
+    path: Path,
+    fileSystem: FileSystem,
+) {
+    if (!fileSystem.exists(path)) return
+    runCatching {
+        val connection = MySQLiteDriver(BundledSQLiteDriver()).open(path.toString())
+        try {
+            connection.execSQL("PRAGMA wal_checkpoint(TRUNCATE)")
+        } finally {
+            connection.close()
+        }
+    }.onFailure { snapshotLogger.w(it) { "Failed to checkpoint ${path.name} before seeding snapshot" } }
+}

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshot.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshot.kt
@@ -55,6 +55,11 @@ fun findSeedCandidate(
  *  3. Hand the target path to [buildDatabase], which is responsible for invoking the platform
  *     Room builder, registering migrations, and returning the built database.
  *  4. On migration failure, delete the target so the next launch may recover, then rethrow.
+ *
+ * [checkpoint] is invoked on a source database immediately before it is copied. It must fold any
+ * write-ahead log into the main `.db` file (e.g. `PRAGMA wal_checkpoint(TRUNCATE)`) so that copying
+ * the main file alone captures all committed data. This is required because only the main file is
+ * copied -- copying the `-wal`/`-shm` sidecars to a new path is unsafe and can drop recent writes.
  */
 fun <T> openVersionedDatabase(
     directory: Path,
@@ -62,10 +67,11 @@ fun <T> openVersionedDatabase(
     currentVersion: Int,
     buildDatabase: (databasePath: Path) -> T,
     legacyFileName: String,
+    checkpoint: (databasePath: Path) -> Unit = {},
 ): T {
     fileSystem.createDirectories(directory)
 
-    migrateLegacyDatabase(directory, legacyFileName, currentVersion, fileSystem)
+    migrateLegacyDatabase(directory, legacyFileName, currentVersion, fileSystem, checkpoint)
 
     val target = Path(directory, snapshotFileName(currentVersion))
     val seedSource: SnapshotInfo? =
@@ -76,6 +82,7 @@ fun <T> openVersionedDatabase(
             when {
                 candidate == null -> null
                 else -> {
+                    checkpoint(candidate.path)
                     copySnapshot(candidate.path, target, fileSystem)
                     logger.i { "Seeded ${target.name} from ${candidate.path.name}" }
                     candidate
@@ -107,7 +114,14 @@ fun <T> openVersionedDatabase(
 }
 
 /**
- * Copy [source] to [target] (plus any -wal/-shm sidecars that exist next to [source]).
+ * Copy the main `.db` file of [source] to [target]. The `-wal`/`-shm` sidecars are deliberately
+ * NOT copied: a `-shm` is shared-memory coordination state and a `-wal` copied to a new path can
+ * be ignored or mis-replayed by SQLite, reverting the database to a pre-checkpoint state and
+ * silently dropping recent writes. Callers must checkpoint [source] first so the main file holds
+ * all committed data (see [openVersionedDatabase]).
+ *
+ * Any stale `-wal`/`-shm` left next to [target] is removed after the copy so it cannot be applied
+ * on top of the freshly seeded, self-contained main file.
  *
  * The copy is atomic-ish: bytes are written to a `<target>.tmp` companion first and only renamed
  * into place once the write completes. If [target] appears between the existence check and the
@@ -122,48 +136,22 @@ fun copySnapshot(
     if (fileSystem.exists(target)) return // another process / earlier step won
 
     val targetParent = target.parent ?: Path(".")
-    val sourceParent = source.parent ?: Path(".")
-
-    data class SidecarCopy(
-        val source: Path,
-        val tmp: Path,
-        val target: Path,
-    )
     val mainTmp = Path(targetParent, target.name + ".tmp")
-    val sidecars =
-        sidecarSuffixes.mapNotNull { suffix ->
-            val src = Path(sourceParent, source.name + suffix)
-            if (!fileSystem.exists(src)) return@mapNotNull null
-            SidecarCopy(
-                source = src,
-                tmp = Path(targetParent, target.name + suffix + ".tmp"),
-                target = Path(targetParent, target.name + suffix),
-            )
-        }
-
-    fun cleanupTmps() {
-        runCatching { fileSystem.delete(mainTmp, mustExist = false) }
-        for (s in sidecars) runCatching { fileSystem.delete(s.tmp, mustExist = false) }
-    }
 
     try {
         copyFile(source, mainTmp, fileSystem)
-        for (s in sidecars) copyFile(s.source, s.tmp, fileSystem)
 
         if (fileSystem.exists(target)) {
-            cleanupTmps()
+            runCatching { fileSystem.delete(mainTmp, mustExist = false) }
             return
         }
         fileSystem.atomicMove(mainTmp, target)
-        for (s in sidecars) {
-            if (fileSystem.exists(s.target)) {
-                fileSystem.delete(s.tmp, mustExist = false)
-            } else {
-                fileSystem.atomicMove(s.tmp, s.target)
-            }
+        // Drop any leftover sidecars so SQLite opens the copied main file from a clean state.
+        for (suffix in sidecarSuffixes) {
+            runCatching { fileSystem.delete(Path(targetParent, target.name + suffix), mustExist = false) }
         }
     } catch (t: Throwable) {
-        cleanupTmps()
+        runCatching { fileSystem.delete(mainTmp, mustExist = false) }
         throw t
     }
 }
@@ -192,12 +180,14 @@ private fun migrateLegacyDatabase(
     legacyFileName: String,
     currentVersion: Int,
     fileSystem: FileSystem,
+    checkpoint: (databasePath: Path) -> Unit,
 ) {
     val legacy = Path(directory, legacyFileName)
     if (!fileSystem.exists(legacy)) return
     if (listSnapshots(directory, fileSystem).isNotEmpty()) return
 
     val target = Path(directory, snapshotFileName(currentVersion))
+    checkpoint(legacy)
     copySnapshot(legacy, target, fileSystem)
     logger.i { "Copied legacy $legacyFileName to ${target.name}" }
 }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshot.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshot.kt
@@ -145,11 +145,12 @@ fun copySnapshot(
             runCatching { fileSystem.delete(mainTmp, mustExist = false) }
             return
         }
-        fileSystem.atomicMove(mainTmp, target)
-        // Drop any leftover sidecars so SQLite opens the copied main file from a clean state.
+        // Drop any leftover sidecars BEFORE the main file lands, so there is never a moment where
+        // the freshly copied main coexists with a stale -wal/-shm that SQLite could mis-apply.
         for (suffix in sidecarSuffixes) {
             runCatching { fileSystem.delete(Path(targetParent, target.name + suffix), mustExist = false) }
         }
+        fileSystem.atomicMove(mainTmp, target)
     } catch (t: Throwable) {
         runCatching { fileSystem.delete(mainTmp, mustExist = false) }
         throw t

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshotTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshotTest.kt
@@ -82,7 +82,7 @@ class DatabaseSnapshotTest {
     }
 
     @Test
-    fun copySnapshot_copiesMainAndSidecarsAtomically() {
+    fun copySnapshot_copiesOnlyMainAndIgnoresSourceSidecars() {
         val source = Path(dir, "warlock-v10.db")
         write(source, "main")
         write(Path(dir, "warlock-v10.db-wal"), "wal")
@@ -92,11 +92,27 @@ class DatabaseSnapshotTest {
         copySnapshot(source, target, fs)
 
         assertEquals("main", read(target))
-        assertEquals("wal", read(Path(dir, "warlock-v17.db-wal")))
-        assertEquals("shm", read(Path(dir, "warlock-v17.db-shm")))
+        // Sidecars are deliberately not copied; the main file is expected to be self-contained.
+        assertFalse(fs.exists(Path(dir, "warlock-v17.db-wal")))
+        assertFalse(fs.exists(Path(dir, "warlock-v17.db-shm")))
         assertFalse(fs.exists(Path(dir, "warlock-v17.db.tmp")))
-        assertFalse(fs.exists(Path(dir, "warlock-v17.db-wal.tmp")))
         assertTrue(fs.exists(source))
+        // Source sidecars are left untouched.
+        assertTrue(fs.exists(Path(dir, "warlock-v10.db-wal")))
+    }
+
+    @Test
+    fun copySnapshot_removesStaleTargetSidecars() {
+        write(Path(dir, "warlock-v10.db"), "main")
+        // Leftovers from a previous crashed/aborted seed next to the target.
+        write(Path(dir, "warlock-v17.db-wal"), "stale-wal")
+        write(Path(dir, "warlock-v17.db-shm"), "stale-shm")
+
+        copySnapshot(Path(dir, "warlock-v10.db"), Path(dir, "warlock-v17.db"), fs)
+
+        assertEquals("main", read(Path(dir, "warlock-v17.db")))
+        assertFalse(fs.exists(Path(dir, "warlock-v17.db-wal")))
+        assertFalse(fs.exists(Path(dir, "warlock-v17.db-shm")))
     }
 
     @Test
@@ -117,6 +133,7 @@ class DatabaseSnapshotTest {
     private fun open(
         currentVersion: Int = 17,
         legacy: String = "prefs.db",
+        checkpoint: (Path) -> Unit = {},
         build: (Path) -> Unit = { path -> if (!fs.exists(path)) write(path, "fresh") },
     ) = openVersionedDatabase(
         directory = dir,
@@ -124,6 +141,7 @@ class DatabaseSnapshotTest {
         currentVersion = currentVersion,
         legacyFileName = legacy,
         buildDatabase = build,
+        checkpoint = checkpoint,
     )
 
     @Test
@@ -146,9 +164,27 @@ class DatabaseSnapshotTest {
         write(Path(dir, "warlock-v10.db"), "v10-data")
         write(Path(dir, "warlock-v14.db"), "v14-data")
         var saw: String? = null
-        open { path -> saw = read(path) }
+        open(build = { path -> saw = read(path) })
         assertEquals("v14-data", saw)
         assertTrue(fs.exists(Path(dir, "warlock-v14.db")))
+    }
+
+    @Test
+    fun checkpointsSeedSourceBeforeCopying() {
+        write(Path(dir, "warlock-v10.db"), "v10-data")
+        write(Path(dir, "warlock-v14.db"), "v14-data")
+        val checkpointed = mutableListOf<String>()
+        // The seed source must be checkpointed before it is copied so its WAL is folded in first.
+        open(checkpoint = { path -> checkpointed.add(path.name) })
+        assertEquals(listOf("warlock-v14.db"), checkpointed)
+    }
+
+    @Test
+    fun checkpointsLegacySourceBeforeCopying() {
+        write(Path(dir, "prefs.db"), "legacy-data")
+        val checkpointed = mutableListOf<String>()
+        open(checkpoint = { path -> checkpointed.add(path.name) })
+        assertEquals(listOf("prefs.db"), checkpointed)
     }
 
     @Test

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -56,13 +56,14 @@ kotlin {
 }
 
 // TODO: verify version fits nucleus tag pattern
-val releaseVersion: String =
+val resolvedReleaseVersion: String? =
     System
         .getenv("RELEASE_VERSION")
         ?.removePrefix("v")
         ?.takeIf { it.isNotBlank() }
         ?: project.version.toString().takeIf { it != "unspecified" }
-        ?: "0.0.0"
+
+val releaseVersion: String = resolvedReleaseVersion ?: "0.0.0"
 
 // Dmg/Msi accept only MAJOR.MINOR.PATCH; strip any "-beta3"-style suffix.
 val numericPackageVersion: String = releaseVersion.substringBefore('-')
@@ -72,7 +73,11 @@ nucleus.application {
 
     // SQLite calls a restricted method
     jvmArgs += "--enable-native-access=ALL-UNNAMED"
-    jvmArgs += "-Dwarlock.release.version=$releaseVersion"
+    // Only inject a version for real releases; leaving it unset in dev lets the app
+    // detect dev mode (version == null) and enable debug logging.
+    if (resolvedReleaseVersion != null) {
+        jvmArgs += "-Dwarlock.release.version=$releaseVersion"
+    }
 
     nativeDistributions {
         val currentOs = OperatingSystem.current()

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -98,9 +98,7 @@ import java.io.File
 import kotlin.system.exitProcess
 import kotlin.time.Duration.Companion.seconds
 
-private val version =
-    System.getProperty("warlock.release.version")?.takeIf { it.isNotBlank() }
-        ?: NucleusApp.version
+private val version = System.getProperty("warlock.release.version")?.takeIf { it.isNotBlank() }
 
 private class WarlockCommand : CliktCommand() {
     val port: Int? by option("-p", "--port", help = "Port to connect to").int()

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -43,7 +43,6 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.versionOption
 import com.github.ajalt.clikt.parameters.types.boolean
 import com.github.ajalt.clikt.parameters.types.int
-import io.github.kdroidfilter.nucleus.core.runtime.NucleusApp
 import io.github.kdroidfilter.nucleus.updater.NucleusUpdater
 import io.github.kdroidfilter.nucleus.updater.UpdateInfo
 import io.github.kdroidfilter.nucleus.updater.UpdateResult

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslScriptInstance.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslScriptInstance.kt
@@ -3,7 +3,6 @@ package warlockfe.warlock3.scripting.wsl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/SgeClientImpl.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/SgeClientImpl.kt
@@ -169,7 +169,11 @@ class SgeClientImpl(
                 _eventFlow.emit(SgeEvent.SgeReadyToPlayEvent(credentials))
             }
 
-            SgeResponse.SgeUnrecognizedResponse -> Unit // TODO: implement?
+            SgeResponse.SgeUnrecognizedResponse -> {
+                // Don't leave the login flow waiting on data we can't interpret; report it.
+                logger.w { "Unrecognized SGE response, treating as error: $line" }
+                _eventFlow.emit(SgeEvent.SgeErrorEvent(SgeError.UNKNOWN_ERROR))
+            }
         }
     }
 
@@ -236,6 +240,10 @@ class SgeClientImpl(
                 }
             }
 
+            // The server replies with a bare "?" when it cannot parse the command we sent
+            // (e.g. a malformed login). Surface it as an error instead of waiting for a timeout.
+            '?' -> SgeResponse.SgeErrorResponse(SgeError.UNKNOWN_ERROR)
+
             else -> SgeResponse.SgeUnrecognizedResponse
         }
 
@@ -268,6 +276,13 @@ class SgeClientImpl(
         password: String,
     ) {
         this@SgeClientImpl.username = username
+        if (password.isEmpty()) {
+            // An empty password produces a malformed "A\t<user>\t\n" command that the server
+            // rejects with "?". Fail up front with a clear error instead of sending it.
+            logger.w { "Refusing to log in with an empty password" }
+            _eventFlow.emit(SgeEvent.SgeErrorEvent(SgeError.INVALID_PASSWORD))
+            return
+        }
         val encryptedPassword = encryptPassword(password.encodeWindows1252())
         val output = "A\t$username\t".encodeWindows1252() + encryptedPassword + '\n'.code.toByte()
         send(output)
@@ -307,11 +322,16 @@ class SgeClientImpl(
         settings: SgeSettings,
         connection: StoredConnection,
     ): AutoConnectResult {
+        val password = connection.password
+        if (password.isNullOrEmpty()) {
+            logger.e { "No password stored for ${connection.username}; cannot auto-connect" }
+            return AutoConnectResult.Failure("No password saved for ${connection.username}")
+        }
         if (!connect(settings)) {
             logger.e { "Unable to connect to server" }
             return AutoConnectResult.Failure("Could not connect to SGE")
         }
-        login(username = connection.username, password = connection.password ?: "")
+        login(username = connection.username, password = password)
 
         return withTimeoutOrNull(30.seconds) {
             while (true) {


### PR DESCRIPTION
Bundles several independent fixes worked out while investigating an SGE login failure (server returning a bare `?` on connect).

## Changes

**SGE login fails fast instead of hanging** (`c53ab87b`)
- Treat a bare `?` (server could not parse our command) and any other unrecognized response as an error event, instead of silently dropping it and waiting for the 30s timeout.
- Reject an empty password up front: `login()` emits `INVALID_PASSWORD` and `autoConnect()` returns a `Failure` before connecting, rather than sending a malformed `A\t<user>\t\n` command the server rejects.

**Database snapshot hardening** (`bd369fec`)
- Versioned-snapshot seeding now checkpoints each source (`PRAGMA wal_checkpoint(TRUNCATE)`) and copies only the main `.db` file, clearing any stale `-wal`/`-shm` next to the target. Copying SQLite sidecars to a new path is unsafe; checkpoint-then-copy-main is the recommended approach. (Hardening — the originally observed null-password DBs were most likely an interim-build artifact, not this copy path.)
- New tests cover copy-only-main, stale-sidecar cleanup, and checkpoint-before-seed for both the seed and legacy sources.

**Dev debug logging** (`5b4d6e77`, `f3f8f429`)
- Running from gradle in development no longer injects a release version, so dev mode is detected and debug logging is enabled. Drops an unused import.

## Testing
- `:core:jvmTest` snapshot tests pass (14/14).
- `:wrayth`, `:core`, `:compose` compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)