### PR TITLE
Reload config files changed out of band

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -143,6 +143,8 @@ abstract class AppContainer(
                 fileSystem = fileSystem,
                 configDirectory = warlockDirs.configDir,
             ).migrateIfNeeded()
+            // Pick up external edits and writes from other app instances for the app's lifetime.
+            characterConfigStore.startWatching(externalScope)
         }
     }
 

--- a/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigWatcher.jvmAndroid.kt
+++ b/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigWatcher.jvmAndroid.kt
@@ -1,0 +1,81 @@
+package warlockfe.warlock3.core.prefs.config
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.nio.file.ClosedWatchServiceException
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardWatchEventKinds.ENTRY_CREATE
+import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
+import java.nio.file.StandardWatchEventKinds.OVERFLOW
+import java.nio.file.WatchKey
+
+internal actual fun watchConfigChanges(rootDir: String): Flow<String> =
+    callbackFlow {
+        val root = Path.of(rootDir)
+        runCatching { Files.createDirectories(root) }
+        val watchService = FileSystems.getDefault().newWatchService()
+        val keys = HashMap<WatchKey, Path>()
+
+        // WatchService is not recursive, so register the root and every existing subdirectory, and
+        // pick up new subdirectories (e.g. characters/<gameCode>) as they appear.
+        fun register(dir: Path) {
+            runCatching {
+                if (Files.isDirectory(dir)) {
+                    keys[dir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY)] = dir
+                }
+            }
+        }
+
+        fun registerTree(start: Path) {
+            if (!Files.exists(start)) return
+            runCatching {
+                Files.walk(start).use { stream ->
+                    stream.filter { Files.isDirectory(it) }.forEach { register(it) }
+                }
+            }
+        }
+
+        registerTree(root)
+
+        val job =
+            launch(Dispatchers.IO) {
+                try {
+                    while (isActive) {
+                        val key = watchService.take()
+                        val dir = keys[key]
+                        if (dir != null) {
+                            for (event in key.pollEvents()) {
+                                if (event.kind() == OVERFLOW) continue
+                                val name = event.context() as? Path ?: continue
+                                val child = dir.resolve(name)
+                                if (event.kind() == ENTRY_CREATE && Files.isDirectory(child)) {
+                                    registerTree(child)
+                                } else if (child.toString().endsWith(".toml")) {
+                                    trySend(child.toString())
+                                }
+                            }
+                        }
+                        if (!key.reset()) {
+                            keys.remove(key)
+                            if (keys.isEmpty()) break
+                        }
+                    }
+                } catch (_: ClosedWatchServiceException) {
+                    // Expected when the flow is cancelled and we close the service below.
+                } catch (e: Exception) {
+                    Logger.w(e) { "Config file watch loop stopped" }
+                }
+            }
+
+        awaitClose {
+            job.cancel()
+            runCatching { watchService.close() }
+        }
+    }

--- a/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.jvmAndroid.kt
+++ b/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.jvmAndroid.kt
@@ -1,0 +1,41 @@
+package warlockfe.warlock3.core.prefs.config
+
+import co.touchlab.kermit.Logger
+import kotlinx.io.files.Path
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.channels.FileLock
+
+internal actual fun withFileLock(
+    lockFile: Path,
+    block: () -> Unit,
+) {
+    val file = File(lockFile.toString())
+    file.parentFile?.mkdirs()
+    val handle =
+        try {
+            RandomAccessFile(file, "rw")
+        } catch (e: Exception) {
+            Logger.w(e) { "Could not open lock file $lockFile; writing without a cross-process lock" }
+            block()
+            return
+        }
+    handle.use { raf ->
+        var lock: FileLock? = null
+        try {
+            // Exclusive, blocks until any other process holding the lock releases it.
+            lock = raf.channel.lock()
+        } catch (e: Exception) {
+            Logger.w(e) { "Could not acquire lock on $lockFile; writing without a cross-process lock" }
+        }
+        try {
+            block()
+        } finally {
+            try {
+                lock?.release()
+            } catch (_: Exception) {
+                // Closing the channel via use{} releases the lock anyway.
+            }
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
@@ -6,11 +6,14 @@ import dev.eav.tomlkt.TomlElement
 import dev.eav.tomlkt.TomlLiteral
 import dev.eav.tomlkt.TomlTable
 import dev.eav.tomlkt.encodeToString
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.io.buffered
@@ -92,6 +95,33 @@ class CharacterConfigStore(
             writeMutex.withLock {
                 ensureParentDir(target)
                 withFileLock(lockFileFor(target)) { persist(key, normalized.getValue(key)) }
+            }
+        }
+    }
+
+    /**
+     * Watches the config directory and reloads any file changed out of band (a hand edit, or a save
+     * from another app instance) into memory, so observers see the latest content. Call once after
+     * [load]; the watch runs for the lifetime of [scope].
+     */
+    fun startWatching(scope: CoroutineScope) {
+        scope.launch {
+            watchConfigChanges(rootDir.toString()).collect { changedPath ->
+                reloadFile(Path(changedPath))
+            }
+        }
+    }
+
+    // Reload a single externally-changed file. Reads under [writeMutex] so it can't race a concurrent
+    // mutate, and skips when the content already matches memory (e.g. our own save echoing back).
+    private suspend fun reloadFile(path: Path) {
+        writeMutex.withLock {
+            val (element, config) = readConfig(path) ?: return@withLock
+            val key = config.character.ifEmpty { characterIdFromPath(path) }
+            val fixed = config.copy(character = key)
+            if (state.value[key] != fixed) {
+                templates[key] = element
+                state.value = state.value + (key to fixed)
             }
         }
     }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
@@ -88,7 +88,11 @@ class CharacterConfigStore(
         }
         state.value = normalized
         for (key in changed) {
-            writeMutex.withLock { persist(key, normalized.getValue(key)) }
+            val target = pathForCharacter(key)
+            writeMutex.withLock {
+                ensureParentDir(target)
+                withFileLock(lockFileFor(target)) { persist(key, normalized.getValue(key)) }
+            }
         }
     }
 
@@ -96,11 +100,24 @@ class CharacterConfigStore(
         characterId: String,
         transform: (CharacterConfig) -> CharacterConfig,
     ) {
+        val target = pathForCharacter(characterId)
         writeMutex.withLock {
-            val current = state.value[characterId] ?: CharacterConfig(character = characterId)
-            val updated = transform(current).copy(character = characterId)
-            state.value = state.value + (characterId to updated)
-            persist(characterId, updated)
+            ensureParentDir(target)
+            withFileLock(lockFileFor(target)) {
+                // Read-modify-write against the current on-disk file so a concurrent write from
+                // another app instance isn't clobbered: re-read inside the lock, apply the transform
+                // to that, then persist. The transform (an upsert / move / delete) composes onto
+                // whatever the other process last wrote, instead of overwriting it with a stale
+                // in-memory snapshot.
+                val onDisk = readConfig(target)
+                if (onDisk != null) templates[characterId] = onDisk.first
+                val base =
+                    (onDisk?.second ?: state.value[characterId] ?: CharacterConfig(character = characterId))
+                        .copy(character = characterId)
+                val updated = transform(base).copy(character = characterId)
+                state.value = state.value + (characterId to updated)
+                persist(characterId, updated)
+            }
         }
     }
 
@@ -140,10 +157,7 @@ class CharacterConfigStore(
     ) {
         val target = pathForCharacter(characterId)
         runCatching {
-            val parent = target.parent
-            if (parent != null && fileSystem.metadataOrNull(parent) == null) {
-                fileSystem.createDirectories(parent)
-            }
+            ensureParentDir(target)
             // When we have the file's previously parsed document, re-encode against it so existing
             // comments are carried over (matched to highlights/names by their `id` so they follow an
             // entry across reorders). Brand-new files have no template and just encode fresh.
@@ -163,6 +177,17 @@ class CharacterConfigStore(
             Logger.e(it) { "Failed to write config file $target" }
         }
     }
+
+    private fun ensureParentDir(target: Path) {
+        val parent = target.parent
+        if (parent != null && fileSystem.metadataOrNull(parent) == null) {
+            fileSystem.createDirectories(parent)
+        }
+    }
+
+    // A sibling `.lock` file we hold the cross-process lock on while writing `target`. Kept separate
+    // from the config file itself because the config is replaced via atomicMove on every save.
+    private fun lockFileFor(target: Path): Path = Path(target.parent ?: rootDir, target.name + ".lock")
 
     // Character ids look like "gs4:tholan"; lay them out as characters/<gameCode>/<name>.toml so the
     // files are easy to browse. The authoritative id is also stored inside the file.

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigWatcher.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigWatcher.kt
@@ -1,0 +1,12 @@
+package warlockfe.warlock3.core.prefs.config
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Emits the absolute path of any `.toml` file under [rootDir] that is created or modified on disk,
+ * so the store can reload configs that were changed out of band: a hand edit in a text editor, or a
+ * save from another running app instance. The flow runs until cancelled.
+ *
+ * No-op (empty) on platforms with no external editors and a single process (iOS).
+ */
+internal expect fun watchConfigChanges(rootDir: String): Flow<String>

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.kt
@@ -1,0 +1,16 @@
+package warlockfe.warlock3.core.prefs.config
+
+import kotlinx.io.files.Path
+
+/**
+ * Runs [block] while holding an exclusive, cross-process advisory lock keyed on [lockFile] (a
+ * sibling `.lock` file of the config being written), so two app instances can't interleave writes to
+ * the same config file. On single-process platforms (iOS) it simply runs [block].
+ *
+ * The lock is best-effort: if it can't be acquired (unsupported filesystem, IO error) the block
+ * still runs, degrading to no cross-process coordination rather than dropping the user's write.
+ */
+internal expect fun withFileLock(
+    lockFile: Path,
+    block: () -> Unit,
+)

--- a/core/src/iosMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigWatcher.ios.kt
+++ b/core/src/iosMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigWatcher.ios.kt
@@ -1,0 +1,8 @@
+package warlockfe.warlock3.core.prefs.config
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+// iOS is single-process and these configs aren't edited by an external editor, so there are no
+// out-of-band changes to watch for.
+internal actual fun watchConfigChanges(rootDir: String): Flow<String> = emptyFlow()

--- a/core/src/iosMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.ios.kt
+++ b/core/src/iosMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.ios.kt
@@ -1,0 +1,10 @@
+package warlockfe.warlock3.core.prefs.config
+
+import kotlinx.io.files.Path
+
+// iOS apps are single-process, so there's no cross-process contention to guard against; the store's
+// in-memory mutex already serializes writes.
+internal actual fun withFileLock(
+    lockFile: Path,
+    block: () -> Unit,
+) = block()

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigConcurrencyTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigConcurrencyTest.kt
@@ -1,0 +1,63 @@
+package warlockfe.warlock3.core.prefs.config
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import java.nio.file.Files
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Two app instances sharing a config dir (e.g. multi-boxing, which shares global.toml) must not
+ * clobber each other's saves. Each [CharacterConfigStore.mutate] re-reads the file under a
+ * cross-process lock and applies its transform to the current on-disk state.
+ */
+class CharacterConfigConcurrencyTest {
+    private val fs = SystemFileSystem
+    private lateinit var dir: Path
+    private lateinit var configDir: String
+
+    @BeforeTest
+    fun setUp() {
+        dir = Path(Files.createTempDirectory("config-concurrency-test").toAbsolutePath().toString())
+        configDir = dir.toString()
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        java.nio.file.Path
+            .of(dir.toString())
+            .deleteRecursively()
+    }
+
+    private fun addHighlight(
+        id: String,
+        pattern: String,
+    ): (CharacterConfig) -> CharacterConfig = { it.copy(highlights = it.highlights + HighlightConfig(id = id, pattern = pattern)) }
+
+    @Test
+    fun second_instance_does_not_clobber_the_first() =
+        runBlocking {
+            // Both instances launch and load the same (empty) starting state.
+            val instanceA = CharacterConfigStore(configDir, fs)
+            val instanceB = CharacterConfigStore(configDir, fs)
+            instanceA.load()
+            instanceB.load()
+
+            // A writes. B's in-memory snapshot is now stale (it never saw A's write).
+            instanceA.mutate(GLOBAL_CHARACTER_ID, addHighlight("a", "apple"))
+            instanceB.mutate(GLOBAL_CHARACTER_ID, addHighlight("b", "banana"))
+
+            // A fresh load sees BOTH highlights: B re-read A's write before applying its own.
+            val reloaded = CharacterConfigStore(configDir, fs)
+            reloaded.load()
+            val patterns = reloaded.current(GLOBAL_CHARACTER_ID).highlights.map { it.pattern }
+            assertEquals(setOf("apple", "banana"), patterns.toSet(), "a save was lost: $patterns")
+            assertTrue(patterns.size == 2, "expected exactly two highlights, got $patterns")
+        }
+}

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigWatchTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigWatchTest.kt
@@ -1,0 +1,103 @@
+package warlockfe.warlock3.core.prefs.config
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.writeString
+import java.nio.file.Files
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The store reloads files changed out of band (hand edits, or writes from another app instance) so
+ * observers see the latest content without a restart. Relies on the platform WatchService, so it
+ * polls with a generous timeout rather than asserting an exact latency.
+ */
+class CharacterConfigWatchTest {
+    private val fs = SystemFileSystem
+    private lateinit var dir: Path
+    private lateinit var configDir: String
+
+    @BeforeTest
+    fun setUp() {
+        dir = Path(Files.createTempDirectory("config-watch-test").toAbsolutePath().toString())
+        configDir = dir.toString()
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        java.nio.file.Path
+            .of(dir.toString())
+            .deleteRecursively()
+    }
+
+    private fun globalFile() = Path(configDir, "$GLOBAL_CHARACTER_ID.toml")
+
+    private fun globalToml(vararg patterns: String): String =
+        buildString {
+            appendLine("character = \"global\"")
+            for (p in patterns) {
+                appendLine()
+                appendLine("[[highlights]]")
+                appendLine("id = \"$p-id\"")
+                appendLine("pattern = \"$p\"")
+            }
+        }
+
+    // Write the way another instance would: a complete file swapped in atomically.
+    private fun atomicWrite(
+        path: Path,
+        text: String,
+    ) {
+        val tmp = Path(path.parent ?: Path(configDir), path.name + ".ext.tmp")
+        fs.sink(tmp).buffered().use { it.writeString(text) }
+        fs.atomicMove(tmp, path)
+    }
+
+    @Test
+    fun external_edit_is_reloaded_into_memory() =
+        runBlocking {
+            atomicWrite(globalFile(), globalToml("apple"))
+
+            val store = CharacterConfigStore(configDir, fs)
+            store.load()
+            assertTrue(
+                store
+                    .current(GLOBAL_CHARACTER_ID)
+                    .highlights
+                    .single()
+                    .pattern == "apple",
+            )
+
+            val watchScope = CoroutineScope(Dispatchers.IO + Job())
+            store.startWatching(watchScope)
+            delay(500) // let the watcher register its directories before we change the file
+
+            // Another instance (or the user in a text editor) adds a highlight.
+            atomicWrite(globalFile(), globalToml("apple", "banana"))
+
+            try {
+                withTimeout(15_000) {
+                    while (store.current(GLOBAL_CHARACTER_ID).highlights.none { it.pattern == "banana" }) {
+                        delay(100)
+                    }
+                }
+            } finally {
+                watchScope.cancel()
+            }
+
+            val patterns = store.current(GLOBAL_CHARACTER_ID).highlights.map { it.pattern }
+            assertTrue("banana" in patterns, "external edit was not reloaded: $patterns")
+        }
+}


### PR DESCRIPTION
Stacked on #129. Completes the multi-instance / external-edit story: #129 made concurrent **writes** safe; this makes **reads** stay current.

## Problem
An instance kept the snapshot it loaded at startup and only picked up another instance's (or an external editor's) changes the next time it wrote. Since these files are meant to be hand-editable, edits made in a text editor never appeared live.

## Change
- `watchConfigChanges(rootDir)` is an `expect/actual` that emits the path of any `.toml` file created/modified on disk: a recursive `WatchService` on JVM/Android (`commonJvmAndroidMain`, registers the root and subdirectories and picks up new `characters/<gameCode>` dirs), and empty on iOS (single-process, no external editors).
- `CharacterConfigStore.startWatching(scope)` collects it and reloads each changed file under the write mutex, skipping when the content already matches memory so the store's own saves don't churn. `AppContainer` starts it after load + migration, for the app's lifetime.
- `mutate()` is unchanged: it still re-reads the file on disk **inside the write lock** before writing, so it never trusts the (possibly-lagging) watched snapshot. That is the "after we lock, read the most recent version" guarantee, and it sits below the watcher.

## Test
`CharacterConfigWatchTest`: load a file with one highlight, start watching, then atomically rewrite the file (as another instance/editor would) adding a second highlight; the store's in-memory state reflects the new highlight. Polls with a generous timeout since it depends on the platform `WatchService`. Full `:core:jvmTest` passes; core + compose JVM/Android + shared metadata compile; ktlint clean.

Note: iOS Kotlin/Native isn't cross-compilable on the Linux host; the iOS actual is an `emptyFlow()` matching the `expect`, verified by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)