### PR TITLE
Align IntelliJ continuation indent with ktlint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,11 @@
 root = true
 
 [{*.kt,*.kts}]
+indent_style = space
+indent_size = 4
+# Match ktlint's indent rule, which uses one indent level (4) for wrapped/continuation lines.
+# IntelliJ defaults to 8 here, which makes it re-indent continuations to a width ktlint rejects.
+ij_continuation_indent_size = 4
 ij_kotlin_imports_layout = *, java.**, javax.**, kotlin.**, ^
 ij_kotlin_name_count_to_use_star_import = 2147483647
 ij_kotlin_name_count_to_use_star_import_for_members = 2147483647


### PR DESCRIPTION
## Summary
ktlint's `indent` rule uses a single indent level (4 spaces) for wrapped/continuation lines, but IntelliJ defaults to 8 — so the IDE re-indents continuations to a width ktlint then rejects, causing recurring format churn.

This sets `indent_size` and `ij_continuation_indent_size` to `4` in `.editorconfig` so IntelliJ and ktlint agree, and the IDE stops fighting the linter.

## Test plan
- ktlint already enforces 4-space continuation, so existing code is unaffected.
- In IntelliJ, reformatting a file with wrapped expressions now produces ktlint-clean output.