### PR TITLE
Add minimum command length and history size settings

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -206,6 +206,7 @@ abstract class AppContainer(
             scriptManagerFactory = scriptManagerFactory,
             windowSettingsRepository = windowSettingRepository,
             progressBarSettingRepository = progressBarSettingRepository,
+            clientSettingRepository = clientSettings,
             ioDispatcher = ioDispatcher,
         )
     }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -67,6 +67,7 @@ import warlockfe.warlock3.core.macro.parseMacro
 import warlockfe.warlock3.core.prefs.models.ProgressBarSettingEntity
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterSettingsRepository
+import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
 import warlockfe.warlock3.core.prefs.repositories.DEFAULT_MAX_TYPE_AHEAD
 import warlockfe.warlock3.core.prefs.repositories.MAX_TYPE_AHEAD_KEY
 import warlockfe.warlock3.core.prefs.repositories.MacroRepository
@@ -103,6 +104,7 @@ class GameViewModel(
     aliasRepository: AliasRepository,
     private val windowRegistry: WindowRegistry,
     private val progressBarSettingRepository: ProgressBarSettingRepository,
+    private val clientSettingRepository: ClientSettingRepository,
     private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel(),
     MacroHandler {
@@ -346,13 +348,26 @@ class GameViewModel(
     private val _selectedWindow: MutableStateFlow<String> = MutableStateFlow("main")
     val selectedWindow: StateFlow<String> = _selectedWindow
 
-    private var minHistoryLen = 0
+    // Commands shorter than this are not saved to history; history is capped at historySize entries.
+    // Both are seeded from client settings (see init); the defaults apply until the flows emit.
+    private var minHistoryLen = ClientSettingRepository.DEFAULT_MIN_COMMAND_LENGTH
+    private var historySize = ClientSettingRepository.DEFAULT_HISTORY_SIZE
 
     val disconnected = client.disconnected
 
     val menuData = client.menuData
 
     init {
+        clientSettingRepository
+            .observeMinCommandLength()
+            .onEach { minHistoryLen = it }
+            .launchIn(viewModelScope)
+        clientSettingRepository
+            .observeHistorySize()
+            .onEach {
+                historySize = it
+                trimHistory()
+            }.launchIn(viewModelScope)
         // Load initial
         client.characterId
             .onEach { characterId ->
@@ -554,6 +569,15 @@ class GameViewModel(
         if (line.length >= minHistoryLen && sendHistory.getOrNull(1) != line) {
             sendHistory[0] = line
             sendHistory.add(0, "")
+            trimHistory()
+        }
+    }
+
+    // sendHistory[0] is the in-progress entry buffer; indices 1..n are the stored commands, so the
+    // list holds at most historySize + 1 elements.
+    private fun trimHistory() {
+        while (sendHistory.size > historySize + 1) {
+            sendHistory.removeAt(sendHistory.size - 1)
         }
     }
 

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModelFactory.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModelFactory.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import warlockfe.warlock3.core.client.WarlockClient
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterSettingsRepository
+import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
 import warlockfe.warlock3.core.prefs.repositories.MacroRepository
 import warlockfe.warlock3.core.prefs.repositories.PresetRepository
 import warlockfe.warlock3.core.prefs.repositories.ProgressBarSettingRepository
@@ -21,6 +22,7 @@ class GameViewModelFactory(
     private val scriptManagerFactory: ScriptManagerFactory,
     private val windowSettingsRepository: WindowSettingsRepository,
     private val progressBarSettingRepository: ProgressBarSettingRepository,
+    private val clientSettingRepository: ClientSettingRepository,
     private val ioDispatcher: CoroutineDispatcher,
 ) {
     fun create(
@@ -38,6 +40,7 @@ class GameViewModelFactory(
             aliasRepository = aliasRepository,
             windowRegistry = windowRegistry,
             progressBarSettingRepository = progressBarSettingRepository,
+            clientSettingRepository = clientSettingRepository,
             ioDispatcher = ioDispatcher,
         )
 }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopGeneralSettingsView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopGeneralSettingsView.kt
@@ -97,6 +97,23 @@ fun DesktopGeneralSettingsView(
 
             Spacer(Modifier.height(16.dp))
 
+            val minCommandLengthValue = rememberTextFieldState()
+            LaunchedEffect(Unit) {
+                val initialMinCommandLength =
+                    clientSettingRepository.observeMinCommandLength().first().toString()
+                minCommandLengthValue.setTextAndPlaceCursorAtEnd(initialMinCommandLength)
+                snapshotFlow { minCommandLengthValue.text.toString() }
+                    .collectLatest {
+                        if (it != initialMinCommandLength && it.isNotBlank()) {
+                            clientSettingRepository.putMinCommandLength(it.toIntOrNull())
+                        }
+                    }
+            }
+            Text("Minimum command length for history")
+            WarlockTextField(state = minCommandLengthValue, modifier = Modifier.fillMaxWidth())
+
+            Spacer(Modifier.height(16.dp))
+
             val markLinks by clientSettingRepository
                 .observeMarkLinks()
                 .collectAsState(initial = true)

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/GeneralSettingsView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/GeneralSettingsView.kt
@@ -164,6 +164,29 @@ fun GeneralSettingsView(
 
             Spacer(Modifier.height(16.dp))
 
+            val minCommandLengthValue = rememberTextFieldState()
+            LaunchedEffect(Unit) {
+                val initialMinCommandLength =
+                    clientSettingRepository.observeMinCommandLength().first().toString()
+                minCommandLengthValue.setTextAndPlaceCursorAtEnd(initialMinCommandLength)
+                snapshotFlow { minCommandLengthValue.text.toString() }
+                    .collectLatest {
+                        if (it != initialMinCommandLength && it.isNotBlank()) {
+                            clientSettingRepository.putMinCommandLength(it.toIntOrNull())
+                        }
+                    }
+            }
+            TextField(
+                state = minCommandLengthValue,
+                label = {
+                    Text("Minimum command length for history")
+                },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                lineLimits = TextFieldLineLimits.SingleLine,
+            )
+
+            Spacer(Modifier.height(16.dp))
+
             val markLinks by clientSettingRepository
                 .observeMarkLinks()
                 .collectAsState(initial = true)

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
@@ -247,6 +247,10 @@ data class ClientConfig(
     val logTimestamps: Boolean = true,
     val skinFile: String? = null,
     val releaseChannel: String? = null,
+    @TomlComment("Commands shorter than this are not saved to the command history.")
+    val minCommandLength: Int? = null,
+    @TomlComment("Maximum number of commands kept in the command history. Not exposed in the UI.")
+    val historySize: Int? = null,
 )
 
 /**

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ClientSettingRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ClientSettingRepository.kt
@@ -85,6 +85,14 @@ class ClientSettingRepository(
 
     fun observeMaxScrollLines(): Flow<Int> = clientConfigStore.observeClient().map { it.scrollback ?: DEFAULT_MAX_SCROLL_LINES }
 
+    fun observeMinCommandLength(): Flow<Int> = clientConfigStore.observeClient().map { it.minCommandLength ?: DEFAULT_MIN_COMMAND_LENGTH }
+
+    /**
+     * Maximum number of commands retained in the command history. Hidden setting: read from
+     * `client.toml` only, never written from the UI.
+     */
+    fun observeHistorySize(): Flow<Int> = clientConfigStore.observeClient().map { it.historySize ?: DEFAULT_HISTORY_SIZE }
+
     fun observeMarkLinks(): Flow<Boolean> = clientConfigStore.observeClient().map { it.markLinks }
 
     fun observeShowImages(): Flow<Boolean> = clientConfigStore.observeClient().map { it.showImages }
@@ -115,6 +123,10 @@ class ClientSettingRepository(
 
     suspend fun putMaxScrollLines(value: Int?) {
         clientConfigStore.mutateClient { it.copy(scrollback = value) }
+    }
+
+    suspend fun putMinCommandLength(value: Int?) {
+        clientConfigStore.mutateClient { it.copy(minCommandLength = value) }
     }
 
     suspend fun putMarkLinks(value: Boolean) {
@@ -160,6 +172,8 @@ class ClientSettingRepository(
 
     companion object {
         const val DEFAULT_MAX_SCROLL_LINES = 2_000
+        const val DEFAULT_MIN_COMMAND_LENGTH = 3
+        const val DEFAULT_HISTORY_SIZE = 1_000
         const val SCROLLBACK_KEY = "scrollback"
         const val MARK_LINKS_KEY = "markLinks"
         const val SHOW_IMAGES_KEY = "showImages"


### PR DESCRIPTION
Adds two command-history settings, both stored client-wide in `client.toml`:

- **Minimum command length for history** (default 3) - exposed in the general settings UI (desktop and mobile). Commands shorter than this are not saved to the command history.
- **History size** (default 1000) - a hidden setting that only lives in `client.toml`, not exposed in the UI. The command history is trimmed to this many entries.

The command entry (`GameViewModel`) observes both settings, skips saving short commands, and trims the history (oldest first) when it exceeds the configured size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)