### PR TITLE
Remember GameState so theme changes don't reset navigation

### DIFF
--- a/androidApp/src/main/kotlin/warlockfe/warlock3/android/WarlockApp.kt
+++ b/androidApp/src/main/kotlin/warlockfe/warlock3/android/WarlockApp.kt
@@ -55,7 +55,7 @@ fun WarlockApp(
         }
     LaunchedEffect(darkMode) { appContainer.darkMode.value = darkMode }
     AppTheme(useDarkTheme = darkMode) {
-        val gameState = GameState()
+        val gameState = remember { GameState() }
         var settingsPage by remember { mutableStateOf<SettingsPage?>(null) }
         var currentCharacter: GameCharacter? by remember { mutableStateOf(null) }
 

--- a/compose/src/iosMain/kotlin/warlockfe/warlock3/compose/MainViewController.kt
+++ b/compose/src/iosMain/kotlin/warlockfe/warlock3/compose/MainViewController.kt
@@ -92,7 +92,7 @@ private fun IosWarlockApp(
         }
     LaunchedEffect(darkMode) { appContainer.darkMode.value = darkMode }
     AppTheme(useDarkTheme = darkMode) {
-        val gameState = GameState()
+        val gameState = remember { GameState() }
         var settingsPage by remember { mutableStateOf<SettingsPage?>(null) }
         var currentCharacter: GameCharacter? by remember { mutableStateOf(null) }
 


### PR DESCRIPTION
## Problem

Changing the theme (e.g. auto → dark) while connected on Android (and iOS) kicked the user back to the dashboard and got stuck there — "back to main" went to the dashboard instead of the game, and reconnecting stayed on the dashboard instead of showing the connected game.

## Root cause

`GameState` (which holds the current screen) was created **without `remember`** inside the theme composable on Android (`WarlockApp.kt:58`) and iOS (`MainViewController.kt:95`).

It normally survived because screen changes only invalidate `MainScreen`'s scope, not the outer `WarlockApp` body. But the theme setting is read in the `WarlockApp` body, so switching the theme re-ran the body, created a fresh `GameState` reset to `Dashboard`, and dropped the user off the connected game.

It then stayed stuck because the cached `DashboardViewModel` (from `viewModel { ... }`) still held the **old** `GameState` reference — so `connect()` called `setScreen(ConnectedGameState)` on the stale instance while the UI rendered the new one that never left `Dashboard`.

## Fix

Wrap the creation in `remember { GameState() }` on both platforms so a single stable instance survives theme-driven recompositions.

Desktop was unaffected — it creates its `GameState` list outside the `application {}` composable.

## Testing

- `:androidApp:compileDebugKotlin` passes; ktlint pre-commit hook passes.
- Manually confirmed on device: changing the theme while connected no longer resets to the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)