### PR TITLE
Deduplicate mobile/desktop UI code

### DIFF
--- a/androidApp/src/main/kotlin/warlockfe/warlock3/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/warlockfe/warlock3/android/MainActivity.kt
@@ -11,13 +11,11 @@ import co.touchlab.kermit.Logger
 import co.touchlab.kermit.platformLogWriter
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.dialogs.init
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
 import warlockfe.warlock3.compose.WarlockApp
 import warlockfe.warlock3.compose.generated.resources.Res
+import warlockfe.warlock3.compose.observeSkin
 import warlockfe.warlock3.compose.util.LocalSkin
-import warlockfe.warlock3.compose.util.SkinLoader
 import warlockfe.warlock3.core.sge.SgeSettings
 import java.io.File
 
@@ -36,22 +34,9 @@ class MainActivity : ComponentActivity() {
         val warlockApplication = application as WarlockApplication
         val appContainer = warlockApplication.appContainer
 
-        appContainer.clientSettings
-            .observeSkinFile()
-            .onEach { skinFile ->
-                val bytes =
-                    skinFile
-                        ?.let { File(it) }
-                        ?.takeIf { it.exists() }
-                        ?.readBytes()
-                        ?: Res.readBytes("files/skin.zip")
-                try {
-                    appContainer.skin.value = SkinLoader.parse(bytes)
-                } catch (e: Exception) {
-                    // TODO: notify user of error
-                    logger.e(e) { "Failed to load skin file" }
-                }
-            }.launchIn(appContainer.externalScope)
+        appContainer.observeSkin(logger) { path ->
+            File(path).takeIf { it.exists() }?.readBytes()
+        }
 
         val simuCert = runBlocking { Res.readBytes("files/simu.pem") }
 

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/SkinObserver.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/SkinObserver.kt
@@ -1,0 +1,32 @@
+package warlockfe.warlock3.compose
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import warlockfe.warlock3.compose.generated.resources.Res
+import warlockfe.warlock3.compose.util.SkinLoader
+
+/**
+ * Watch the user's configured skin file and keep [AppContainer.skin] in sync.
+ *
+ * The pipeline (observe the setting -> read bytes -> parse -> publish, logging any parse failure) is
+ * identical on every platform; only sourcing the bytes from a user-selected file differs.
+ * [readSkinFile] returns the bytes for a configured skin path, or null to fall back to the bundled
+ * `skin.zip`. iOS has no user skin file, so it omits [readSkinFile] and always uses the bundle.
+ */
+fun AppContainer.observeSkin(
+    logger: Logger,
+    readSkinFile: (path: String) -> ByteArray? = { null },
+) {
+    clientSettings
+        .observeSkinFile()
+        .onEach { skinFile ->
+            val bytes = skinFile?.let { readSkinFile(it) } ?: Res.readBytes("files/skin.zip")
+            try {
+                skin.value = SkinLoader.parse(bytes)
+            } catch (e: Exception) {
+                // TODO: notify user of error
+                logger.e(e) { "Failed to load skin file" }
+            }
+        }.launchIn(externalScope)
+}

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/MacroKeyHelpers.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/MacroKeyHelpers.kt
@@ -1,0 +1,66 @@
+package warlockfe.warlock3.compose.util
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import warlockfe.warlock3.core.macro.MacroKeyCombo
+
+// Shared helpers for translating between Compose key events, the macro key-combo model, and the
+// "ctrl+alt+shift+meta+key" display string. Used by both the desktop (Jewel) and mobile (Material3)
+// macro editors, which otherwise duplicated all of this.
+
+internal fun buildKeyString(
+    key: Key?,
+    modifierKeys: Set<String>,
+): String {
+    val newKey = StringBuilder()
+    if (modifierKeys.contains("ctrl")) newKey.append("ctrl+")
+    if (modifierKeys.contains("alt")) newKey.append("alt+")
+    if (modifierKeys.contains("shift")) newKey.append("shift+")
+    if (modifierKeys.contains("meta")) newKey.append("meta+")
+    if (key != null) newKey.append(key.getLabel())
+    return newKey.toString()
+}
+
+internal fun KeyEvent.getKeyModifiers(): Set<String> {
+    val modifiers = mutableSetOf<String>()
+    if (isAltPressed) modifiers.add("alt")
+    if (isShiftPressed) modifiers.add("shift")
+    if (isMetaPressed) modifiers.add("meta")
+    if (isCtrlPressed) modifiers.add("ctrl")
+    return modifiers
+}
+
+internal fun buildKeyCombo(
+    key: Key,
+    modifierKeys: Set<String>,
+): MacroKeyCombo =
+    MacroKeyCombo(
+        keyCode = key.keyCode,
+        ctrl = modifierKeys.contains("ctrl"),
+        alt = modifierKeys.contains("alt"),
+        shift = modifierKeys.contains("shift"),
+        meta = modifierKeys.contains("meta"),
+    )
+
+internal fun keyComboToKey(keyCombo: MacroKeyCombo): Pair<Key, Set<String>> {
+    val modifiers = mutableSetOf<String>()
+    if (keyCombo.ctrl) modifiers.add("ctrl")
+    if (keyCombo.alt) modifiers.add("alt")
+    if (keyCombo.shift) modifiers.add("shift")
+    if (keyCombo.meta) modifiers.add("meta")
+    return Key(keyCombo.keyCode) to modifiers
+}
+
+internal fun MacroKeyCombo.toDisplayString(): String {
+    val keyString = StringBuilder()
+    if (ctrl) keyString.append("ctrl+")
+    if (alt) keyString.append("alt+")
+    if (shift) keyString.append("shift+")
+    if (meta) keyString.append("meta+")
+    keyString.append(Key(keyCode).getLabel())
+    return keyString.toString()
+}

--- a/compose/src/iosMain/kotlin/warlockfe/warlock3/compose/MainViewController.kt
+++ b/compose/src/iosMain/kotlin/warlockfe/warlock3/compose/MainViewController.kt
@@ -6,11 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.window.ComposeUIViewController
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.util.LocalSkin
-import warlockfe.warlock3.compose.util.SkinLoader
 
 @Suppress("ktlint:standard:function-naming")
 fun MainViewController() =
@@ -21,16 +17,7 @@ fun MainViewController() =
         val logger = remember { Logger.withTag("WarlockiOS") }
 
         remember {
-            appContainer.clientSettings
-                .observeSkinFile()
-                .onEach {
-                    val bytes = Res.readBytes("files/skin.zip")
-                    try {
-                        appContainer.skin.value = SkinLoader.parse(bytes)
-                    } catch (e: Exception) {
-                        logger.e(e) { "Failed to load skin file" }
-                    }
-                }.launchIn(appContainer.externalScope)
+            appContainer.observeSkin(logger)
             true
         }
 

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopEditMacroDialog.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopEditMacroDialog.kt
@@ -15,12 +15,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.isAltPressed
-import androidx.compose.ui.input.key.isCtrlPressed
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
@@ -30,10 +25,11 @@ import warlockfe.warlock3.compose.desktop.shim.WarlockButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockDialog
 import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockTextField
-import warlockfe.warlock3.compose.util.getLabel
+import warlockfe.warlock3.compose.util.buildKeyCombo
+import warlockfe.warlock3.compose.util.buildKeyString
+import warlockfe.warlock3.compose.util.getKeyModifiers
 import warlockfe.warlock3.compose.util.isModifier
 import warlockfe.warlock3.core.macro.Macro
-import warlockfe.warlock3.core.macro.MacroKeyCombo
 
 @Suppress("ktlint:compose:modifier-missing-check")
 @Composable
@@ -103,37 +99,3 @@ fun DesktopEditMacroDialog(
         }
     }
 }
-
-private fun buildKeyString(
-    key: Key?,
-    modifierKeys: Set<String>,
-): String {
-    val newKey = StringBuilder()
-    if (modifierKeys.contains("ctrl")) newKey.append("ctrl+")
-    if (modifierKeys.contains("alt")) newKey.append("alt+")
-    if (modifierKeys.contains("shift")) newKey.append("shift+")
-    if (modifierKeys.contains("meta")) newKey.append("meta+")
-    if (key != null) newKey.append(key.getLabel())
-    return newKey.toString()
-}
-
-private fun KeyEvent.getKeyModifiers(): Set<String> {
-    val modifiers = mutableSetOf<String>()
-    if (isAltPressed) modifiers.add("alt")
-    if (isShiftPressed) modifiers.add("shift")
-    if (isMetaPressed) modifiers.add("meta")
-    if (isCtrlPressed) modifiers.add("ctrl")
-    return modifiers
-}
-
-private fun buildKeyCombo(
-    key: Key,
-    modifierKeys: Set<String>,
-): MacroKeyCombo =
-    MacroKeyCombo(
-        keyCode = key.keyCode,
-        ctrl = modifierKeys.contains("ctrl"),
-        alt = modifierKeys.contains("alt"),
-        shift = modifierKeys.contains("shift"),
-        meta = modifierKeys.contains("meta"),
-    )

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopMacrosView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopMacrosView.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.jetbrains.jewel.ui.component.Text
@@ -23,11 +22,11 @@ import warlockfe.warlock3.compose.desktop.shim.WarlockButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockListItem
 import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
-import warlockfe.warlock3.compose.util.getLabel
 import warlockfe.warlock3.compose.util.insertDefaultMacrosIfNeeded
+import warlockfe.warlock3.compose.util.keyComboToKey
+import warlockfe.warlock3.compose.util.toDisplayString
 import warlockfe.warlock3.core.client.GameCharacter
 import warlockfe.warlock3.core.macro.Macro
-import warlockfe.warlock3.core.macro.MacroKeyCombo
 import warlockfe.warlock3.core.prefs.repositories.MacroRepository
 
 @Composable
@@ -141,25 +140,6 @@ fun DesktopMacrosView(
 
         else -> {}
     }
-}
-
-private fun keyComboToKey(keyCombo: MacroKeyCombo): Pair<Key, Set<String>> {
-    val modifiers = mutableSetOf<String>()
-    if (keyCombo.ctrl) modifiers.add("ctrl")
-    if (keyCombo.alt) modifiers.add("alt")
-    if (keyCombo.shift) modifiers.add("shift")
-    if (keyCombo.meta) modifiers.add("meta")
-    return Key(keyCombo.keyCode) to modifiers
-}
-
-private fun MacroKeyCombo.toDisplayString(): String {
-    val keyString = StringBuilder()
-    if (ctrl) keyString.append("ctrl+")
-    if (alt) keyString.append("alt+")
-    if (shift) keyString.append("shift+")
-    if (meta) keyString.append("meta+")
-    keyString.append(Key(keyCode).getLabel())
-    return keyString.toString()
 }
 
 sealed class DesktopEditMacroState {

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/components/SettingsToggleRows.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/components/SettingsToggleRows.kt
@@ -1,0 +1,101 @@
+package warlockfe.warlock3.compose.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+
+// Settings screens repeated these label-plus-control rows inline a dozen times. The control takes
+// `onCheckedChange = null` / `onClick = null` because the surrounding row owns the toggle/select
+// semantics (so tapping the label works too). These mirror the desktop shim/WarlockCheckboxRow and
+// WarlockRadioButtonRow helpers.
+
+/** A label and a Material [Switch] in a single [toggleable] row. */
+@Composable
+fun SwitchRow(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier.toggleable(
+                value = checked,
+                onValueChange = onCheckedChange,
+                role = Role.Switch,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Switch(checked = checked, onCheckedChange = null)
+        Spacer(Modifier.width(16.dp))
+        Text(text)
+    }
+}
+
+/** A label and a Material [Checkbox] in a single [toggleable] row. */
+@Composable
+fun CheckboxRow(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier.toggleable(
+                value = checked,
+                onValueChange = onCheckedChange,
+                role = Role.Checkbox,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(checked = checked, onCheckedChange = null)
+        Spacer(Modifier.width(16.dp))
+        Text(text)
+    }
+}
+
+/**
+ * A label and a Material [RadioButton] in a single [selectable] row, for vertical
+ * [androidx.compose.foundation.selection.selectableGroup] option lists.
+ */
+@Composable
+fun RadioRow(
+    selected: Boolean,
+    onClick: () -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .height(48.dp)
+                .selectable(
+                    selected = selected,
+                    onClick = onClick,
+                    role = Role.RadioButton,
+                ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected, onClick = null)
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(start = 16.dp),
+        )
+    }
+}

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/EditMacroDialog.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/EditMacroDialog.kt
@@ -18,22 +18,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.isAltPressed
-import androidx.compose.ui.input.key.isCtrlPressed
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import kotlinx.collections.immutable.toPersistentSet
-import warlockfe.warlock3.compose.util.getLabel
+import warlockfe.warlock3.compose.util.buildKeyCombo
+import warlockfe.warlock3.compose.util.buildKeyString
+import warlockfe.warlock3.compose.util.getKeyModifiers
 import warlockfe.warlock3.compose.util.isModifier
 import warlockfe.warlock3.core.macro.Macro
-import warlockfe.warlock3.core.macro.MacroKeyCombo
 
 @Composable
 fun EditMacroDialog(
@@ -103,39 +98,3 @@ fun EditMacroDialog(
         },
     )
 }
-
-private fun buildKeyString(
-    key: Key?,
-    modifierKeys: Set<String>,
-): String {
-    val newKey = StringBuilder()
-    if (modifierKeys.contains("ctrl")) newKey.append("ctrl+")
-    if (modifierKeys.contains("alt")) newKey.append("alt+")
-    if (modifierKeys.contains("shift")) newKey.append("shift+")
-    if (modifierKeys.contains("meta")) newKey.append("meta+")
-    if (key != null) {
-        newKey.append(key.getLabel())
-    }
-    return newKey.toString()
-}
-
-private fun KeyEvent.getKeyModifiers(): Set<String> {
-    val modifiers = mutableSetOf<String>()
-    if (isAltPressed) modifiers.add("alt")
-    if (isShiftPressed) modifiers.add("shift")
-    if (isMetaPressed) modifiers.add("meta")
-    if (isCtrlPressed) modifiers.add("ctrl")
-    return modifiers.toPersistentSet()
-}
-
-private fun buildKeyCombo(
-    key: Key,
-    modifierKeys: Set<String>,
-): MacroKeyCombo =
-    MacroKeyCombo(
-        keyCode = key.keyCode,
-        ctrl = modifierKeys.contains("ctrl"),
-        alt = modifierKeys.contains("alt"),
-        shift = modifierKeys.contains("shift"),
-        meta = modifierKeys.contains("meta"),
-    )

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/GeneralSettingsView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/GeneralSettingsView.kt
@@ -8,10 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -24,8 +21,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
@@ -38,9 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -54,7 +47,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.io.files.Path
 import org.jetbrains.compose.resources.painterResource
+import warlockfe.warlock3.compose.components.RadioRow
 import warlockfe.warlock3.compose.components.ScrollableColumn
+import warlockfe.warlock3.compose.components.SwitchRow
 import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.generated.resources.delete
 import warlockfe.warlock3.compose.generated.resources.error_filled
@@ -190,50 +185,22 @@ fun GeneralSettingsView(
             val markLinks by clientSettingRepository
                 .observeMarkLinks()
                 .collectAsState(initial = true)
-            Row(
-                modifier =
-                    Modifier.toggleable(
-                        value = markLinks,
-                        onValueChange = {
-                            scope.launch {
-                                clientSettingRepository.putMarkLinks(it)
-                            }
-                        },
-                        role = Role.Switch,
-                    ),
-            ) {
-                Switch(
-                    checked = markLinks,
-                    onCheckedChange = null,
-                )
-                Spacer(Modifier.width(16.dp))
-                Text("Mark links in text")
-            }
+            SwitchRow(
+                checked = markLinks,
+                onCheckedChange = { scope.launch { clientSettingRepository.putMarkLinks(it) } },
+                text = "Mark links in text",
+            )
 
             Spacer(Modifier.height(16.dp))
 
             val showImages by clientSettingRepository
                 .observeShowImages()
                 .collectAsState(initial = true)
-            Row(
-                modifier =
-                    Modifier.toggleable(
-                        value = showImages,
-                        onValueChange = {
-                            scope.launch {
-                                clientSettingRepository.putShowImages(it)
-                            }
-                        },
-                        role = Role.Switch,
-                    ),
-            ) {
-                Switch(
-                    checked = showImages,
-                    onCheckedChange = null,
-                )
-                Spacer(Modifier.width(16.dp))
-                Text("Show images in stream")
-            }
+            SwitchRow(
+                checked = showImages,
+                onCheckedChange = { scope.launch { clientSettingRepository.putShowImages(it) } },
+                text = "Show images in stream",
+            )
 
             Spacer(Modifier.height(16.dp))
 
@@ -391,30 +358,11 @@ fun GeneralSettingsView(
             Text("Select theme")
             Column(Modifier.selectableGroup()) {
                 ThemeSetting.entries.forEach { entry ->
-                    Row(
-                        Modifier
-                            .height(48.dp)
-                            .selectable(
-                                selected = currentTheme == entry,
-                                onClick = {
-                                    scope.launch {
-                                        clientSettingRepository.putTheme(entry)
-                                    }
-                                },
-                                role = Role.RadioButton,
-                            ),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        RadioButton(
-                            selected = currentTheme == entry,
-                            onClick = null,
-                        )
-                        Text(
-                            text = entry.name,
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.padding(start = 16.dp),
-                        )
-                    }
+                    RadioRow(
+                        selected = currentTheme == entry,
+                        onClick = { scope.launch { clientSettingRepository.putTheme(entry) } },
+                        text = entry.name,
+                    )
                 }
             }
 
@@ -493,55 +441,19 @@ fun GeneralSettingsView(
                 Text("Select logging style")
                 Column(Modifier.selectableGroup()) {
                     LogType.entries.forEach { entry ->
-                        Row(
-                            modifier =
-                                Modifier
-                                    .height(48.dp)
-                                    .selectable(
-                                        selected = loggingSettings!!.type == entry,
-                                        onClick = {
-                                            scope.launch {
-                                                clientSettingRepository.putLoggingType(entry)
-                                            }
-                                        },
-                                        role = Role.RadioButton,
-                                    ),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            RadioButton(
-                                selected = loggingSettings!!.type == entry,
-                                onClick = null,
-                            )
-                            Text(
-                                text = entry.name,
-                                style = MaterialTheme.typography.bodyLarge,
-                                modifier = Modifier.padding(start = 16.dp),
-                            )
-                        }
+                        RadioRow(
+                            selected = loggingSettings!!.type == entry,
+                            onClick = { scope.launch { clientSettingRepository.putLoggingType(entry) } },
+                            text = entry.name,
+                        )
                     }
                 }
 
-                Row(
-                    modifier =
-                        Modifier
-                            .toggleable(
-                                value = loggingSettings!!.logTimestamps,
-                                onValueChange = {
-                                    scope.launch {
-                                        clientSettingRepository.putLoggingTimestamps(it)
-                                    }
-                                },
-                                role = Role.Switch,
-                            ),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Switch(
-                        checked = loggingSettings!!.logTimestamps,
-                        onCheckedChange = null,
-                    )
-                    Spacer(Modifier.width(16.dp))
-                    Text("Add timestamps to logs")
-                }
+                SwitchRow(
+                    checked = loggingSettings!!.logTimestamps,
+                    onCheckedChange = { scope.launch { clientSettingRepository.putLoggingTimestamps(it) } },
+                    text = "Add timestamps to logs",
+                )
             }
         }
     }

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/HighlightsView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/HighlightsView.kt
@@ -14,12 +14,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -54,6 +52,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import sh.calvin.reorderable.ReorderableColumn
+import warlockfe.warlock3.compose.components.CheckboxRow
 import warlockfe.warlock3.compose.components.ColorPickerDialog
 import warlockfe.warlock3.compose.components.ScrollableColumn
 import warlockfe.warlock3.compose.generated.resources.Res
@@ -388,49 +387,22 @@ fun EditHighlightDialog(
                 }
                 if (!isRegex) {
                     val style = styles[0]
-                    Row(
-                        Modifier.toggleable(
-                            value = style.entireLine,
-                            onValueChange = { styles[0] = style.copy(entireLine = it) },
-                            role = Role.Checkbox,
-                        ),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Checkbox(
-                            checked = style.entireLine,
-                            onCheckedChange = null,
-                        )
-                        Spacer(Modifier.width(16.dp))
-                        Text(text = "Highlight entire line")
-                    }
-                    Row(
-                        Modifier.toggleable(
-                            value = matchPartialWord,
-                            onValueChange = { matchPartialWord = it },
-                            role = Role.Checkbox,
-                        ),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Checkbox(
-                            checked = matchPartialWord,
-                            onCheckedChange = null,
-                        )
-                        Spacer(Modifier.width(16.dp))
-                        Text(text = "Match partial words")
-                    }
+                    CheckboxRow(
+                        checked = style.entireLine,
+                        onCheckedChange = { styles[0] = style.copy(entireLine = it) },
+                        text = "Highlight entire line",
+                    )
+                    CheckboxRow(
+                        checked = matchPartialWord,
+                        onCheckedChange = { matchPartialWord = it },
+                        text = "Match partial words",
+                    )
                 }
-                Row(
-                    Modifier.toggleable(
-                        value = ignoreCase,
-                        onValueChange = { ignoreCase = it },
-                        role = Role.Checkbox,
-                    ),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Checkbox(checked = ignoreCase, onCheckedChange = null)
-                    Spacer(Modifier.width(16.dp))
-                    Text(text = "Ignore case")
-                }
+                CheckboxRow(
+                    checked = ignoreCase,
+                    onCheckedChange = { ignoreCase = it },
+                    text = "Ignore case",
+                )
                 val soundLauncher =
                     rememberFilePickerLauncher { file ->
                         if (file != null) {

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/MacrosView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/MacrosView.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
@@ -32,11 +31,11 @@ import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.generated.resources.add
 import warlockfe.warlock3.compose.generated.resources.delete
 import warlockfe.warlock3.compose.generated.resources.edit
-import warlockfe.warlock3.compose.util.getLabel
 import warlockfe.warlock3.compose.util.insertDefaultMacrosIfNeeded
+import warlockfe.warlock3.compose.util.keyComboToKey
+import warlockfe.warlock3.compose.util.toDisplayString
 import warlockfe.warlock3.core.client.GameCharacter
 import warlockfe.warlock3.core.macro.Macro
-import warlockfe.warlock3.core.macro.MacroKeyCombo
 import warlockfe.warlock3.core.prefs.repositories.MacroRepository
 
 @Composable
@@ -172,41 +171,6 @@ fun MacrosView(
             Unit
         }
     }
-}
-
-private fun keyComboToKey(keyCombo: MacroKeyCombo): Pair<Key, Set<String>> {
-    val modifiers = mutableSetOf<String>()
-    if (keyCombo.ctrl) {
-        modifiers.add("ctrl")
-    }
-    if (keyCombo.alt) {
-        modifiers.add("alt")
-    }
-    if (keyCombo.shift) {
-        modifiers.add("shift")
-    }
-    if (keyCombo.meta) {
-        modifiers.add("meta")
-    }
-    return Key(keyCombo.keyCode) to modifiers
-}
-
-private fun MacroKeyCombo.toDisplayString(): String {
-    val keyString = StringBuilder()
-    if (ctrl) {
-        keyString.append("ctrl+")
-    }
-    if (alt) {
-        keyString.append("alt+")
-    }
-    if (shift) {
-        keyString.append("shift+")
-    }
-    if (meta) {
-        keyString.append("meta+")
-    }
-    keyString.append(Key(keyCode).getLabel())
-    return keyString.toString()
 }
 
 sealed class EditMacroState {

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/WindowSettingsDialog.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/WindowSettingsDialog.kt
@@ -2,13 +2,8 @@ package warlockfe.warlock3.compose.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -17,10 +12,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import warlockfe.warlock3.compose.components.CheckboxRow
 import warlockfe.warlock3.compose.components.ColorPickerButton
 import warlockfe.warlock3.compose.components.ColorPickerDialog
 import warlockfe.warlock3.compose.components.FontPickerDialog
@@ -114,22 +107,11 @@ fun WindowSettingsDialog(
                     Text("Font: ${style.fontFamily ?: "Default"} ${style.fontSize ?: "Default"}")
                 }
                 if (nameFilterOption) {
-                    Row(
-                        modifier =
-                            Modifier.toggleable(
-                                value = nameFilter,
-                                onValueChange = { saveNameFilter(it) },
-                                role = Role.Checkbox,
-                            ),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Checkbox(
-                            checked = nameFilter,
-                            onCheckedChange = null,
-                        )
-                        Spacer(Modifier.width(16.dp))
-                        Text(text = "Only show lines with names in list")
-                    }
+                    CheckboxRow(
+                        checked = nameFilter,
+                        onCheckedChange = { saveNameFilter(it) },
+                        text = "Only show lines with names in list",
+                    )
                 }
                 Button(onClick = {
                     saveStyle(StyleDefinition())

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -80,10 +80,10 @@ import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.macros.KeyboardKeyMappings
 import warlockfe.warlock3.compose.model.GameScreen
 import warlockfe.warlock3.compose.model.GameState
+import warlockfe.warlock3.compose.observeSkin
 import warlockfe.warlock3.compose.openPrefsDatabase
 import warlockfe.warlock3.compose.util.LocalSkin
 import warlockfe.warlock3.compose.util.LocalWindowComponent
-import warlockfe.warlock3.compose.util.SkinLoader
 import warlockfe.warlock3.core.prefs.PrefsDatabase
 import warlockfe.warlock3.core.prefs.ReleaseChannelSetting
 import warlockfe.warlock3.core.prefs.ThemeSetting
@@ -216,22 +216,9 @@ private class WarlockCommand : CliktCommand() {
 
         val appContainer = JvmAppContainer(database, warlockDirs, SystemFileSystem)
 
-        appContainer.clientSettings
-            .observeSkinFile()
-            .onEach { skinFile ->
-                val bytes =
-                    skinFile
-                        ?.let { File(it) }
-                        ?.takeIf { it.exists() }
-                        ?.readBytes()
-                        ?: Res.readBytes("files/skin.zip")
-                try {
-                    appContainer.skin.value = SkinLoader.parse(bytes)
-                } catch (e: Exception) {
-                    // TODO: notify user of error
-                    logger.e(e) { "Failed to load skin file" }
-                }
-            }.launchIn(appContainer.externalScope)
+        appContainer.observeSkin(logger) { path ->
+            File(path).takeIf { it.exists() }?.readBytes()
+        }
 
         // Load config files + run the DB->TOML migration + seed default macros before any startup
         // reads below (window size, release channel, auto-connect) touch the config stores.


### PR DESCRIPTION
Behavior-preserving cleanups that remove copy-paste between the mobile (Material3) and desktop (Jewel) UI, plus repeated patterns within the mobile settings screens. Found via a parallel readability scan of the codebase; this PR addresses the "mobile/desktop duplication" theme.

## Changes

**1. Centralized macro key helpers** → new `compose/commonMain/util/MacroKeyHelpers.kt`
`buildKeyString`, `KeyEvent.getKeyModifiers`, `buildKeyCombo`, `keyComboToKey`, and `MacroKeyCombo.toDisplayString` were duplicated verbatim across mobile `EditMacroDialog`/`MacrosView` and desktop `DesktopEditMacroDialog`/`DesktopMacrosView`. Now defined once; all four files call the shared copies.

**2. Shared skin-loading helper** → new `compose/commonMain/SkinObserver.kt`
The observe → read-bytes → `SkinLoader.parse` → publish pipeline was copy-pasted (TODO comment and all) in desktop `Main.kt`, android `MainActivity.kt`, and iOS `MainViewController.kt`. Now a single `AppContainer.observeSkin(logger, readSkinFile)` extension; each platform supplies only its file-reading bit (JVM/Android read from disk; iOS uses the default that always falls back to the bundled `skin.zip`).

**3. Mobile row shims** → new `compose/mobileMain/components/SettingsToggleRows.kt`
`SwitchRow`/`CheckboxRow`/`RadioRow` mirror the existing desktop Jewel shims. Replaced 9 hand-rolled `toggleable`/`selectable` row blocks across `GeneralSettingsView` (3 switches + 2 radio groups), `HighlightsView` (3 checkboxes), and `WindowSettingsDialog` (1 checkbox).

Net **−378 / +68** lines across 10 files, plus 3 small shared files.

## Verification
- ✅ Compiles: `:compose` JVM + Android (covers commonMain/jvmMain/mobileMain/androidMain), `:desktopApp`, `:androidApp`.
- ✅ ktlint clean on every touched source set.
- ⚠️ iOS not compiled locally — Kotlin/Native iOS targets need a macOS host (disabled on the Linux dev machine). `MainViewController.kt` is a same-package call to `observeSkin` with no new imports; verify on macOS/CI.

## Note
`SwitchRow` applies `verticalAlignment = CenterVertically` uniformly, which normalizes two `GeneralSettingsView` switch rows that previously lacked it — a tiny intentional visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)