### PR TITLE
Parser handler: reuse instances, stateless element listeners, benchmark parseLine

### DIFF
--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
@@ -110,16 +110,24 @@ class WraythProtocolHandler {
             "updateverbs" to UpdateVerbsHandler(),
         )
 
+    // Reused across [parseLine] calls (see the note there). Error listeners are removed so malformed
+    // game lines don't spam stderr - parseLine catches parse failures and emits a WraythParseErrorEvent.
+    private val lexer = WraythLexer(CharStreams.fromString("")).apply { removeErrorListeners() }
+    private val parser = WraythParser(CommonTokenStream(lexer)).apply { removeErrorListeners() }
+
     fun parseLine(line: String): List<WraythEvent> {
         return try {
             // Ignore lines with Wizard commands
             if (line.startsWith('\u001C')) {
                 return emptyList()
             }
-            val inputStream = CharStreams.fromString(line)
-            val lexer = WraythLexer(inputStream)
-            val tokens = CommonTokenStream(lexer)
-            val parser = WraythParser(tokens)
+            // Reuse the lexer/parser (and their ATN simulators / DFA cache) across lines, resetting
+            // them per call, to avoid per-line allocation. Safe because parseLine is only ever called
+            // sequentially on a single connection's read loop.
+            lexer.inputStream = CharStreams.fromString(line)
+            lexer.reset()
+            parser.tokenStream = CommonTokenStream(lexer)
+            parser.reset()
             val contents = WraythNodeVisitor.visitDocument(parser.document())
             handleContent(contents)
         } catch (e: Exception) {

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
@@ -139,14 +139,17 @@ class WraythProtocolHandler {
     private fun handleContent(contents: List<Content>): List<WraythEvent> {
         // open/close tags must occur on the same line
         var lineHasTags = false
-        val tagStack = ArrayDeque<String>()
+        val tagStack = ArrayDeque<OpenTag>()
         val events = mutableListOf<WraythEvent>()
+
+        fun close(tag: OpenTag): WraythEvent? = elementListeners[tag.name]?.endElement(tag.element.attributes, tag.chars.toString())
+
         for (content in contents) {
             when (content) {
                 is StartElement -> {
                     lineHasTags = true
                     val tagName = content.name.lowercase()
-                    tagStack.addFirst(tagName)
+                    tagStack.addFirst(OpenTag(tagName, content))
                     val listener = elementListeners[tagName]
                     if (listener != null) {
                         listener.startElement(content)?.let {
@@ -170,28 +173,27 @@ class WraythProtocolHandler {
                         tagStack.firstOrNull()
                             ?: continue // rule #1
                     val tagName = content.name.lowercase()
-                    if (topOfStack != tagName) {
-                        logger.e { "Received end element ($tagName) does not match element on the top of the stack ($topOfStack)!" }
-                        if (tagStack.contains(tagName)) {
-                            while (tagName != tagStack.first()) {
+                    val matched: OpenTag
+                    if (topOfStack.name != tagName) {
+                        logger.e {
+                            "Received end element ($tagName) does not match element on the top of the stack (${topOfStack.name})!"
+                        }
+                        if (tagStack.any { it.name == tagName }) {
+                            while (tagName != tagStack.first().name) {
                                 // close excess tags - rule #3
-                                val unbalancedTag = tagStack.removeFirst()
-                                elementListeners[unbalancedTag]?.endElement()?.let {
-                                    events.add(it)
-                                }
+                                close(tagStack.removeFirst())?.let { events.add(it) }
                             }
+                            matched = tagStack.first()
                         } else {
                             // ignore unmatched end tag - rule #2
                             continue
                         }
                     } else {
                         // remove the matched tag from the stack - rule #0
-                        tagStack.removeFirst()
+                        matched = tagStack.removeFirst()
                     }
                     // rules 0, and 3
-                    elementListeners[tagName]?.endElement()?.let {
-                        events.add(it)
-                    }
+                    close(matched)?.let { events.add(it) }
                 }
 
                 is CharData -> {
@@ -199,10 +201,12 @@ class WraythProtocolHandler {
 
                     // Go through the stack until someone handles these characters,
                     //   otherwise use the default handler
-                    for (tagName in tagStack) {
-                        val event = elementListeners[tagName]?.characters(content.data)
+                    for (tag in tagStack) {
+                        val event = elementListeners[tag.name]?.characters(content.data)
                         if (event != null) {
                             charEvent = event
+                            // Accumulate the consumed text so the tag's endElement can use it.
+                            tag.chars.append(content.data)
                             break
                         }
                     }
@@ -214,10 +218,9 @@ class WraythProtocolHandler {
                 }
             }
         }
-        // Close remaining open tags
+        // Close remaining open tags - rule #5
         while (tagStack.isNotEmpty()) {
-            val topOfStack = tagStack.removeFirst()
-            elementListeners[topOfStack]?.endElement()?.let { events.add(it) }
+            close(tagStack.removeFirst())?.let { events.add(it) }
         }
         // If a line has tags, ignore it when it has no text
         events.add(WraythEolEvent(ignoreWhenBlank = lineHasTags))
@@ -231,6 +234,26 @@ interface ElementListener {
     fun characters(data: String): WraythEvent?
 
     fun endElement(): WraythEvent?
+
+    /**
+     * Called when the element closes, with the element's [attributes] and the character [text]
+     * accumulated inside it. Listeners that need that context (e.g. a command link) override this and
+     * stay stateless; the rest inherit the default, which ignores both and falls back to [endElement].
+     */
+    fun endElement(
+        attributes: Map<String, String>,
+        text: String,
+    ): WraythEvent? = endElement()
+}
+
+// The state needed to close an open tag, tracked by the handler (not the element listeners) so the
+// shared listener instances stay stateless: the tag name, its start element (for attributes), and the
+// character data accumulated inside it.
+private class OpenTag(
+    val name: String,
+    val element: StartElement,
+) {
+    val chars = StringBuilder()
 }
 
 abstract class BaseElementListener : ElementListener {

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/DHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/DHandler.kt
@@ -7,22 +7,14 @@ import warlockfe.warlock3.wrayth.protocol.WraythEvent
 import warlockfe.warlock3.wrayth.protocol.WraythHandledEvent
 
 class DHandler : BaseElementListener() {
-    private val stringBuilder = StringBuilder()
-    private var command: String? = null
+    // Consume the start tag and the inner text; the command and accumulated text are supplied on close
+    // by the protocol handler, so this listener holds no state and is safe to share across elements.
+    override fun startElement(element: StartElement): WraythEvent = WraythHandledEvent
 
-    override fun startElement(element: StartElement): WraythEvent {
-        command = element.attributes["cmd"]
-        return WraythHandledEvent
-    }
+    override fun characters(data: String): WraythEvent = WraythHandledEvent
 
-    override fun characters(data: String): WraythEvent {
-        stringBuilder.append(data)
-        return WraythHandledEvent
-    }
-
-    override fun endElement(): WraythEvent {
-        val text = stringBuilder.toString()
-        stringBuilder.clear()
-        return WraythActionEvent(text, command ?: text)
-    }
+    override fun endElement(
+        attributes: Map<String, String>,
+        text: String,
+    ): WraythEvent = WraythActionEvent(text, attributes["cmd"] ?: text)
 }

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/PromptHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/PromptHandler.kt
@@ -1,27 +1,24 @@
 package warlockfe.warlock3.wrayth.protocol.elements
 
-import warlockfe.warlock3.wrayth.protocol.ElementListener
+import warlockfe.warlock3.wrayth.protocol.BaseElementListener
 import warlockfe.warlock3.wrayth.protocol.StartElement
 import warlockfe.warlock3.wrayth.protocol.WraythEvent
 import warlockfe.warlock3.wrayth.protocol.WraythHandledEvent
 import warlockfe.warlock3.wrayth.protocol.WraythPromptEvent
 import warlockfe.warlock3.wrayth.protocol.WraythTimeEvent
 
-class PromptHandler : ElementListener {
-    // the following is undefined: <prompt> <prompt>foo</prompt> bar </prompt>
-    private val prompt = StringBuilder()
-
-    override fun startElement(element: StartElement): WraythEvent? {
-        prompt.setLength(0)
-        return element.attributes["time"]?.toLongOrNull()?.let { time ->
+class PromptHandler : BaseElementListener() {
+    // The time attribute (if any) is emitted on open; the prompt text is accumulated by the protocol
+    // handler and supplied on close, so this listener holds no state.
+    override fun startElement(element: StartElement): WraythEvent? =
+        element.attributes["time"]?.toLongOrNull()?.let { time ->
             WraythTimeEvent(time = time)
         }
-    }
 
-    override fun characters(data: String): WraythEvent {
-        prompt.append(data)
-        return WraythHandledEvent
-    }
+    override fun characters(data: String): WraythEvent = WraythHandledEvent
 
-    override fun endElement(): WraythEvent = WraythPromptEvent(prompt.toString())
+    override fun endElement(
+        attributes: Map<String, String>,
+        text: String,
+    ): WraythEvent = WraythPromptEvent(text)
 }

--- a/wrayth/src/commonTest/kotlin/WraythBackgroundTests.kt
+++ b/wrayth/src/commonTest/kotlin/WraythBackgroundTests.kt
@@ -180,6 +180,27 @@ class WraythBackgroundTests {
         )
     }
 
+    @Test
+    fun reusedHandlerParsesConsecutiveLinesIndependently() {
+        // The handler reuses one lexer/parser across calls; consecutive lines must not contaminate
+        // each other.
+        val handler = WraythProtocolHandler()
+        val first = handler.parseLine("<background img=\"room1.png\" opacity=\"40\"/>")
+        val second =
+            handler.parseLine("<background img=\"room2.png\" mode=\"gradient\" start=\"10\" end=\"90\"/>")
+
+        assertEquals(backgroundEvent(image = "room1.png", opacity = 40), first.first())
+        assertEquals(
+            backgroundEvent(
+                image = "room2.png",
+                mode = BackgroundImageMode.GRADIENT,
+                gradientStart = 10,
+                gradientEnd = 90,
+            ),
+            second.first(),
+        )
+    }
+
     private fun backgroundEvent(
         windowName: String = "main",
         image: String? = null,

--- a/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
+++ b/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
@@ -1,0 +1,54 @@
+import warlockfe.warlock3.wrayth.protocol.WraythActionEvent
+import warlockfe.warlock3.wrayth.protocol.WraythProtocolHandler
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WraythProtocolHandlerTests {
+    @Test
+    fun commandLinkProducesActionEvent() {
+        val events = WraythProtocolHandler().parseLine("<d cmd=\"go north\">north</d>")
+
+        assertEquals(
+            WraythActionEvent(text = "north", command = "go north"),
+            events.filterIsInstance<WraythActionEvent>().single(),
+        )
+    }
+
+    @Test
+    fun commandLinkWithoutCmdUsesTextAsCommand() {
+        val events = WraythProtocolHandler().parseLine("<d>look</d>")
+
+        assertEquals(
+            WraythActionEvent(text = "look", command = "look"),
+            events.filterIsInstance<WraythActionEvent>().single(),
+        )
+    }
+
+    @Test
+    fun twoCommandLinksInOneLineAreIndependent() {
+        val events =
+            WraythProtocolHandler()
+                .parseLine("<d cmd=\"go north\">north</d> or <d cmd=\"go south\">south</d>")
+                .filterIsInstance<WraythActionEvent>()
+
+        assertEquals(
+            listOf(
+                WraythActionEvent("north", "go north"),
+                WraythActionEvent("south", "go south"),
+            ),
+            events,
+        )
+    }
+
+    @Test
+    fun consecutiveCommandLinksDoNotLeakState() {
+        // One handler parsing two command links in a row must not carry command/text between them -
+        // the per-element state lives in the protocol handler's tag stack, not the shared DHandler.
+        val handler = WraythProtocolHandler()
+        val first = handler.parseLine("<d cmd=\"go north\">north</d>").filterIsInstance<WraythActionEvent>().single()
+        val second = handler.parseLine("<d cmd=\"swim\">into the river</d>").filterIsInstance<WraythActionEvent>().single()
+
+        assertEquals(WraythActionEvent("north", "go north"), first)
+        assertEquals(WraythActionEvent("into the river", "swim"), second)
+    }
+}

--- a/wrayth/src/jvmBenchmark/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolParserBenchmark.kt
+++ b/wrayth/src/jvmBenchmark/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolParserBenchmark.kt
@@ -8,15 +8,11 @@ import kotlinx.benchmark.Mode
 import kotlinx.benchmark.OutputTimeUnit
 import kotlinx.benchmark.Scope
 import kotlinx.benchmark.State
-import org.antlr.v4.kotlinruntime.CharStreams
-import org.antlr.v4.kotlinruntime.CommonTokenStream
-import warlockfe.warlock3.wrayth.parsers.generated.WraythLexer
-import warlockfe.warlock3.wrayth.parsers.generated.WraythParser
 
 /**
- * Microbenchmarks for the Wrayth protocol parser: the lexer + parser + [WraythNodeVisitor] pipeline
- * that turns one line of SGE protocol into a list of [Content]. This is the pure parse step (no
- * protocol-handler state), measured across representative line shapes.
+ * Microbenchmarks for [WraythProtocolHandler.parseLine] - the full path that turns one line of SGE
+ * protocol into a list of [WraythEvent] (lex + parse + visit + element handling). Measured across
+ * representative line shapes on a single long-lived handler, as in production.
  *
  * Run with: `./gradlew :wrayth:jvmBenchmarkBenchmark` (or `:wrayth:benchmark` for all targets).
  *
@@ -27,6 +23,9 @@ import warlockfe.warlock3.wrayth.parsers.generated.WraythParser
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 class WraythProtocolParserBenchmark {
+    // One long-lived handler, reused across calls like the real connection read loop does.
+    private val handler = WraythProtocolHandler()
+
     // Plain narrative text with no tags - the common case, exercises the TEXT lexer rule.
     private val plainText = "You see a tall orc warrior standing guard by the gate, gripping a rusty halberd."
 
@@ -48,23 +47,17 @@ class WraythProtocolParserBenchmark {
         "Roundtime: 3 sec. &lt;A &amp; B&gt; deal &#62;50 damage &#x26; gain &lt;xp&gt; for the &quot;kill&quot;."
 
     @Benchmark
-    fun parsePlainText(bh: Blackhole) = bh.consume(parse(plainText))
+    fun parsePlainText(bh: Blackhole) = bh.consume(handler.parseLine(plainText))
 
     @Benchmark
-    fun parseStyledLine(bh: Blackhole) = bh.consume(parse(styledLine))
+    fun parseStyledLine(bh: Blackhole) = bh.consume(handler.parseLine(styledLine))
 
     @Benchmark
-    fun parseStreamLine(bh: Blackhole) = bh.consume(parse(streamLine))
+    fun parseStreamLine(bh: Blackhole) = bh.consume(handler.parseLine(streamLine))
 
     @Benchmark
-    fun parseLinkHeavyLine(bh: Blackhole) = bh.consume(parse(linkHeavyLine))
+    fun parseLinkHeavyLine(bh: Blackhole) = bh.consume(handler.parseLine(linkHeavyLine))
 
     @Benchmark
-    fun parseEntityHeavyLine(bh: Blackhole) = bh.consume(parse(entityHeavyLine))
-
-    private fun parse(line: String): List<Content> {
-        val lexer = WraythLexer(CharStreams.fromString(line))
-        val parser = WraythParser(CommonTokenStream(lexer))
-        return WraythNodeVisitor.visitDocument(parser.document())
-    }
+    fun parseEntityHeavyLine(bh: Blackhole) = bh.consume(handler.parseLine(entityHeavyLine))
 }


### PR DESCRIPTION
A few related improvements to `WraythProtocolHandler` and its benchmark.

## 1. Reuse the lexer/parser
`parseLine` built a fresh `CharStream`, lexer, token stream, and parser (each with their ATN simulators / DFA caches) on **every** line. It now reuses a single lexer/parser held by the handler, resetting them per call, cutting per-line allocation and GC pressure. Safe because `parseLine` is only ever called sequentially on a single connection's read loop. Also removes the default console error listeners, so malformed game lines no longer spam stderr (`parseLine` already catches failures and emits a `WraythParseErrorEvent`).

## 2. Make element listeners stateless
The element listeners are shared singletons, but `DHandler` and `PromptHandler` held per-element mutable state (the `cmd` attribute / accumulated text) bridged across `startElement → characters → endElement`. That per-element state now lives in `handleContent`'s tag stack: each open tag carries its start element and the character data accumulated inside it, handed back via a new `ElementListener.endElement(attributes, text)` overload (defaulting to the existing no-arg `endElement`, so the other ~12 listeners are untouched). `DHandler`/`PromptHandler` are now stateless, which is what makes the shared, reused handler clean and easy to test.

## 3. Benchmark `parseLine` directly
The benchmark now measures `WraythProtocolHandler.parseLine` on one long-lived handler (the real path) instead of replicating the lexer/parser pipeline.

## Testing
- New `WraythProtocolHandlerTests`: command-link output, and that consecutive / sibling `<d>` links don't leak state.
- New reuse test that consecutive `parseLine` calls stay independent.
- `./gradlew :wrayth:build` passes (all targets); existing parser/background tests green; ktlint clean; benchmark assembles and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)