### PR TITLE
Add --sal CLI option to connect from a .sal launch file

### DIFF
--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/sge/SalFile.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/sge/SalFile.kt
@@ -1,0 +1,33 @@
+package warlockfe.warlock3.core.sge
+
+/**
+ * Parses a Simutronics ".sal" launch file into the credentials needed to connect to the game.
+ *
+ * A .sal file is a plain text file of KEY=VALUE lines written by the website launcher. Only the
+ * GAMEHOST, GAMEPORT, and KEY entries are required to establish a connection; any other entries
+ * (GAME, GAMECODE, FULLGAMENAME, etc.) are ignored.
+ */
+fun parseSalCredentials(content: String): SimuGameCredentials {
+    val values =
+        content
+            .lineSequence()
+            .mapNotNull { line ->
+                val separator = line.indexOf('=')
+                if (separator <= 0) {
+                    return@mapNotNull null
+                }
+                line.substring(0, separator).trim().uppercase() to line.substring(separator + 1).trim()
+            }.toMap()
+
+    val host =
+        values["GAMEHOST"]?.takeIf { it.isNotEmpty() }
+            ?: throw IllegalArgumentException("Missing GAMEHOST in .sal file")
+    val port =
+        values["GAMEPORT"]?.toIntOrNull()
+            ?: throw IllegalArgumentException("Missing or invalid GAMEPORT in .sal file")
+    val key =
+        values["KEY"]?.takeIf { it.isNotEmpty() }
+            ?: throw IllegalArgumentException("Missing KEY in .sal file")
+
+    return SimuGameCredentials(host = host, port = port, key = key)
+}

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/sge/SalFileTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/sge/SalFileTest.kt
@@ -1,0 +1,65 @@
+package warlockfe.warlock3.core.sge
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class SalFileTest {
+    @Test
+    fun parsesHostPortAndKey() {
+        val content =
+            """
+            GAME=STORM
+            GAMECODE=DR
+            FULLGAMENAME=DragonRealms
+            GAMEHOST=storm.gs4.game.play.net
+            GAMEPORT=10024
+            KEY=abc123def456
+            """.trimIndent()
+
+        val credentials = parseSalCredentials(content)
+
+        assertEquals("storm.gs4.game.play.net", credentials.host)
+        assertEquals(10024, credentials.port)
+        assertEquals("abc123def456", credentials.key)
+    }
+
+    @Test
+    fun ignoresWhitespaceAndCasing() {
+        val content =
+            """
+              gamehost = play.net
+            GamePort=4901
+            key=  secret-key
+            """.trimIndent()
+
+        val credentials = parseSalCredentials(content)
+
+        assertEquals("play.net", credentials.host)
+        assertEquals(4901, credentials.port)
+        assertEquals("secret-key", credentials.key)
+    }
+
+    @Test
+    fun failsWhenKeyMissing() {
+        val content =
+            """
+            GAMEHOST=play.net
+            GAMEPORT=4901
+            """.trimIndent()
+
+        assertFailsWith<IllegalArgumentException> { parseSalCredentials(content) }
+    }
+
+    @Test
+    fun failsWhenPortInvalid() {
+        val content =
+            """
+            GAMEHOST=play.net
+            GAMEPORT=notaport
+            KEY=secret
+            """.trimIndent()
+
+        assertFailsWith<IllegalArgumentException> { parseSalCredentials(content) }
+    }
+}

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -89,6 +89,7 @@ import warlockfe.warlock3.core.prefs.repositories.MainWindowBounds
 import warlockfe.warlock3.core.sge.AutoConnectResult
 import warlockfe.warlock3.core.sge.SgeSettings
 import warlockfe.warlock3.core.sge.SimuGameCredentials
+import warlockfe.warlock3.core.sge.parseSalCredentials
 import warlockfe.warlock3.core.util.WarlockDirs
 import warlockfe.warlock3.wrayth.network.NetworkSocket
 import java.awt.Dimension
@@ -106,6 +107,7 @@ private class WarlockCommand : CliktCommand() {
     val stdin: Boolean by option("--stdin", help = "Read input from stdin").flag()
     val inputFile: String? by option("-i", "--input", help = "Read input from file")
     val autoConnectName: String? by option("-c", "--connection", help = "Auto-connect to the named connection")
+    val salFile: String? by option("--sal", help = "Path to a .sal launch file to connect with")
     val sgeHost: String by option("--sge-host", help = "Credentials/SGE host").default("eaccess.play.net")
     val sgePort: Int by option("--sge-port", help = "Credentials/SGE port").int().default(7910)
     val sgeSecure: Boolean by option("--sge-secure", help = "Credentials/SGE uses encryption").boolean().default(true)
@@ -138,6 +140,9 @@ private class WarlockCommand : CliktCommand() {
         if (autoConnectName != null) {
             loginOptions.add("connection")
         }
+        if (salFile != null) {
+            loginOptions.add("sal")
+        }
         if (loginOptions.size > 1) {
             println("More than one login method was specified. Please only use one of the following methods: $loginOptions")
             exitProcess(-1)
@@ -157,7 +162,21 @@ private class WarlockCommand : CliktCommand() {
         FileKit.init("warlock")
 
         val credentials =
-            if (port != null && host != null && key != null) {
+            if (salFile != null) {
+                val file = File(salFile!!)
+                if (!file.exists()) {
+                    println("SAL file does not exist: $salFile")
+                    exitProcess(-1)
+                }
+                try {
+                    parseSalCredentials(file.readText()).also {
+                        logger.d { "Connecting to ${it.host}:${it.port} from .sal file" }
+                    }
+                } catch (e: Exception) {
+                    println("Failed to parse .sal file: ${e.message}")
+                    exitProcess(-1)
+                }
+            } else if (port != null && host != null && key != null) {
                 logger.d { "Connecting to $host:$port with $key" }
                 SimuGameCredentials(host = host!!, port = port!!, key = key!!)
             } else if (port != null || host != null || key != null) {


### PR DESCRIPTION
## Summary

Adds a `--sal <path>` CLI option to the desktop app that reads a Simutronics `.sal` launch file and connects directly to the game using the credentials within.

## Changes

- **`core/.../sge/SalFile.kt`** (new): `parseSalCredentials(content)` — a multiplatform pure-string parser. A `.sal` file is plain `KEY=VALUE` text; it extracts `GAMEHOST`, `GAMEPORT`, and `KEY` (case-insensitive, whitespace-tolerant) and ignores the rest. Throws a clear error if a required field is missing/invalid.
- **`desktopApp/.../Main.kt`**: new Clikt `--sal` option, added to the mutually-exclusive login-method validation, and wired into the credentials block (reads/parses the file, then flows through the existing direct-connect path just like `--host/--port/--key`).
- **`core/.../sge/SalFileTest.kt`** (new): tests for normal parsing, whitespace/casing tolerance, and missing-key / invalid-port failures.

## Verification

- `:core` and `:desktopApp` compile.
- `SalFileTest` passes.
- ktlint clean.
- Not yet exercised against a live server with a real `.sal` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)