### PR TITLE
Guard config saves with read-modify-write under a cross-process lock

### DIFF
--- a/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.jvmAndroid.kt
+++ b/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.jvmAndroid.kt
@@ -1,0 +1,41 @@
+package warlockfe.warlock3.core.prefs.config
+
+import co.touchlab.kermit.Logger
+import kotlinx.io.files.Path
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.channels.FileLock
+
+internal actual fun withFileLock(
+    lockFile: Path,
+    block: () -> Unit,
+) {
+    val file = File(lockFile.toString())
+    file.parentFile?.mkdirs()
+    val handle =
+        try {
+            RandomAccessFile(file, "rw")
+        } catch (e: Exception) {
+            Logger.w(e) { "Could not open lock file $lockFile; writing without a cross-process lock" }
+            block()
+            return
+        }
+    handle.use { raf ->
+        var lock: FileLock? = null
+        try {
+            // Exclusive, blocks until any other process holding the lock releases it.
+            lock = raf.channel.lock()
+        } catch (e: Exception) {
+            Logger.w(e) { "Could not acquire lock on $lockFile; writing without a cross-process lock" }
+        }
+        try {
+            block()
+        } finally {
+            try {
+                lock?.release()
+            } catch (_: Exception) {
+                // Closing the channel via use{} releases the lock anyway.
+            }
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
@@ -88,7 +88,11 @@ class CharacterConfigStore(
         }
         state.value = normalized
         for (key in changed) {
-            writeMutex.withLock { persist(key, normalized.getValue(key)) }
+            val target = pathForCharacter(key)
+            writeMutex.withLock {
+                ensureParentDir(target)
+                withFileLock(lockFileFor(target)) { persist(key, normalized.getValue(key)) }
+            }
         }
     }
 
@@ -96,11 +100,24 @@ class CharacterConfigStore(
         characterId: String,
         transform: (CharacterConfig) -> CharacterConfig,
     ) {
+        val target = pathForCharacter(characterId)
         writeMutex.withLock {
-            val current = state.value[characterId] ?: CharacterConfig(character = characterId)
-            val updated = transform(current).copy(character = characterId)
-            state.value = state.value + (characterId to updated)
-            persist(characterId, updated)
+            ensureParentDir(target)
+            withFileLock(lockFileFor(target)) {
+                // Read-modify-write against the current on-disk file so a concurrent write from
+                // another app instance isn't clobbered: re-read inside the lock, apply the transform
+                // to that, then persist. The transform (an upsert / move / delete) composes onto
+                // whatever the other process last wrote, instead of overwriting it with a stale
+                // in-memory snapshot.
+                val onDisk = readConfig(target)
+                if (onDisk != null) templates[characterId] = onDisk.first
+                val base =
+                    (onDisk?.second ?: state.value[characterId] ?: CharacterConfig(character = characterId))
+                        .copy(character = characterId)
+                val updated = transform(base).copy(character = characterId)
+                state.value = state.value + (characterId to updated)
+                persist(characterId, updated)
+            }
         }
     }
 
@@ -140,10 +157,7 @@ class CharacterConfigStore(
     ) {
         val target = pathForCharacter(characterId)
         runCatching {
-            val parent = target.parent
-            if (parent != null && fileSystem.metadataOrNull(parent) == null) {
-                fileSystem.createDirectories(parent)
-            }
+            ensureParentDir(target)
             // When we have the file's previously parsed document, re-encode against it so existing
             // comments are carried over (matched to highlights/names by their `id` so they follow an
             // entry across reorders). Brand-new files have no template and just encode fresh.
@@ -163,6 +177,17 @@ class CharacterConfigStore(
             Logger.e(it) { "Failed to write config file $target" }
         }
     }
+
+    private fun ensureParentDir(target: Path) {
+        val parent = target.parent
+        if (parent != null && fileSystem.metadataOrNull(parent) == null) {
+            fileSystem.createDirectories(parent)
+        }
+    }
+
+    // A sibling `.lock` file we hold the cross-process lock on while writing `target`. Kept separate
+    // from the config file itself because the config is replaced via atomicMove on every save.
+    private fun lockFileFor(target: Path): Path = Path(target.parent ?: rootDir, target.name + ".lock")
 
     // Character ids look like "gs4:tholan"; lay them out as characters/<gameCode>/<name>.toml so the
     // files are easy to browse. The authoritative id is also stored inside the file.

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.kt
@@ -1,0 +1,16 @@
+package warlockfe.warlock3.core.prefs.config
+
+import kotlinx.io.files.Path
+
+/**
+ * Runs [block] while holding an exclusive, cross-process advisory lock keyed on [lockFile] (a
+ * sibling `.lock` file of the config being written), so two app instances can't interleave writes to
+ * the same config file. On single-process platforms (iOS) it simply runs [block].
+ *
+ * The lock is best-effort: if it can't be acquired (unsupported filesystem, IO error) the block
+ * still runs, degrading to no cross-process coordination rather than dropping the user's write.
+ */
+internal expect fun withFileLock(
+    lockFile: Path,
+    block: () -> Unit,
+)

--- a/core/src/iosMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.ios.kt
+++ b/core/src/iosMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.ios.kt
@@ -1,0 +1,10 @@
+package warlockfe.warlock3.core.prefs.config
+
+import kotlinx.io.files.Path
+
+// iOS apps are single-process, so there's no cross-process contention to guard against; the store's
+// in-memory mutex already serializes writes.
+internal actual fun withFileLock(
+    lockFile: Path,
+    block: () -> Unit,
+) = block()

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigConcurrencyTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigConcurrencyTest.kt
@@ -1,0 +1,63 @@
+package warlockfe.warlock3.core.prefs.config
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import java.nio.file.Files
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Two app instances sharing a config dir (e.g. multi-boxing, which shares global.toml) must not
+ * clobber each other's saves. Each [CharacterConfigStore.mutate] re-reads the file under a
+ * cross-process lock and applies its transform to the current on-disk state.
+ */
+class CharacterConfigConcurrencyTest {
+    private val fs = SystemFileSystem
+    private lateinit var dir: Path
+    private lateinit var configDir: String
+
+    @BeforeTest
+    fun setUp() {
+        dir = Path(Files.createTempDirectory("config-concurrency-test").toAbsolutePath().toString())
+        configDir = dir.toString()
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        java.nio.file.Path
+            .of(dir.toString())
+            .deleteRecursively()
+    }
+
+    private fun addHighlight(
+        id: String,
+        pattern: String,
+    ): (CharacterConfig) -> CharacterConfig = { it.copy(highlights = it.highlights + HighlightConfig(id = id, pattern = pattern)) }
+
+    @Test
+    fun second_instance_does_not_clobber_the_first() =
+        runBlocking {
+            // Both instances launch and load the same (empty) starting state.
+            val instanceA = CharacterConfigStore(configDir, fs)
+            val instanceB = CharacterConfigStore(configDir, fs)
+            instanceA.load()
+            instanceB.load()
+
+            // A writes. B's in-memory snapshot is now stale (it never saw A's write).
+            instanceA.mutate(GLOBAL_CHARACTER_ID, addHighlight("a", "apple"))
+            instanceB.mutate(GLOBAL_CHARACTER_ID, addHighlight("b", "banana"))
+
+            // A fresh load sees BOTH highlights: B re-read A's write before applying its own.
+            val reloaded = CharacterConfigStore(configDir, fs)
+            reloaded.load()
+            val patterns = reloaded.current(GLOBAL_CHARACTER_ID).highlights.map { it.pattern }
+            assertEquals(setOf("apple", "banana"), patterns.toSet(), "a save was lost: $patterns")
+            assertTrue(patterns.size == 2, "expected exactly two highlights, got $patterns")
+        }
+}


### PR DESCRIPTION
Stacked on #128 (uses its `readConfig`-to-element refactor and the per-character template map).

## Problem
`global.toml` is shared across all characters, so two app instances (multi-boxing, or just launching the client twice) can both load it and then save in turn. The store kept an in-memory snapshot taken at load and rewrote the whole file from it on every save, so the second writer clobbered the first: a silent lost update, at whole-file granularity. The atomic temp-file write prevented corruption but not lost updates.

## Change
Every save is now a read-modify-write under an exclusive cross-process file lock:

- `mutate()` acquires a lock on a sibling `.lock` file, **re-reads the current on-disk config inside the lock**, applies its transform (an upsert / move / delete, which composes onto whatever the other process last wrote), then persists. The load-time id backfill writes under the same lock. Applies to both `global.toml` and per-character files.
- The lock is an `expect/actual`: a real `FileChannel.lock()` on JVM/Android (`commonJvmAndroidMain`), and a no-op on iOS where the app is single-process. Best-effort: if the lock can't be acquired (unsupported FS, IO error) the write still proceeds rather than dropping the edit.
- Re-reading inside the lock also keeps the comment template current, so preserved comments reflect the latest file.

## Scope / limits
- Fixes lost updates on concurrent **writes**. It does not make in-memory **reads** live: instance B still shows its loaded snapshot until it next saves (or reloads), at which point it picks up A's changes. Live cross-process refresh (file watching) is out of scope.
- The `.lock` files are advisory and sit beside the configs (consistent with the existing `prefs.db.lck`). They're ignored by the loader (not `.toml`).

## Test
`CharacterConfigConcurrencyTest`: two `CharacterConfigStore` instances over one dir both load empty, A adds a highlight, B (with a stale snapshot) adds another; a fresh load sees **both**, proving B re-read A's write instead of clobbering it. Full `:core:jvmTest` passes; JVM + Android + shared metadata compile; ktlint clean.

Note: iOS Kotlin/Native can't be cross-compiled on the Linux CI host, so the iOS actual (a trivial pass-through matching the `expect`) was verified by inspection, following the existing `PlatformBufferedWriter.ios.kt` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)