### PR TITLE
Track .idea/vcs.xml so the IDE keeps its Git root mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ android/src/main/play
 .idea/*
 !.idea/dictionaries
 !.idea/dictionaries/**
+!.idea/vcs.xml
 
 *.iml
 *.ipr

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
`.idea/vcs.xml` holds the IDE's Git root mapping. It was being swallowed by the broad `.idea/*` ignore rule, so when JetBrains periodically rewrites `.idea`, the file would disappear and the IDE would lose its VCS mapping — reverting the Git toolbar to the generic "VCS" menu.

This un-ignores `.idea/vcs.xml` (via `!.idea/vcs.xml`) and checks it in so the mapping persists across IDE rewrites and on fresh checkouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)