### PR TITLE
Add a JMH benchmark for the Wrayth protocol parser

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,9 +7,11 @@ android-kmp-library = { id = "com.android.kotlin.multiplatform.library", version
 antlr-kotlin = { id = "com.strumenta.antlr-kotlin", version.ref = "antlr-kotlin" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
 nucleus = { id = "io.github.kdroidfilter.nucleus", version.ref = "nucleus" }
@@ -46,6 +48,7 @@ jewel = "0.37.0-261.25134.95"
 ## ⬆ = "0.37.0-262.4852.51"
 kermit = "2.1.0"
 kotlin = "2.4.0"
+kotlinx-benchmark = "0.4.14"
 kotlinx-collections-immutable = "0.5.0"
 kotlinx-coroutines =  "1.11.0"
 kotlinx-datetime = "0.8.0"
@@ -95,6 +98,7 @@ kermit = { group = "co.touchlab", name = "kermit", version.ref = "kermit" }
 ktlint-compose-rules = { module = "io.nlopez.compose.rules:ktlint", version.ref = "ktlint-compose-rules" }
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
+kotlinx-benchmark-runtime = { group = "org.jetbrains.kotlinx", name = "kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }

--- a/wrayth/build.gradle.kts
+++ b/wrayth/build.gradle.kts
@@ -9,6 +9,14 @@ plugins {
     alias(libs.plugins.android.kmp.library)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.antlr.kotlin)
+    alias(libs.plugins.kotlin.allopen)
+    alias(libs.plugins.kotlinx.benchmark)
+}
+
+// JMH (which kotlinx-benchmark uses on the JVM) subclasses @State benchmark classes, so they must be open.
+allOpen {
+    annotation("org.openjdk.jmh.annotations.State")
+    annotation("kotlinx.benchmark.State")
 }
 
 val generateKotlinGrammarSource =
@@ -43,7 +51,14 @@ val generateKotlinGrammarSource =
 val skipIos = (findProperty("iosSkip") as? String)?.toBoolean() == true
 
 kotlin {
-    jvm()
+    jvm {
+        // A separate compilation so benchmark code (and the kotlinx-benchmark runtime) stays out of the
+        // published library. Sources live in src/jvmBenchmark/kotlin; it can see the main classpath.
+        val main by compilations.getting
+        compilations.create("benchmark") {
+            associateWith(main)
+        }
+    }
     androidLibrary {
         namespace = "warlockfe.warlock3.wrayth"
         compileSdk =
@@ -96,7 +111,7 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.kotlinx.serialization.core)
                 implementation(libs.xmlutil.serialization)
-                implementation(libs.antlr.kotlin.runtime)
+                api(libs.antlr.kotlin.runtime)
                 implementation(libs.ktor.network)
                 implementation(libs.ktor.network.tls)
             }
@@ -105,11 +120,30 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }
+
+        getByName("jvmBenchmark").dependencies {
+            implementation(libs.kotlinx.benchmark.runtime)
+        }
     }
 
     compilerOptions {
         optIn.add("kotlin.time.ExperimentalTime")
         optIn.add("kotlin.experimental.ExperimentalNativeApi")
         freeCompilerArgs.add("-Xexpect-actual-classes")
+    }
+}
+
+benchmark {
+    configurations {
+        named("main") {
+            warmups = 5
+            iterations = 5
+            iterationTime = 1
+            iterationTimeUnit = "s"
+        }
+    }
+    targets {
+        // <jvm target><Benchmark compilation> -> "jvmBenchmark"
+        register("jvmBenchmark")
     }
 }

--- a/wrayth/src/jvmBenchmark/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolParserBenchmark.kt
+++ b/wrayth/src/jvmBenchmark/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolParserBenchmark.kt
@@ -1,0 +1,61 @@
+package warlockfe.warlock3.wrayth.protocol
+
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Blackhole
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.State
+import org.antlr.v4.kotlinruntime.CharStreams
+import org.antlr.v4.kotlinruntime.CommonTokenStream
+import warlockfe.warlock3.wrayth.parsers.generated.WraythLexer
+import warlockfe.warlock3.wrayth.parsers.generated.WraythParser
+
+/**
+ * Microbenchmarks for the Wrayth protocol parser: the lexer + parser + [WraythNodeVisitor] pipeline
+ * that turns one line of SGE protocol into a list of [Content]. This is the pure parse step (no
+ * protocol-handler state), measured across representative line shapes.
+ *
+ * Run with: `./gradlew :wrayth:jvmBenchmarkBenchmark` (or `:wrayth:benchmark` for all targets).
+ */
+@State(Scope.Benchmark)
+class WraythProtocolParserBenchmark {
+    // Plain narrative text with no tags - the common case, exercises the TEXT lexer rule.
+    private val plainText = "You see a tall orc warrior standing guard by the gate, gripping a rusty halberd."
+
+    // A combat line with styling and a clickable noun - a typical mix of tags, attributes, and text.
+    private val styledLine =
+        "<pushBold/>You attack the <a exist=\"42\" noun=\"orc\">orc</a> and <preset id=\"speech\">it staggers back</preset>!"
+
+    // Stream routing plus a component update - nested empty/start/end tags.
+    private val streamLine =
+        "<pushStream id=\"inv\"/>a leather backpack<popStream/><component id=\"room desc\">A wide cobbled plaza.</component>"
+
+    // A room line dense with command links, including angle brackets inside an attribute value.
+    private val linkHeavyLine =
+        "<style id=\"roomName\"/>[Town Square Central]<style id=\"\"/> Obvious exits: " +
+            "<a cmd=\"go north\">north</a>, <a cmd=\"go east\">east</a>, <d cmd=\"go <hidden path>\">a hidden path</d>."
+
+    // Text peppered with entity and character references - exercises the reference rules and unescaping.
+    private val entityHeavyLine =
+        "Roundtime: 3 sec. &lt;A &amp; B&gt; deal &#62;50 damage &#x26; gain &lt;xp&gt; for the &quot;kill&quot;."
+
+    @Benchmark
+    fun parsePlainText(bh: Blackhole) = bh.consume(parse(plainText))
+
+    @Benchmark
+    fun parseStyledLine(bh: Blackhole) = bh.consume(parse(styledLine))
+
+    @Benchmark
+    fun parseStreamLine(bh: Blackhole) = bh.consume(parse(streamLine))
+
+    @Benchmark
+    fun parseLinkHeavyLine(bh: Blackhole) = bh.consume(parse(linkHeavyLine))
+
+    @Benchmark
+    fun parseEntityHeavyLine(bh: Blackhole) = bh.consume(parse(entityHeavyLine))
+
+    private fun parse(line: String): List<Content> {
+        val lexer = WraythLexer(CharStreams.fromString(line))
+        val parser = WraythParser(CommonTokenStream(lexer))
+        return WraythNodeVisitor.visitDocument(parser.document())
+    }
+}


### PR DESCRIPTION
## Summary

Adds a JMH-backed benchmark (via `kotlinx-benchmark`) for the Wrayth protocol parser, scoped to wrayth's JVM target.

**Build wiring** (`gradle/libs.versions.toml`, `wrayth/build.gradle.kts`):
- Adds the `kotlinx-benchmark` (0.4.14) and `kotlin-allopen` plugins and the `kotlinx-benchmark-runtime` library to the version catalog.
- Adds a dedicated **`benchmark` compilation** on the `jvm()` target (associated with `main`), so benchmark code and the runtime stay out of the published library. Sources live in `src/jvmBenchmark/kotlin`.
- `allOpen { … @State … }` so JMH can subclass the benchmark state class.
- A `benchmark { }` block registering the `jvmBenchmark` target (5 warmups / 5 × 1s measurement iterations).

**Benchmark** (`WraythProtocolParserBenchmark`): measures the pure parse pipeline (lexer + parser + `WraythNodeVisitor` → `List<Content>`) — the parser proper, no protocol-handler state — across five representative line shapes: plain text, a styled combat line, stream/component routing, a link-heavy room line (with `<…>` inside an attribute value), and an entity/char-reference-heavy line.

Run with:
```
./gradlew :wrayth:jvmBenchmarkBenchmark
```

## Testing

`./gradlew :wrayth:build` passes; JMH codegen/compile/jar succeed; ktlint clean. Smoke run produced numbers (plain text ~134k ops/s; tag/link-heavy lines ~20–40k ops/s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)