### PR TITLE
Persist command history per character

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -44,6 +44,7 @@ import warlockfe.warlock3.core.prefs.repositories.AlterationRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterSettingsRepository
 import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
+import warlockfe.warlock3.core.prefs.repositories.CommandHistoryRepository
 import warlockfe.warlock3.core.prefs.repositories.ConnectionRepository
 import warlockfe.warlock3.core.prefs.repositories.ConnectionSettingsRepository
 import warlockfe.warlock3.core.prefs.repositories.ExportRepository
@@ -129,6 +130,7 @@ abstract class AppContainer(
     val connectionSettingsRepository = ConnectionSettingsRepository(clientConfigStore)
     val aliasRepository = AliasRepository(characterConfigStore)
     val alterationRepository = AlterationRepository(characterConfigStore)
+    val commandHistoryRepository = CommandHistoryRepository(characterConfigStore, fileSystem, ioDispatcher)
 
     private val initializeMutex = Mutex()
     private var initialized = false
@@ -207,6 +209,7 @@ abstract class AppContainer(
             windowSettingsRepository = windowSettingRepository,
             progressBarSettingRepository = progressBarSettingRepository,
             clientSettingRepository = clientSettings,
+            commandHistoryRepository = commandHistoryRepository,
             ioDispatcher = ioDispatcher,
         )
     }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -30,7 +30,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -68,6 +70,7 @@ import warlockfe.warlock3.core.prefs.models.ProgressBarSettingEntity
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterSettingsRepository
 import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
+import warlockfe.warlock3.core.prefs.repositories.CommandHistoryRepository
 import warlockfe.warlock3.core.prefs.repositories.DEFAULT_MAX_TYPE_AHEAD
 import warlockfe.warlock3.core.prefs.repositories.MAX_TYPE_AHEAD_KEY
 import warlockfe.warlock3.core.prefs.repositories.MacroRepository
@@ -104,7 +107,8 @@ class GameViewModel(
     aliasRepository: AliasRepository,
     private val windowRegistry: WindowRegistry,
     private val progressBarSettingRepository: ProgressBarSettingRepository,
-    private val clientSettingRepository: ClientSettingRepository,
+    clientSettingRepository: ClientSettingRepository,
+    private val commandHistoryRepository: CommandHistoryRepository,
     private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel(),
     MacroHandler {
@@ -368,6 +372,20 @@ class GameViewModel(
                 historySize = it
                 trimHistory()
             }.launchIn(viewModelScope)
+        // Load each character's saved command history when it connects.
+        client.characterId
+            .filterNotNull()
+            .distinctUntilChanged()
+            .onEach { characterId ->
+                val saved = commandHistoryRepository.load(characterId)
+                // sendHistory[0] is the in-progress entry buffer; commands follow it newest-first,
+                // while the file stores them oldest-first, so reverse on load.
+                sendHistory.clear()
+                sendHistory.add("")
+                saved.asReversed().forEach { sendHistory.add(it) }
+                trimHistory()
+                historyPosition = 0
+            }.launchIn(viewModelScope)
         // Load initial
         client.characterId
             .onEach { characterId ->
@@ -570,6 +588,16 @@ class GameViewModel(
             sendHistory[0] = line
             sendHistory.add(0, "")
             trimHistory()
+            persistHistory()
+        }
+    }
+
+    // Persist the current command history (commands only, oldest first) for the connected character.
+    private fun persistHistory() {
+        val characterId = client.characterId.value ?: return
+        val commands = sendHistory.drop(1).filter { it.isNotEmpty() }.asReversed()
+        viewModelScope.launch {
+            commandHistoryRepository.save(characterId, commands)
         }
     }
 

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModelFactory.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModelFactory.kt
@@ -5,6 +5,7 @@ import warlockfe.warlock3.core.client.WarlockClient
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterSettingsRepository
 import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
+import warlockfe.warlock3.core.prefs.repositories.CommandHistoryRepository
 import warlockfe.warlock3.core.prefs.repositories.MacroRepository
 import warlockfe.warlock3.core.prefs.repositories.PresetRepository
 import warlockfe.warlock3.core.prefs.repositories.ProgressBarSettingRepository
@@ -23,6 +24,7 @@ class GameViewModelFactory(
     private val windowSettingsRepository: WindowSettingsRepository,
     private val progressBarSettingRepository: ProgressBarSettingRepository,
     private val clientSettingRepository: ClientSettingRepository,
+    private val commandHistoryRepository: CommandHistoryRepository,
     private val ioDispatcher: CoroutineDispatcher,
 ) {
     fun create(
@@ -41,6 +43,7 @@ class GameViewModelFactory(
             windowRegistry = windowRegistry,
             progressBarSettingRepository = progressBarSettingRepository,
             clientSettingRepository = clientSettingRepository,
+            commandHistoryRepository = commandHistoryRepository,
             ioDispatcher = ioDispatcher,
         )
 }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
@@ -74,6 +74,13 @@ class CharacterConfigStore(
     fun snapshot(): Map<String, CharacterConfig> = state.value
 
     /**
+     * The on-disk directory where a character's files live (the per-section config files, and the
+     * command-history file). Exposed so sibling repositories can store their files alongside the
+     * config using the same `characters/<gameCode>/<name>/` layout.
+     */
+    fun directoryFor(characterId: String): Path = dirForCharacter(characterId)
+
+    /**
      * Reads every character's config files from disk into memory. Hand-authored entries missing an
      * `id` are assigned one and the affected section files are rewritten so the id stays stable across
      * launches. Safe to call before any data exists (results in an empty store).

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/CommandHistoryRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/CommandHistoryRepository.kt
@@ -1,0 +1,71 @@
+package warlockfe.warlock3.core.prefs.repositories
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import kotlinx.io.buffered
+import kotlinx.io.files.FileSystem
+import kotlinx.io.files.Path
+import kotlinx.io.readString
+import kotlinx.io.writeString
+import warlockfe.warlock3.core.prefs.config.CharacterConfigStore
+
+/**
+ * Persists each character's command history as a plain-text file (`history.txt`, one command per
+ * line, oldest first) alongside that character's config files. The history is loaded when the
+ * character connects and rewritten whenever a new command is added.
+ */
+class CommandHistoryRepository(
+    private val configStore: CharacterConfigStore,
+    private val fileSystem: FileSystem,
+    private val ioDispatcher: CoroutineDispatcher,
+) {
+    private fun fileFor(characterId: String): Path = Path(configStore.directoryFor(characterId), HISTORY_FILE_NAME)
+
+    /** Reads the saved commands for [characterId], oldest first. Empty if there's no file yet. */
+    suspend fun load(characterId: String): List<String> =
+        withContext(ioDispatcher) {
+            val path = fileFor(characterId)
+            if (fileSystem.metadataOrNull(path) == null) return@withContext emptyList()
+            runCatching {
+                fileSystem
+                    .source(path)
+                    .buffered()
+                    .use { it.readString() }
+                    .lineSequence()
+                    .filter { it.isNotEmpty() }
+                    .toList()
+            }.onFailure {
+                Logger.e(it) { "Failed to read command history $path" }
+            }.getOrDefault(emptyList())
+        }
+
+    /** Overwrites the history file for [characterId] with [commands] (oldest first). */
+    suspend fun save(
+        characterId: String,
+        commands: List<String>,
+    ) = withContext(ioDispatcher + NonCancellable) {
+        val path = fileFor(characterId)
+        val dir = path.parent
+        runCatching {
+            if (commands.isEmpty()) {
+                if (fileSystem.metadataOrNull(path) != null) fileSystem.delete(path)
+                return@runCatching
+            }
+            if (dir != null && fileSystem.metadataOrNull(dir) == null) fileSystem.createDirectories(dir)
+            val text = commands.joinToString(separator = "\n", postfix = "\n")
+            // Write to a temp file and atomically move it into place so a crash mid-write can't leave a
+            // truncated history file.
+            val tmp = Path(dir ?: path, "$HISTORY_FILE_NAME.tmp")
+            fileSystem.sink(tmp).buffered().use { it.writeString(text) }
+            fileSystem.atomicMove(tmp, path)
+        }.onFailure {
+            Logger.e(it) { "Failed to write command history $path" }
+        }
+    }
+
+    companion object {
+        const val HISTORY_FILE_NAME = "history.txt"
+    }
+}

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/repositories/CommandHistoryRepositoryTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/repositories/CommandHistoryRepositoryTest.kt
@@ -1,0 +1,93 @@
+package warlockfe.warlock3.core.prefs.repositories
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readString
+import kotlinx.io.writeString
+import warlockfe.warlock3.core.prefs.config.CharacterConfigStore
+import java.nio.file.Files
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CommandHistoryRepositoryTest {
+    private val fs = SystemFileSystem
+    private lateinit var dir: Path
+    private lateinit var configDir: String
+
+    @BeforeTest
+    fun setUp() {
+        dir = Path(Files.createTempDirectory("history-test").toAbsolutePath().toString())
+        configDir = dir.toString()
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        java.nio.file.Path
+            .of(dir.toString())
+            .deleteRecursively()
+    }
+
+    private fun newRepo() = CommandHistoryRepository(CharacterConfigStore(configDir, fs), fs, Dispatchers.Unconfined)
+
+    private fun historyFile(characterId: String): Path {
+        val (gameCode, name) = characterId.split(":")
+        return Path(Path(Path(Path(configDir), "characters"), gameCode), name).let { Path(it, "history.txt") }
+    }
+
+    @Test
+    fun load_missingFile_returnsEmpty() =
+        runBlocking {
+            assertEquals(emptyList(), newRepo().load("gs4:tholan"))
+        }
+
+    @Test
+    fun save_thenLoad_roundTripsInOrder() =
+        runBlocking {
+            val repo = newRepo()
+            val commands = listOf("look", "go north", "attack troll")
+            repo.save("gs4:tholan", commands)
+
+            assertEquals(commands, repo.load("gs4:tholan"))
+        }
+
+    @Test
+    fun save_writesOneCommandPerLineOldestFirst() =
+        runBlocking {
+            val repo = newRepo()
+            repo.save("gs4:tholan", listOf("look", "go north", "attack troll"))
+
+            val text = fs.source(historyFile("gs4:tholan")).buffered().use { it.readString() }
+            assertEquals("look\ngo north\nattack troll\n", text)
+        }
+
+    @Test
+    fun load_ignoresBlankLines() =
+        runBlocking {
+            val repo = newRepo()
+            val file = historyFile("gs4:tholan")
+            file.parent?.let { fs.createDirectories(it) }
+            fs.sink(file).buffered().use { it.writeString("look\n\ngo north\n") }
+
+            assertEquals(listOf("look", "go north"), repo.load("gs4:tholan"))
+        }
+
+    @Test
+    fun save_emptyList_deletesFile() =
+        runBlocking {
+            val repo = newRepo()
+            repo.save("gs4:tholan", listOf("look"))
+            assertTrue(fs.metadataOrNull(historyFile("gs4:tholan")) != null)
+
+            repo.save("gs4:tholan", emptyList())
+            assertFalse(fs.metadataOrNull(historyFile("gs4:tholan")) != null)
+        }
+}


### PR DESCRIPTION
Saves each character's command history to disk so it survives restarts.

- New `CommandHistoryRepository` stores history as a plain-text `history.txt` (one command per line, oldest first) in the character's existing config directory (`characters/<gameCode>/<name>/`), written atomically. An empty history deletes the file.
- `CharacterConfigStore` now exposes `directoryFor(characterId)` so the repository reuses the exact same per-character directory layout (no duplicated path logic).
- `GameViewModel` loads the saved history when a character connects and rewrites it whenever a command is added. The existing **minimum command length** and **history size** settings still apply, so the file stays trimmed.
- Scripts go through `commandHandler` directly and don't touch history, so there's no disk churn from scripts.
- Tests cover the save/load round-trip, on-disk format, blank-line handling, missing-file, and empty-save-deletes-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)