### PR TITLE
Report parser benchmark throughput in ops/ms

### DIFF
--- a/wrayth/src/jvmBenchmark/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolParserBenchmark.kt
+++ b/wrayth/src/jvmBenchmark/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolParserBenchmark.kt
@@ -1,7 +1,11 @@
 package warlockfe.warlock3.wrayth.protocol
 
 import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.BenchmarkTimeUnit
 import kotlinx.benchmark.Blackhole
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
 import kotlinx.benchmark.Scope
 import kotlinx.benchmark.State
 import org.antlr.v4.kotlinruntime.CharStreams
@@ -15,8 +19,13 @@ import warlockfe.warlock3.wrayth.parsers.generated.WraythParser
  * protocol-handler state), measured across representative line shapes.
  *
  * Run with: `./gradlew :wrayth:jvmBenchmarkBenchmark` (or `:wrayth:benchmark` for all targets).
+ *
+ * Throughput is reported in operations per millisecond - small, readable numbers, vs. the
+ * ~10^5-10^6 ops/second the default unit would print.
  */
 @State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 class WraythProtocolParserBenchmark {
     // Plain narrative text with no tags - the common case, exercises the TEXT lexer rule.
     private val plainText = "You see a tall orc warrior standing guard by the gate, gripping a rusty halberd."


### PR DESCRIPTION
## Summary

Adds `@BenchmarkMode(Throughput)` + `@OutputTimeUnit(MILLISECONDS)` to `WraythProtocolParserBenchmark` so results print as small, readable **operations-per-millisecond** numbers instead of the ~10^5–10^6 ops/second the default unit produces.

Before:
```
parsePlainText   1461152.491 ops/s
parseLinkHeavyLine 182276.715 ops/s
```
After:
```
parsePlainText      ~1596 ops/ms
parseLinkHeavyLine   ~168 ops/ms
```

(JMH's text table has no thousands-grouping or k/M/G option, so choosing a smaller unit is the clean, native way to keep the numbers readable.)

## Testing

`./gradlew :wrayth:assembleBenchmarks` succeeds; ktlint clean; a smoke run confirms `ops/ms` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)