### PR TITLE
Avoid List.removeFirst/removeLast SequencedCollection conflict

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeViewModel.kt
@@ -191,12 +191,10 @@ class SgeViewModel(
     }
 
     fun goBack() {
-        try {
-            backStack.removeLast()
-            _state.value = backStack.last()
-        } catch (_: NoSuchElementException) {
-            // Can't go back, double-clicked back button?
-        }
+        // Pop the current entry and show the previous one. No-op if the stack is empty
+        // (e.g. the back button was double-clicked).
+        backStack.removeLastOrNull()
+        backStack.lastOrNull()?.let { _state.value = it }
     }
 
     fun saveAccount(account: AccountEntity) {

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -199,8 +199,8 @@ class ComposeTextStream(
 
     private fun removeLines() {
         while (maxLines > 0 && finishedLines.size >= maxLines) {
-            finishedLines.removeFirst()
-            cacheLines.removeFirst()
+            finishedLines.removeAt(0)
+            cacheLines.removeAt(0)
             removedLines++
             // Intentionally leak components here. They don't exist in the main window,
             // and no other windows get long enough

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowsAtLocation.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowsAtLocation.kt
@@ -187,7 +187,7 @@ private fun DockableSection(
             itemBounds.add(Rect.Zero)
         }
         while (itemBounds.size > windowUiStates.size) {
-            itemBounds.removeLast()
+            itemBounds.removeAt(itemBounds.lastIndex)
         }
     }
 

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowsAtLocation.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowsAtLocation.kt
@@ -182,7 +182,7 @@ private fun DockableSection(
             itemBounds.add(Rect.Zero)
         }
         while (itemBounds.size > windowUiStates.size) {
-            itemBounds.removeLast()
+            itemBounds.removeAt(itemBounds.lastIndex)
         }
     }
 


### PR DESCRIPTION
## Summary
JDK 21 / Android API 35 added `SequencedCollection.removeFirst()` and `removeLast()` to `List`, which clash with Kotlin's stdlib `MutableList` functions of the same name and produce an SDK warning. This replaces the affected `MutableList`/`SnapshotStateList` calls with non-conflicting equivalents:

- `removeFirst()` → `removeAt(0)`
- `removeLast()` → `removeAt(lastIndex)`, or `removeLastOrNull()` where the empty case was previously handled by catching the thrown exception (`SgeViewModel.goBack`)

`ArrayDeque` usages (e.g. the Wrayth tag stack) are intentionally left as-is — `removeFirst` is the deque's own member there and does not trigger the warning.

## Test plan
- `./gradlew :compose:compileKotlinJvm` — builds clean
- ktlint passes on the touched source sets