### PR TITLE
Add reconnect button to disconnect banner

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ConnectToGameUseCase.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ConnectToGameUseCase.kt
@@ -75,6 +75,8 @@ class ConnectToGameUseCase(
                         gameViewModelFactory.create(
                             client = sfClient,
                             windowRegistry = streamRegistry,
+                            // Reuse the same credentials (and key) on reconnect.
+                            reconnect = { invoke(credentials, proxySettings, gameState) },
                         )
                     gameState.setScreen(GameScreen.ConnectedGameState(gameViewModel))
                     break

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -110,6 +110,7 @@ class GameViewModel(
     clientSettingRepository: ClientSettingRepository,
     private val commandHistoryRepository: CommandHistoryRepository,
     private val ioDispatcher: CoroutineDispatcher,
+    private val reconnectAction: (suspend () -> Unit)? = null,
 ) : ViewModel(),
     MacroHandler {
     private val logger = Logger.withTag("GameViewModel")
@@ -358,6 +359,8 @@ class GameViewModel(
     private var historySize = ClientSettingRepository.DEFAULT_HISTORY_SIZE
 
     val disconnected = client.disconnected
+
+    val canReconnect: Boolean = reconnectAction != null
 
     val menuData = client.menuData
 
@@ -1068,6 +1071,19 @@ class GameViewModel(
         }
         client.close()
         windowRegistry.close()
+    }
+
+    /**
+     * Reconnect using the same credentials. This spins up a fresh client, window registry, and
+     * GameViewModel (replacing this screen), so all prior game state is cleared. The old client and
+     * window registry are then released. No-op if reconnecting isn't supported for this session.
+     */
+    fun reconnect() {
+        val action = reconnectAction ?: return
+        viewModelScope.launch {
+            action()
+            close()
+        }
     }
 
     fun getCurrentTime(): Instant = client.getCurrentTime()

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModelFactory.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModelFactory.kt
@@ -30,6 +30,7 @@ class GameViewModelFactory(
     fun create(
         client: WarlockClient,
         windowRegistry: WindowRegistry,
+        reconnect: (suspend () -> Unit)? = null,
     ): GameViewModel =
         GameViewModel(
             client = client,
@@ -45,5 +46,6 @@ class GameViewModelFactory(
             clientSettingRepository = clientSettingRepository,
             commandHistoryRepository = commandHistoryRepository,
             ioDispatcher = ioDispatcher,
+            reconnectAction = reconnect,
         )
 }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeViewModel.kt
@@ -28,6 +28,7 @@ import warlockfe.warlock3.core.sge.SgeError
 import warlockfe.warlock3.core.sge.SgeEvent
 import warlockfe.warlock3.core.sge.SgeGame
 import warlockfe.warlock3.core.sge.SgeSettings
+import warlockfe.warlock3.core.sge.SimuGameCredentials
 import warlockfe.warlock3.wrayth.network.NetworkSocket
 
 // FIXME: This needs some re-organization
@@ -130,37 +131,43 @@ class SgeViewModel(
                                 }
                             }
 
-                            withContext(ioDispatcher) {
-                                try {
-                                    val streamRegistry = windowRegistryFactory.create()
-                                    val socket = NetworkSocket(ioDispatcher)
-                                    socket.connect(credentials.host, credentials.port)
-                                    val sfClient =
-                                        warlockClientFactory.createClient(
-                                            windowRegistry = streamRegistry,
-                                            socket = socket,
-                                        )
-                                    sfClient.connect(credentials.key)
-                                    val gameViewModel =
-                                        gameViewModelFactory.create(
-                                            client = sfClient,
-                                            windowRegistry = streamRegistry,
-                                        )
-                                    gameState.setScreen(GameScreen.ConnectedGameState(gameViewModel))
-                                } catch (e: Exception) {
-                                    ensureActive()
-                                    gameState.setScreen(
-                                        GameScreen.ErrorState(
-                                            message = "Unknown host: ${e.message}",
-                                            returnTo = GameScreen.NewGameState,
-                                        ),
-                                    )
-                                }
-                            }
+                            connectToGame(credentials)
                         }
                     }
                 }
             }
+    }
+
+    private suspend fun connectToGame(credentials: SimuGameCredentials) {
+        withContext(ioDispatcher) {
+            try {
+                val streamRegistry = windowRegistryFactory.create()
+                val socket = NetworkSocket(ioDispatcher)
+                socket.connect(credentials.host, credentials.port)
+                val sfClient =
+                    warlockClientFactory.createClient(
+                        windowRegistry = streamRegistry,
+                        socket = socket,
+                    )
+                sfClient.connect(credentials.key)
+                val gameViewModel =
+                    gameViewModelFactory.create(
+                        client = sfClient,
+                        windowRegistry = streamRegistry,
+                        // Reuse the same credentials (and key) on reconnect.
+                        reconnect = { connectToGame(credentials) },
+                    )
+                gameState.setScreen(GameScreen.ConnectedGameState(gameViewModel))
+            } catch (e: Exception) {
+                ensureActive()
+                gameState.setScreen(
+                    GameScreen.ErrorState(
+                        message = "Unknown host: ${e.message}",
+                        returnTo = GameScreen.NewGameState,
+                    ),
+                )
+            }
+        }
     }
 
     fun accountSelected(account: AccountEntity) {

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
@@ -106,10 +106,18 @@ fun DesktopGameView(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 Text("You have been disconnected from the server")
-                WarlockButton(
-                    onClick = navigateToDashboard,
-                    text = "Back to dashboard",
-                )
+                Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    if (viewModel.canReconnect) {
+                        WarlockButton(
+                            onClick = viewModel::reconnect,
+                            text = "Reconnect",
+                        )
+                    }
+                    WarlockButton(
+                        onClick = navigateToDashboard,
+                        text = "Go to dashboard",
+                    )
+                }
             }
         }
 

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
@@ -120,8 +120,15 @@ fun GameView(
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     Text("You have been disconnected from the server")
-                    FilledTonalButton(onClick = navigateToDashboard) {
-                        Text("Back to dashboard")
+                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        if (viewModel.canReconnect) {
+                            FilledTonalButton(onClick = viewModel::reconnect) {
+                                Text("Reconnect")
+                            }
+                        }
+                        FilledTonalButton(onClick = navigateToDashboard) {
+                            Text("Go to dashboard")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Adds a **Reconnect** button to the disconnect banner (desktop and mobile). Reconnect reuses the same credentials/key and spins up a fresh `WraythClient`, window registry, and `GameViewModel`, replacing the connected screen — so all prior game state is cleared.

## Changes

- `GameViewModel`: new `reconnectAction` constructor param, `canReconnect` flag, and `reconnect()` method. `reconnect()` runs the action (builds a fresh client/registry/VM and swaps the `ConnectedGameState`), then closes the old client and window registry.
- `GameViewModelFactory.create()`: threads the optional `reconnect` lambda through.
- `ConnectToGameUseCase` (dashboard path): supplies `reconnect = { invoke(credentials, proxySettings, gameState) }`, reusing the original credentials including proxy handling.
- `SgeViewModel` (SGE wizard path): extracted the inline connect block into a reusable `connectToGame(credentials)`, used for both initial connect and reconnect.
- `DesktopGameView` / mobile `GameView`: banner now shows a Reconnect button (guarded by `canReconnect`) next to "Go to dashboard".

## Notes

- The same key is reused per the request. SGE login keys can be short-lived/single-use, so a reused key may be rejected server-side; if that becomes an issue, reconnect would need to re-run the SGE login to mint a fresh key.
- Not yet exercised against a live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)