### PR TITLE
Accept .sal launch file as positional argument instead of --sal

### DIFF
--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -37,6 +37,8 @@ import co.touchlab.kermit.Severity
 import co.touchlab.kermit.platformLogWriter
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.main
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
@@ -107,7 +109,7 @@ private class WarlockCommand : CliktCommand() {
     val stdin: Boolean by option("--stdin", help = "Read input from stdin").flag()
     val inputFile: String? by option("-i", "--input", help = "Read input from file")
     val autoConnectName: String? by option("-c", "--connection", help = "Auto-connect to the named connection")
-    val salFile: String? by option("--sal", help = "Path to a .sal launch file to connect with")
+    val salFile: String? by argument("SAL_FILE", help = "Path to a .sal launch file to connect with").optional()
     val sgeHost: String by option("--sge-host", help = "Credentials/SGE host").default("eaccess.play.net")
     val sgePort: Int by option("--sge-port", help = "Credentials/SGE port").int().default(7910)
     val sgeSecure: Boolean by option("--sge-secure", help = "Credentials/SGE uses encryption").boolean().default(true)

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ For a faster edit-recompile loop with Compose Hot Reload:
 
 Useful command-line flags exposed by the desktop entry point — pass them after `--args="..."`:
 
+- `<path.sal>` — connect using a Simutronics `.sal` launch file passed as a positional argument
 - `-c <name>` — auto-connect to a saved connection by name
 - `-i <path>` / `--stdin` — replay a log file or stdin instead of connecting to a server
 - `-d` — enable debug logging
@@ -57,6 +58,7 @@ Example:
 
 ```
 ./gradlew :desktopApp:run --args="-c Tefrin -d"
+./gradlew :desktopApp:run --args="/path/to/launch.sal"
 ```
 
 ### Running tests and lint


### PR DESCRIPTION
## Summary
- Replaces the `--sal` option with a positional `SAL_FILE` argument, so a Simutronics `.sal` launch file can be opened by passing its path directly (e.g. `warlock3 mychar.sal`).
- Downstream logic is unchanged: the argument still feeds the login-method mutual-exclusion check and `parseSalCredentials`.

## Testing
- `./gradlew :desktopApp:compileKotlin`
- Existing `SalFileTest` covers the unchanged parser; no CLI-level test existed for the old flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)