### PR TITLE
Add MUD Mobile settings sync for per-character TOML config

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -33,6 +33,7 @@ import warlockfe.warlock3.core.client.WarlockClientFactory
 import warlockfe.warlock3.core.client.WarlockProxy
 import warlockfe.warlock3.core.client.WarlockSocket
 import warlockfe.warlock3.core.mudmobile.MudMobileApi
+import warlockfe.warlock3.core.mudmobile.WarlockSettingsSync
 import warlockfe.warlock3.core.prefs.MIGRATION_10_11
 import warlockfe.warlock3.core.prefs.MIGRATION_14_16
 import warlockfe.warlock3.core.prefs.MySQLiteDriver
@@ -255,6 +256,17 @@ abstract class AppContainer(
 
     val mudMobileApi by lazy { MudMobileApi(mudMobileHttpClient) }
 
+    // Backs up / syncs the per-character TOML settings to the user's MUD Mobile account.
+    val warlockSettingsSync by lazy {
+        WarlockSettingsSync(
+            api = mudMobileApi,
+            configDirectory = warlockDirs.configDir,
+            fileSystem = fileSystem,
+            tokenProvider = { clientSettings.getMudMobileToken() },
+            writeThroughStore = { path, content -> characterConfigStore.writeSectionFile(path, content) },
+        )
+    }
+
     val mudMobileConnectUseCase by lazy {
         MudMobileConnectUseCase(
             api = mudMobileApi,
@@ -284,6 +296,7 @@ abstract class AppContainer(
             mudMobileApi = mudMobileApi,
             mudMobileConnectUseCase = mudMobileConnectUseCase,
             mudMobileDiscoverUseCase = mudMobileDiscoverUseCase,
+            warlockSettingsSync = warlockSettingsSync,
         )
     }
 

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
@@ -19,7 +19,9 @@ import warlockfe.warlock3.compose.MudMobileDiscoverUseCase
 import warlockfe.warlock3.compose.model.GameScreen
 import warlockfe.warlock3.compose.model.GameState
 import warlockfe.warlock3.core.mudmobile.CharactersResult
+import warlockfe.warlock3.core.mudmobile.ConflictResolution
 import warlockfe.warlock3.core.mudmobile.MudMobileApi
+import warlockfe.warlock3.core.mudmobile.WarlockSettingsSync
 import warlockfe.warlock3.core.prefs.models.AccountEntity
 import warlockfe.warlock3.core.prefs.repositories.AccountRepository
 import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
@@ -43,8 +45,12 @@ class DashboardViewModel(
     private val mudMobileApi: MudMobileApi,
     private val mudMobileConnect: MudMobileConnectUseCase,
     private val mudMobileDiscover: MudMobileDiscoverUseCase,
+    private val warlockSettingsSync: WarlockSettingsSync,
 ) : ViewModel() {
     val connections = connectionRepository.observeAllConnections()
+
+    /** Settings-sync status + any conflicts awaiting the user's decision. */
+    val syncState = warlockSettingsSync.state
 
     private val logger = Logger.withTag("DashboardViewModel")
 
@@ -91,8 +97,35 @@ class DashboardViewModel(
         viewModelScope.launch {
             if (clientSettingRepository.getMudMobileToken() != null) {
                 refreshMudMobileCharacters()
+                // Auto-sync settings whenever the dashboard appears (app start, and on return from a
+                // game after disconnect) so per-character settings follow the user between machines.
+                warlockSettingsSync.sync()
             }
         }
+    }
+
+    // --- Settings sync ---
+
+    /** Manually trigger a settings sync (the "Sync now" action). */
+    fun syncSettings() {
+        viewModelScope.launch { warlockSettingsSync.sync() }
+    }
+
+    /** Resolve one conflicting file with the user's choice (keep local / take remote). */
+    fun resolveSyncConflict(
+        path: String,
+        resolution: ConflictResolution,
+    ) {
+        viewModelScope.launch { warlockSettingsSync.resolveConflict(path, resolution) }
+    }
+
+    fun dismissSyncMessage() {
+        warlockSettingsSync.clearMessage()
+    }
+
+    /** Defer the pending conflicts ("Later"); they resurface on the next sync. */
+    fun deferSyncConflicts() {
+        warlockSettingsSync.clearConflicts()
     }
 
     private suspend fun reloadAccounts() {
@@ -165,6 +198,8 @@ class DashboardViewModel(
                 clientSettingRepository.putMudMobileToken(trimmed)
                 connectionRepository.syncMudMobileConnections(result.characters)
                 mudMobileMessage = null
+                // Pull/push settings now that the account is connected.
+                viewModelScope.launch { warlockSettingsSync.sync() }
                 null
             }
 

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModelFactory.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModelFactory.kt
@@ -5,6 +5,7 @@ import warlockfe.warlock3.compose.MudMobileConnectUseCase
 import warlockfe.warlock3.compose.MudMobileDiscoverUseCase
 import warlockfe.warlock3.compose.model.GameState
 import warlockfe.warlock3.core.mudmobile.MudMobileApi
+import warlockfe.warlock3.core.mudmobile.WarlockSettingsSync
 import warlockfe.warlock3.core.prefs.repositories.AccountRepository
 import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
 import warlockfe.warlock3.core.prefs.repositories.ConnectionRepository
@@ -22,6 +23,7 @@ class DashboardViewModelFactory(
     private val mudMobileApi: MudMobileApi,
     private val mudMobileConnectUseCase: MudMobileConnectUseCase,
     private val mudMobileDiscoverUseCase: MudMobileDiscoverUseCase,
+    private val warlockSettingsSync: WarlockSettingsSync,
 ) {
     fun create(
         gameState: GameState,
@@ -39,5 +41,6 @@ class DashboardViewModelFactory(
             mudMobileApi = mudMobileApi,
             mudMobileConnect = mudMobileConnectUseCase,
             mudMobileDiscover = mudMobileDiscoverUseCase,
+            warlockSettingsSync = warlockSettingsSync,
         )
 }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopDashboardView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopDashboardView.kt
@@ -58,6 +58,7 @@ import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
 import warlockfe.warlock3.compose.desktop.shim.WarlockTextField
 import warlockfe.warlock3.compose.desktop.ui.settings.DesktopConfirmationDialog
 import warlockfe.warlock3.compose.ui.dashboard.DashboardViewModel
+import warlockfe.warlock3.core.mudmobile.SyncStatus
 import warlockfe.warlock3.core.prefs.models.AccountEntity
 import warlockfe.warlock3.core.sge.StoredConnection
 
@@ -219,6 +220,14 @@ private fun MudMobileRailBlock(
                 enabled = !viewModel.mudMobileBusy,
                 modifier = Modifier.fillMaxWidth(),
             )
+            val syncState by viewModel.syncState.collectAsState()
+            WarlockOutlinedButton(
+                onClick = { viewModel.syncSettings() },
+                text = if (syncState.status == SyncStatus.Syncing) "Syncing settings…" else "Sync settings",
+                enabled = syncState.status != SyncStatus.Syncing,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            syncState.message?.let { Text(it) }
             WarlockOutlinedButton(
                 onClick = { viewModel.disconnectMudMobile() },
                 text = "Disconnect MUD Mobile",
@@ -258,6 +267,10 @@ private fun MudMobileMenu(
                 dismiss()
                 viewModel.refreshMudMobileCharacters()
             }) { Text("Refresh") }
+            selectableItem(selected = false, onClick = {
+                dismiss()
+                viewModel.syncSettings()
+            }) { Text("Sync settings") }
             selectableItem(selected = false, onClick = {
                 dismiss()
                 viewModel.disconnectMudMobile()
@@ -517,6 +530,15 @@ private fun DashboardDialogs(
     viewModel: DashboardViewModel,
     ui: DashboardUiState,
 ) {
+    val syncState by viewModel.syncState.collectAsState()
+    if (syncState.conflicts.isNotEmpty()) {
+        DesktopSettingsSyncConflictDialog(
+            conflicts = syncState.conflicts,
+            onResolve = { path, resolution -> viewModel.resolveSyncConflict(path, resolution) },
+            onDismiss = { viewModel.deferSyncConflicts() },
+        )
+    }
+
     if (ui.showTokenDialog) {
         MudMobileTokenDialog(
             viewModel = viewModel,

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopSettingsSyncDialog.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopSettingsSyncDialog.kt
@@ -1,0 +1,127 @@
+package warlockfe.warlock3.compose.desktop.ui.dashboard
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Text
+import warlockfe.warlock3.compose.desktop.shim.WarlockButton
+import warlockfe.warlock3.compose.desktop.shim.WarlockDialog
+import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
+import warlockfe.warlock3.core.mudmobile.ConflictResolution
+import warlockfe.warlock3.core.mudmobile.SyncConflict
+
+/**
+ * Resolution dialog for settings-sync conflicts: one file at a time (the first in the list), showing
+ * the local and remote versions side by side so the user can pick which one wins. Resolving a file
+ * removes it from the list; the dialog closes when none remain.
+ */
+@Suppress("ktlint:compose:modifier-missing-check")
+@Composable
+fun DesktopSettingsSyncConflictDialog(
+    conflicts: List<SyncConflict>,
+    onResolve: (path: String, resolution: ConflictResolution) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val conflict = conflicts.firstOrNull() ?: return
+    WarlockDialog(
+        title = "Resolve settings conflict",
+        onCloseRequest = onDismiss,
+        width = 760.dp,
+        height = 560.dp,
+    ) {
+        Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(conflict.path, fontWeight = FontWeight.SemiBold)
+            Text(
+                "This file changed on this computer and on MUD Mobile. Choose which version to keep" +
+                    (if (conflicts.size > 1) " (${conflicts.size} files need review)." else "."),
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth().weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                DiffPane(
+                    title = "This computer",
+                    content = conflict.localContent,
+                    deletedText = "Deleted on this computer",
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                )
+                DiffPane(
+                    title = "MUD Mobile" + (conflict.remoteModified?.let { " (updated $it)" } ?: ""),
+                    content = conflict.remoteContent,
+                    deletedText = "Deleted on MUD Mobile",
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                WarlockButton(
+                    onClick = { onResolve(conflict.path, ConflictResolution.KEEP_LOCAL) },
+                    text = "Keep this computer's",
+                )
+                WarlockButton(
+                    onClick = { onResolve(conflict.path, ConflictResolution.TAKE_REMOTE) },
+                    text = "Use MUD Mobile's",
+                )
+                Box(Modifier.weight(1f))
+                WarlockButton(onClick = onDismiss, text = "Later")
+            }
+        }
+    }
+}
+
+@Composable
+private fun DiffPane(
+    title: String,
+    content: String?,
+    deletedText: String,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(2.dp)
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(title, fontWeight = FontWeight.Medium)
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(JewelTheme.globalColors.panelBackground, shape)
+                    .border(Dp.Hairline, JewelTheme.globalColors.borders.normal, shape)
+                    .padding(8.dp),
+        ) {
+            if (content == null) {
+                Text(deletedText)
+            } else {
+                WarlockScrollableColumn(Modifier.fillMaxSize()) {
+                    Text(
+                        modifier = Modifier.horizontalScroll(rememberScrollState()),
+                        text = content,
+                        fontFamily = FontFamily.Monospace,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/MudMobileApi.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/MudMobileApi.kt
@@ -5,6 +5,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
@@ -24,7 +25,7 @@ import kotlinx.serialization.json.Json
 class MudMobileApi(
     private val httpClient: HttpClient,
     private val baseUrl: String = DEFAULT_BASE_URL,
-) {
+) : WarlockFilesApi {
     private val logger = Logger.withTag("MudMobileApi")
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -215,6 +216,143 @@ class MudMobileApi(
             response.status.value in 200..299 || response.status.value == 404
         }.getOrElse { e ->
             logger.d(e) { "deleteSession failed" }
+            false
+        }
+
+    // --- Warlock settings sync (`/api/warlock/files`) -------------------------------------------
+
+    /** List the user's stored settings files (path + content hash + modified time). */
+    override suspend fun listWarlockFiles(token: String): ListWarlockFilesResult =
+        runCatching {
+            val response =
+                httpClient.get("$baseUrl/api/warlock/files") {
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                }
+            when (response.status.value) {
+                in 200..299 -> {
+                    val body = json.decodeFromString<WarlockFilesResponse>(response.bodyAsText())
+                    ListWarlockFilesResult.Success(body.files)
+                }
+
+                401 -> {
+                    ListWarlockFilesResult.Unauthorized
+                }
+
+                else -> {
+                    ListWarlockFilesResult.Error(errorMessage(response))
+                }
+            }
+        }.getOrElse { e ->
+            logger.e(e) { "listWarlockFiles failed" }
+            ListWarlockFilesResult.Error(e.message ?: "Network error")
+        }
+
+    /** Read one settings file's content + hash. */
+    override suspend fun readWarlockFile(
+        token: String,
+        path: String,
+    ): ReadWarlockFileResult =
+        runCatching {
+            val response =
+                httpClient.get("$baseUrl/api/warlock/files/file") {
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                    parameter("path", path)
+                }
+            when (response.status.value) {
+                in 200..299 -> {
+                    val body = json.decodeFromString<WarlockFileBody>(response.bodyAsText())
+                    ReadWarlockFileResult.Success(body.content, body.hash, body.modified)
+                }
+
+                401 -> {
+                    ReadWarlockFileResult.Unauthorized
+                }
+
+                404 -> {
+                    ReadWarlockFileResult.NotFound
+                }
+
+                else -> {
+                    ReadWarlockFileResult.Error(errorMessage(response))
+                }
+            }
+        }.getOrElse { e ->
+            logger.e(e) { "readWarlockFile failed" }
+            ReadWarlockFileResult.Error(e.message ?: "Network error")
+        }
+
+    /**
+     * Compare-and-swap write of one settings file. [baseHash] = the hash you last saw (null =
+     * create-only). [overwrite] = force, ignoring [baseHash]. A `409` returns [WriteWarlockFileResult.Conflict]
+     * with the current remote hash so the caller can diff/resolve.
+     */
+    override suspend fun writeWarlockFile(
+        token: String,
+        path: String,
+        content: String,
+        baseHash: String?,
+        overwrite: Boolean,
+    ): WriteWarlockFileResult =
+        runCatching {
+            val requestBody =
+                json.encodeToString(
+                    WriteWarlockFileRequest(
+                        path = path,
+                        content = content,
+                        baseHash = baseHash,
+                        overwrite = overwrite,
+                    ),
+                )
+            val response =
+                httpClient.post("$baseUrl/api/warlock/files") {
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                    contentType(ContentType.Application.Json)
+                    setBody(requestBody)
+                }
+            when (response.status.value) {
+                in 200..299 -> {
+                    val body = json.decodeFromString<WriteWarlockFileResponse>(response.bodyAsText())
+                    val hash = body.hash
+                    if (hash != null) {
+                        WriteWarlockFileResult.Success(hash, body.modified)
+                    } else {
+                        WriteWarlockFileResult.Error("Write succeeded but no hash was returned")
+                    }
+                }
+
+                401 -> {
+                    WriteWarlockFileResult.Unauthorized
+                }
+
+                409 -> {
+                    val body =
+                        runCatching { json.decodeFromString<WarlockFileConflictBody>(response.bodyAsText()) }.getOrNull()
+                    WriteWarlockFileResult.Conflict(body?.currentHash, body?.modified)
+                }
+
+                else -> {
+                    WriteWarlockFileResult.Error(errorMessage(response))
+                }
+            }
+        }.getOrElse { e ->
+            logger.e(e) { "writeWarlockFile failed" }
+            WriteWarlockFileResult.Error(e.message ?: "Network error")
+        }
+
+    /** Delete one settings file. Returns true on a 2xx (or 404, already gone). */
+    override suspend fun deleteWarlockFile(
+        token: String,
+        path: String,
+    ): Boolean =
+        runCatching {
+            val response =
+                httpClient.delete("$baseUrl/api/warlock/files/file") {
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                    parameter("path", path)
+                }
+            response.status.value in 200..299 || response.status.value == 404
+        }.getOrElse { e ->
+            logger.d(e) { "deleteWarlockFile failed" }
             false
         }
 

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/MudMobileModels.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/MudMobileModels.kt
@@ -137,3 +137,105 @@ sealed interface SessionStatusResult {
         val message: String,
     ) : SessionStatusResult
 }
+
+// --- Warlock settings sync (`/api/warlock/files`) ------------------------------------------------
+// Back up / restore / sync Warlock's own `.toml` settings. Every file is identified by
+// `hash = sha256_hex(raw_file_bytes)`; writes are compare-and-swap against `baseHash`. See §4.5 of
+// docs/specs/mudmobile-integration.md.
+
+/** Metadata for one stored settings file, from `GET /api/warlock/files`. */
+@Serializable
+data class WarlockFileMeta(
+    val path: String,
+    val size: Long = 0,
+    val modified: String? = null,
+    val hash: String,
+)
+
+@Serializable
+internal data class WarlockFilesResponse(
+    val files: List<WarlockFileMeta> = emptyList(),
+)
+
+/** Body of `GET /api/warlock/files/file?path=…`. */
+@Serializable
+internal data class WarlockFileBody(
+    val path: String,
+    val content: String,
+    val hash: String,
+    val modified: String? = null,
+)
+
+@Serializable
+internal data class WriteWarlockFileRequest(
+    val path: String,
+    val content: String,
+    val baseHash: String? = null,
+    val overwrite: Boolean = false,
+)
+
+@Serializable
+internal data class WriteWarlockFileResponse(
+    val ok: Boolean = false,
+    val path: String? = null,
+    val hash: String? = null,
+    val modified: String? = null,
+)
+
+/** 409 conflict envelope for a write: `{ "error": "conflict", "currentHash": …, "modified": … }`. */
+@Serializable
+internal data class WarlockFileConflictBody(
+    val error: String? = null,
+    val currentHash: String? = null,
+    val modified: String? = null,
+)
+
+/** Result of `GET /api/warlock/files`. */
+sealed interface ListWarlockFilesResult {
+    data class Success(
+        val files: List<WarlockFileMeta>,
+    ) : ListWarlockFilesResult
+
+    data object Unauthorized : ListWarlockFilesResult
+
+    data class Error(
+        val message: String,
+    ) : ListWarlockFilesResult
+}
+
+/** Result of `GET /api/warlock/files/file?path=…`. */
+sealed interface ReadWarlockFileResult {
+    data class Success(
+        val content: String,
+        val hash: String,
+        val modified: String?,
+    ) : ReadWarlockFileResult
+
+    data object NotFound : ReadWarlockFileResult
+
+    data object Unauthorized : ReadWarlockFileResult
+
+    data class Error(
+        val message: String,
+    ) : ReadWarlockFileResult
+}
+
+/** Result of `POST /api/warlock/files` (compare-and-swap write). */
+sealed interface WriteWarlockFileResult {
+    data class Success(
+        val hash: String,
+        val modified: String?,
+    ) : WriteWarlockFileResult
+
+    /** The remote moved on since [baseHash]; nothing was written. */
+    data class Conflict(
+        val currentHash: String?,
+        val modified: String?,
+    ) : WriteWarlockFileResult
+
+    data object Unauthorized : WriteWarlockFileResult
+
+    data class Error(
+        val message: String,
+    ) : WriteWarlockFileResult
+}

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/WarlockFilesApi.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/WarlockFilesApi.kt
@@ -1,0 +1,28 @@
+package warlockfe.warlock3.core.mudmobile
+
+/**
+ * The subset of the MUD Mobile API used by [WarlockSettingsSync] (the `/api/warlock/files`
+ * endpoints). Extracted so the sync engine can be unit-tested against an in-memory fake without a
+ * real HTTP client. [MudMobileApi] is the production implementation.
+ */
+interface WarlockFilesApi {
+    suspend fun listWarlockFiles(token: String): ListWarlockFilesResult
+
+    suspend fun readWarlockFile(
+        token: String,
+        path: String,
+    ): ReadWarlockFileResult
+
+    suspend fun writeWarlockFile(
+        token: String,
+        path: String,
+        content: String,
+        baseHash: String?,
+        overwrite: Boolean = false,
+    ): WriteWarlockFileResult
+
+    suspend fun deleteWarlockFile(
+        token: String,
+        path: String,
+    ): Boolean
+}

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/WarlockSettingsSync.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/WarlockSettingsSync.kt
@@ -1,0 +1,455 @@
+package warlockfe.warlock3.core.mudmobile
+
+import co.touchlab.kermit.Logger
+import dev.eav.tomlkt.Toml
+import dev.eav.tomlkt.encodeToString
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.io.buffered
+import kotlinx.io.files.FileSystem
+import kotlinx.io.files.Path
+import kotlinx.io.readByteArray
+import kotlinx.io.writeString
+import kotlinx.serialization.Serializable
+import warlockfe.warlock3.core.util.sha256Hex
+
+/**
+ * Two-way sync of Warlock's per-character settings (the `.toml` files under `characters/`) with the
+ * user's MUD Mobile account, so highlights/macros/variables/layout/etc. follow them between machines.
+ *
+ * Only the `characters/` tree is synced. `client.toml` (which holds the MUD Mobile device token and
+ * machine-local paths) and `connections.toml` deliberately stay local.
+ *
+ * Each file is identified by `hash = sha256_hex(raw bytes)`. The server does per-file compare-and-swap
+ * on writes (keyed on a `baseHash`); this class keeps, per file, the **base hash** of the last version
+ * it synced (in a local `.warlock-sync-state.toml`) and uses it to classify each file as unchanged,
+ * locally-changed (push), remotely-changed (pull), or changed on both sides (a [SyncConflict] the user
+ * resolves). Membership (adds/deletes across machines) is reconciled here; the server only does CAS.
+ *
+ * Pulled files are written straight to disk; the [warlockfe.warlock3.core.prefs.config.CharacterConfigStore]
+ * file watcher then reloads them into the live config. The contract is documented in §4.5 of
+ * docs/specs/mudmobile-integration.md.
+ */
+class WarlockSettingsSync(
+    private val api: WarlockFilesApi,
+    configDirectory: String,
+    private val fileSystem: FileSystem,
+    // Supplies the current device token (null when the user hasn't connected MUD Mobile).
+    private val tokenProvider: suspend () -> String?,
+    // Writes a pulled file through CharacterConfigStore so it takes the per-character file lock
+    // (serializing with in-app edits) and updates the live in-memory config. Returns false when the
+    // store doesn't own the path, in which case we fall back to a plain direct write. Defaults to
+    // always-fallback (used in tests, where there is no store).
+    private val writeThroughStore: suspend (Path, String) -> Boolean = { _, _ -> false },
+) {
+    private val logger = Logger.withTag("WarlockSettingsSync")
+    private val toml =
+        Toml {
+            ignoreUnknownKeys = true
+            explicitNulls = false
+        }
+
+    private val rootDir = Path(configDirectory)
+    private val charactersDir = Path(rootDir, "characters")
+
+    // Base-hash snapshot of what we last synced. Lives at the config root (NOT under characters/, so it
+    // is never itself a synced file).
+    private val statePath = Path(rootDir, ".warlock-sync-state.toml")
+
+    private val mutex = Mutex()
+    private val _state = MutableStateFlow(WarlockSyncUiState())
+    val state: StateFlow<WarlockSyncUiState> = _state.asStateFlow()
+
+    /**
+     * Run a full two-way reconcile. Non-conflicting changes are applied automatically (pushed/pulled/
+     * deleted); files changed on both sides are surfaced in [state] as [SyncConflict]s for the user to
+     * resolve with [resolveConflict]. A no-op (and no error) when MUD Mobile isn't connected.
+     */
+    suspend fun sync() {
+        mutex.withLock {
+            val token = tokenProvider() ?: return
+            _state.value = _state.value.copy(status = SyncStatus.Syncing, message = null)
+            runCatching { reconcile(token) }
+                .onFailure { e ->
+                    logger.e(e) { "settings sync failed" }
+                    _state.value = _state.value.copy(status = SyncStatus.Idle, message = "Sync failed: ${e.message}")
+                }
+        }
+    }
+
+    /** Apply the user's decision for a single conflicting file, then drop it from the conflict list. */
+    suspend fun resolveConflict(
+        path: String,
+        resolution: ConflictResolution,
+    ) {
+        mutex.withLock {
+            val token = tokenProvider() ?: return
+            val conflict = _state.value.conflicts.firstOrNull { it.path == path } ?: return
+            val base = readBaseHashes().toMutableMap()
+            runCatching {
+                when (resolution) {
+                    ConflictResolution.KEEP_LOCAL -> {
+                        if (conflict.localContent != null) {
+                            forcePush(token, path, conflict.localContent, base)
+                        } else {
+                            // Local side deleted the file: delete it remotely too.
+                            api.deleteWarlockFile(token, path)
+                            base.remove(path)
+                        }
+                    }
+
+                    ConflictResolution.TAKE_REMOTE -> {
+                        if (conflict.remoteContent != null && conflict.remoteHash != null) {
+                            writeLocal(path, conflict.remoteContent)
+                            base[path] = conflict.remoteHash
+                        } else {
+                            // Remote side deleted the file: delete it locally too.
+                            deleteLocal(path)
+                            base.remove(path)
+                        }
+                    }
+                }
+                writeBaseHashes(base)
+            }.onFailure { e ->
+                logger.e(e) { "resolveConflict failed for $path" }
+            }
+            _state.value =
+                _state.value.copy(conflicts = _state.value.conflicts.filterNot { it.path == path })
+        }
+    }
+
+    /** Clear a finished/failed status message without touching pending conflicts. */
+    fun clearMessage() {
+        _state.value = _state.value.copy(message = null)
+    }
+
+    /**
+     * Defer all pending conflicts (the "Later" action): drops them from view without resolving. They
+     * resurface on the next [sync] because the base hashes are unchanged.
+     */
+    fun clearConflicts() {
+        _state.value = _state.value.copy(conflicts = emptyList())
+    }
+
+    // --- reconcile ------------------------------------------------------------------------------
+
+    private suspend fun reconcile(token: String) {
+        val base = readBaseHashes().toMutableMap()
+        val local = listLocalFiles() // path -> raw bytes
+        val localHashes = local.mapValues { sha256Hex(it.value) }
+
+        val remoteList =
+            when (val result = api.listWarlockFiles(token)) {
+                is ListWarlockFilesResult.Success -> {
+                    result.files
+                }
+
+                ListWarlockFilesResult.Unauthorized -> {
+                    _state.value = _state.value.copy(status = SyncStatus.Idle, message = "MUD Mobile token rejected.")
+                    return
+                }
+
+                is ListWarlockFilesResult.Error -> {
+                    _state.value = _state.value.copy(status = SyncStatus.Idle, message = "Couldn't reach MUD Mobile: ${result.message}")
+                    return
+                }
+            }
+        val remoteHashes = remoteList.associate { it.path to it.hash }
+        val remoteModified = remoteList.associate { it.path to it.modified }
+
+        val conflicts = mutableListOf<SyncConflict>()
+        var pushed = 0
+        var pulled = 0
+        var deleted = 0
+
+        val allPaths = (base.keys + localHashes.keys + remoteHashes.keys).toSortedSet()
+        for (path in allPaths) {
+            val localHash = localHashes[path]
+            val remoteHash = remoteHashes[path]
+            val baseHash = base[path]
+
+            // Already identical on both sides (or both gone): just record the agreed hash as the base.
+            if (localHash == remoteHash) {
+                if (localHash == null) base.remove(path) else base[path] = localHash
+                continue
+            }
+
+            val localChanged = localHash != baseHash
+            val remoteChanged = remoteHash != baseHash
+
+            when {
+                localChanged && !remoteChanged -> {
+                    // Only local moved: push it (or delete remotely if it's gone locally).
+                    if (localHash == null) {
+                        if (api.deleteWarlockFile(token, path)) {
+                            base.remove(path)
+                            deleted++
+                        }
+                    } else {
+                        val content = local.getValue(path).decodeToString()
+                        when (val result = api.writeWarlockFile(token, path, content, baseHash, overwrite = false)) {
+                            is WriteWarlockFileResult.Success -> {
+                                base[path] = result.hash
+                                pushed++
+                            }
+
+                            is WriteWarlockFileResult.Conflict -> {
+                                conflicts += buildConflict(token, path, content, result.currentHash, result.modified)
+                            }
+
+                            WriteWarlockFileResult.Unauthorized -> {
+                                return
+                            }
+
+                            is WriteWarlockFileResult.Error -> {
+                                logger.w { "push $path failed: ${result.message}" }
+                            }
+                        }
+                    }
+                }
+
+                remoteChanged && !localChanged -> {
+                    // Only remote moved: pull it (or delete locally if it's gone remotely).
+                    if (remoteHash == null) {
+                        deleteLocal(path)
+                        base.remove(path)
+                        deleted++
+                    } else {
+                        when (val result = api.readWarlockFile(token, path)) {
+                            is ReadWarlockFileResult.Success -> {
+                                writeLocal(path, result.content)
+                                base[path] = result.hash
+                                pulled++
+                            }
+
+                            ReadWarlockFileResult.NotFound -> {
+                                base.remove(path)
+                            }
+
+                            ReadWarlockFileResult.Unauthorized -> {
+                                return
+                            }
+
+                            is ReadWarlockFileResult.Error -> {
+                                logger.w { "pull $path failed: ${result.message}" }
+                            }
+                        }
+                    }
+                }
+
+                else -> {
+                    // Changed on both sides to different content: needs the user.
+                    val localContent = local[path]?.decodeToString()
+                    val remoteContent = fetchRemoteContent(token, path, remoteHash)
+                    conflicts +=
+                        SyncConflict(
+                            path = path,
+                            localContent = localContent,
+                            remoteContent = remoteContent,
+                            remoteHash = remoteHash,
+                            remoteModified = remoteModified[path],
+                        )
+                }
+            }
+        }
+
+        writeBaseHashes(base)
+        _state.value =
+            _state.value.copy(
+                status = SyncStatus.Idle,
+                conflicts = conflicts,
+                message = summaryMessage(pushed, pulled, deleted, conflicts.size),
+            )
+    }
+
+    private suspend fun buildConflict(
+        token: String,
+        path: String,
+        localContent: String,
+        remoteHash: String?,
+        remoteModified: String?,
+    ): SyncConflict =
+        SyncConflict(
+            path = path,
+            localContent = localContent,
+            remoteContent = fetchRemoteContent(token, path, remoteHash),
+            remoteHash = remoteHash,
+            remoteModified = remoteModified,
+        )
+
+    private suspend fun fetchRemoteContent(
+        token: String,
+        path: String,
+        remoteHash: String?,
+    ): String? {
+        if (remoteHash == null) return null
+        return when (val result = api.readWarlockFile(token, path)) {
+            is ReadWarlockFileResult.Success -> result.content
+            else -> null
+        }
+    }
+
+    private suspend fun forcePush(
+        token: String,
+        path: String,
+        content: String,
+        base: MutableMap<String, String>,
+    ) {
+        when (val result = api.writeWarlockFile(token, path, content, baseHash = null, overwrite = true)) {
+            is WriteWarlockFileResult.Success -> base[path] = result.hash
+            else -> logger.w { "force push $path failed: $result" }
+        }
+    }
+
+    private fun summaryMessage(
+        pushed: Int,
+        pulled: Int,
+        deleted: Int,
+        conflicts: Int,
+    ): String {
+        if (pushed == 0 && pulled == 0 && deleted == 0 && conflicts == 0) return "Settings up to date."
+        val parts = mutableListOf<String>()
+        if (pushed > 0) parts += "$pushed uploaded"
+        if (pulled > 0) parts += "$pulled downloaded"
+        if (deleted > 0) parts += "$deleted removed"
+        if (conflicts > 0) parts += "$conflicts need review"
+        return parts.joinToString(", ")
+    }
+
+    // --- local file IO --------------------------------------------------------------------------
+
+    // Walk characters/ and return each *.toml file keyed by its forward-slash relative path from the
+    // config root (e.g. "characters/gs4/tholan/highlights.toml").
+    private fun listLocalFiles(): Map<String, ByteArray> {
+        val result = mutableMapOf<String, ByteArray>()
+        if (fileSystem.metadataOrNull(charactersDir)?.isDirectory != true) return result
+
+        fun walk(dir: Path) {
+            for (entry in fileSystem.list(dir)) {
+                val meta = fileSystem.metadataOrNull(entry) ?: continue
+                if (meta.isDirectory) {
+                    walk(entry)
+                } else if (entry.name.endsWith(".toml")) {
+                    runCatching {
+                        val bytes = fileSystem.source(entry).buffered().use { it.readByteArray() }
+                        result[relativePath(entry)] = bytes
+                    }.onFailure { logger.w(it) { "couldn't read $entry" } }
+                }
+            }
+        }
+        walk(charactersDir)
+        return result
+    }
+
+    private fun relativePath(path: Path): String {
+        val full = path.toString()
+        val root = rootDir.toString().trimEnd('/', '\\')
+        val rel = full.removePrefix(root).trimStart('/', '\\')
+        return rel.replace('\\', '/')
+    }
+
+    private fun resolveLocal(relativePath: String): Path {
+        var path = rootDir
+        for (segment in relativePath.split('/')) {
+            if (segment.isNotEmpty()) path = Path(path, segment)
+        }
+        return path
+    }
+
+    private suspend fun writeLocal(
+        relativePath: String,
+        content: String,
+    ) {
+        val target = resolveLocal(relativePath)
+        // Prefer writing through CharacterConfigStore so the write takes the per-character file lock
+        // (blocking concurrent in-app edits) and refreshes the in-memory config.
+        if (writeThroughStore(target, content)) return
+        val parent = target.parent
+        if (parent != null && fileSystem.metadataOrNull(parent) == null) {
+            fileSystem.createDirectories(parent)
+        }
+        val tmp = Path(parent ?: rootDir, target.name + ".synctmp")
+        fileSystem.sink(tmp).buffered().use { it.writeString(content) }
+        fileSystem.atomicMove(tmp, target)
+    }
+
+    private fun deleteLocal(relativePath: String) {
+        val target = resolveLocal(relativePath)
+        runCatching {
+            if (fileSystem.metadataOrNull(target) != null) fileSystem.delete(target)
+        }.onFailure { logger.w(it) { "couldn't delete $target" } }
+    }
+
+    // --- base-hash state file -------------------------------------------------------------------
+
+    private fun readBaseHashes(): Map<String, String> {
+        if (fileSystem.metadataOrNull(statePath) == null) return emptyMap()
+        return runCatching {
+            val text =
+                fileSystem
+                    .source(statePath)
+                    .buffered()
+                    .use { it.readByteArray() }
+                    .decodeToString()
+            val element = toml.parseToTomlTable(text)
+            toml
+                .decodeFromTomlElement(SyncStateFile.serializer(), element)
+                .files
+                .associate { it.path to it.baseHash }
+        }.getOrElse {
+            logger.w(it) { "couldn't read sync state; treating as empty" }
+            emptyMap()
+        }
+    }
+
+    private fun writeBaseHashes(hashes: Map<String, String>) {
+        runCatching {
+            if (fileSystem.metadataOrNull(rootDir) == null) fileSystem.createDirectories(rootDir)
+            val file = SyncStateFile(hashes.toSortedMap().map { SyncStateEntry(it.key, it.value) })
+            val text = toml.encodeToString(SyncStateFile.serializer(), file)
+            val tmp = Path(rootDir, statePath.name + ".tmp")
+            fileSystem.sink(tmp).buffered().use { it.writeString(text) }
+            fileSystem.atomicMove(tmp, statePath)
+        }.onFailure { logger.e(it) { "couldn't write sync state" } }
+    }
+}
+
+/** UI-facing sync state. */
+data class WarlockSyncUiState(
+    val status: SyncStatus = SyncStatus.Idle,
+    val message: String? = null,
+    val conflicts: List<SyncConflict> = emptyList(),
+)
+
+enum class SyncStatus {
+    Idle,
+    Syncing,
+}
+
+/** A single file that changed on both sides; [localContent]/[remoteContent] are null when that side deleted it. */
+data class SyncConflict(
+    val path: String,
+    val localContent: String?,
+    val remoteContent: String?,
+    val remoteHash: String?,
+    val remoteModified: String?,
+)
+
+enum class ConflictResolution {
+    KEEP_LOCAL,
+    TAKE_REMOTE,
+}
+
+@Serializable
+internal data class SyncStateFile(
+    val files: List<SyncStateEntry> = emptyList(),
+)
+
+@Serializable
+internal data class SyncStateEntry(
+    val path: String,
+    val baseHash: String,
+)

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
@@ -187,6 +187,44 @@ class CharacterConfigStore(
         }
     }
 
+    /**
+     * Overwrite a single section file at [path] with [content] (raw TOML), serialized against in-app
+     * edits via the same in-memory write lock and cross-process file lock that [mutate] uses, then
+     * update the in-memory config to match. The bytes are written **verbatim** (not re-encoded), so a
+     * caller that tracks content hashes (e.g. settings sync) sees exactly what it wrote.
+     *
+     * Intended for writing a file pulled from an external source (settings sync) without racing a
+     * concurrent in-app save. [path] must be a known section file under `characters/`; returns false
+     * (writing nothing) for anything else, so the caller can fall back to its own write.
+     */
+    suspend fun writeSectionFile(
+        path: Path,
+        content: String,
+    ): Boolean {
+        val section = Section.entries.firstOrNull { it.fileName == path.name } ?: return false
+        val dir = path.parent ?: return false
+        val characterId = characterIdFromDir(dir)
+        writeMutex.withLock {
+            ensureDir(dir)
+            withFileLock(lockFileFor(characterId)) {
+                runCatching {
+                    val tmp = Path(dir, path.name + ".tmp")
+                    fileSystem.sink(tmp).buffered().use { it.writeString(content) }
+                    fileSystem.atomicMove(tmp, path)
+                    // Update in-memory state + comment template from exactly the bytes we wrote.
+                    val element = toml.parseToTomlTable(content)
+                    val current = state.value[characterId] ?: CharacterConfig(character = characterId)
+                    val updated = applySection(section, element, current).copy(character = characterId)
+                    templates.getOrPut(characterId) { mutableMapOf() }[section] = element
+                    state.value = state.value + (characterId to updated)
+                }.onFailure {
+                    Logger.e(it) { "Failed to write section file $path" }
+                }
+            }
+        }
+        return true
+    }
+
     // --- file layout ---
 
     private fun listCharacterDirs(): List<Path> {

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/mudmobile/WarlockSettingsSyncTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/mudmobile/WarlockSettingsSyncTest.kt
@@ -1,0 +1,244 @@
+package warlockfe.warlock3.core.mudmobile
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readString
+import kotlinx.io.writeString
+import org.junit.Test
+import warlockfe.warlock3.core.prefs.config.CharacterConfigStore
+import warlockfe.warlock3.core.util.sha256Hex
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WarlockSettingsSyncTest {
+    private val fs = SystemFileSystem
+    private val root = Path(Files.createTempDirectory("sync-test").toAbsolutePath().toString())
+    private val api = FakeFilesApi()
+    private val sync =
+        WarlockSettingsSync(
+            api = api,
+            configDirectory = root.toString(),
+            fileSystem = fs,
+            tokenProvider = { "wlk_test" },
+        )
+
+    private val highlightsPath = "characters/gs4/tholan/highlights.toml"
+
+    @AfterTest
+    fun cleanup() {
+        runCatching {
+            Files
+                .walk(
+                    java.nio.file.Path
+                        .of(root.toString()),
+                ).sorted(Comparator.reverseOrder())
+                .forEach { Files.deleteIfExists(it) }
+        }
+    }
+
+    @Test
+    fun `pushes a new local file to the remote`() =
+        runBlocking {
+            writeLocal(highlightsPath, "highlights = []\n")
+
+            sync.sync()
+
+            assertEquals(SyncStatus.Idle, sync.state.value.status)
+            assertTrue(
+                sync.state.value.conflicts
+                    .isEmpty(),
+            )
+            assertEquals("highlights = []\n", api.files[highlightsPath]?.content)
+        }
+
+    @Test
+    fun `pulls a remote-only file to disk`() =
+        runBlocking {
+            api.put(highlightsPath, "highlights = [\"remote\"]\n")
+
+            sync.sync()
+
+            assertEquals("highlights = [\"remote\"]\n", readLocal(highlightsPath))
+        }
+
+    @Test
+    fun `second sync with no changes is a no-op`() =
+        runBlocking {
+            writeLocal(highlightsPath, "highlights = []\n")
+            sync.sync()
+            val writesAfterFirst = api.writeCount
+
+            sync.sync()
+
+            assertEquals(writesAfterFirst, api.writeCount, "no extra writes on a clean re-sync")
+            assertEquals("Settings up to date.", sync.state.value.message)
+        }
+
+    @Test
+    fun `divergent edits on both sides produce a conflict`() =
+        runBlocking {
+            // First sync establishes a shared base.
+            writeLocal(highlightsPath, "base\n")
+            sync.sync()
+            // Now both sides edit to different content.
+            writeLocal(highlightsPath, "local-edit\n")
+            api.put(highlightsPath, "remote-edit\n")
+
+            sync.sync()
+
+            val conflicts = sync.state.value.conflicts
+            assertEquals(1, conflicts.size)
+            assertEquals("local-edit\n", conflicts[0].localContent)
+            assertEquals("remote-edit\n", conflicts[0].remoteContent)
+        }
+
+    @Test
+    fun `resolving keep-local overwrites the remote`() =
+        runBlocking {
+            writeLocal(highlightsPath, "base\n")
+            sync.sync()
+            writeLocal(highlightsPath, "local-edit\n")
+            api.put(highlightsPath, "remote-edit\n")
+            sync.sync()
+
+            sync.resolveConflict(highlightsPath, ConflictResolution.KEEP_LOCAL)
+
+            assertEquals("local-edit\n", api.files[highlightsPath]?.content)
+            assertTrue(
+                sync.state.value.conflicts
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `resolving take-remote overwrites the local file`() =
+        runBlocking {
+            writeLocal(highlightsPath, "base\n")
+            sync.sync()
+            writeLocal(highlightsPath, "local-edit\n")
+            api.put(highlightsPath, "remote-edit\n")
+            sync.sync()
+
+            sync.resolveConflict(highlightsPath, ConflictResolution.TAKE_REMOTE)
+
+            assertEquals("remote-edit\n", readLocal(highlightsPath))
+            assertTrue(
+                sync.state.value.conflicts
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `a remote deletion removes the local file`() =
+        runBlocking {
+            writeLocal(highlightsPath, "base\n")
+            sync.sync() // base established, remote now has it
+            api.deleteWarlockFile("wlk_test", highlightsPath) // deleted remotely
+
+            sync.sync()
+
+            assertNull(readLocal(highlightsPath))
+        }
+
+    @Test
+    fun `pull writes through the config store and updates in-memory config`() =
+        runBlocking {
+            val store = CharacterConfigStore(root.toString(), fs)
+            store.load()
+            val syncWithStore =
+                WarlockSettingsSync(
+                    api = api,
+                    configDirectory = root.toString(),
+                    fileSystem = fs,
+                    tokenProvider = { "wlk_test" },
+                    writeThroughStore = { path, content -> store.writeSectionFile(path, content) },
+                )
+            api.put("characters/gs4/tholan/variables.toml", "[variables]\nfoo = \"bar\"\n")
+
+            syncWithStore.sync()
+
+            assertEquals("bar", store.current("gs4:tholan").variables["foo"])
+        }
+
+    private fun writeLocal(
+        rel: String,
+        content: String,
+    ) {
+        var path = root
+        for (segment in rel.split('/')) path = Path(path, segment)
+        path.parent?.let { if (fs.metadataOrNull(it) == null) fs.createDirectories(it) }
+        fs.sink(path).buffered().use { it.writeString(content) }
+    }
+
+    private fun readLocal(rel: String): String? {
+        var path = root
+        for (segment in rel.split('/')) path = Path(path, segment)
+        if (fs.metadataOrNull(path) == null) return null
+        return fs.source(path).buffered().use { it.readString() }
+    }
+}
+
+/** In-memory [WarlockFilesApi] with compare-and-swap semantics matching the server contract. */
+private class FakeFilesApi : WarlockFilesApi {
+    data class Stored(
+        val content: String,
+        val hash: String,
+    )
+
+    val files = mutableMapOf<String, Stored>()
+    var writeCount = 0
+
+    fun put(
+        path: String,
+        content: String,
+    ) {
+        files[path] = Stored(content, sha256Hex(content))
+    }
+
+    override suspend fun listWarlockFiles(token: String): ListWarlockFilesResult =
+        ListWarlockFilesResult.Success(files.map { WarlockFileMeta(path = it.key, hash = it.value.hash) })
+
+    override suspend fun readWarlockFile(
+        token: String,
+        path: String,
+    ): ReadWarlockFileResult {
+        val stored = files[path] ?: return ReadWarlockFileResult.NotFound
+        return ReadWarlockFileResult.Success(stored.content, stored.hash, null)
+    }
+
+    override suspend fun writeWarlockFile(
+        token: String,
+        path: String,
+        content: String,
+        baseHash: String?,
+        overwrite: Boolean,
+    ): WriteWarlockFileResult {
+        val current = files[path]
+        if (!overwrite) {
+            // create-only when baseHash is null; otherwise CAS against the current hash.
+            if (baseHash == null && current != null) {
+                return WriteWarlockFileResult.Conflict(current.hash, null)
+            }
+            if (baseHash != null && current?.hash != baseHash) {
+                return WriteWarlockFileResult.Conflict(current?.hash, null)
+            }
+        }
+        val hash = sha256Hex(content)
+        files[path] = Stored(content, hash)
+        writeCount++
+        return WriteWarlockFileResult.Success(hash, null)
+    }
+
+    override suspend fun deleteWarlockFile(
+        token: String,
+        path: String,
+    ): Boolean {
+        files.remove(path)
+        return true
+    }
+}

--- a/docs/specs/mudmobile-integration.md
+++ b/docs/specs/mudmobile-integration.md
@@ -3,7 +3,7 @@
 **Audience:** the developer (human or Claude Code) working on the **Warlock** front-end client.
 **Goal:** let a Warlock user sign in to MUD Mobile, see the characters they've set up,
 pick one, log in with SGE, and have Warlock connect to MUD Mobile's hosted-Lich service
-instead of directly to play.net — with no manual `.sal` editing.
+instead of directly to play.net - with no manual `.sal` editing.
 
 > MUD Mobile (mudmobile.com) runs **Lich-5** on demand in the cloud. The user keeps using
 > their own client (Warlock); we boot a per-session cloud machine running Lich, bridge the
@@ -12,14 +12,14 @@ instead of directly to play.net — with no manual `.sal` editing.
 
 ---
 
-## 0. TL;DR — what Warlock has to do
+## 0. TL;DR - what Warlock has to do
 
 ```
 1. User pastes a MUD Mobile device token (wlk_…) into Warlock once.            [setup]
 2. GET  https://mudmobile.com/api/characters         (Bearer wlk_…)            → character list
 3. User picks a character; Warlock prompts for that play.net account password.
 4. Warlock runs its NORMAL SGE/EAccess login to eaccess.play.net               → {gamehost, gameport, key}
-   (locally — the password and key NEVER go to MUD Mobile).
+   (locally - the password and key NEVER go to MUD Mobile).
 5. keyHash = sha256_hex(key)
 6. POST https://mudmobile.com/api/sessions           (Bearer wlk_…)            → {sessionId, connect:{host,port,tls}}
    body: {game, character, gamehost, gameport, keyHash}
@@ -105,7 +105,7 @@ Common error envelope: `{ "error": "<code>", "detail"?: <string|object> }`.
 | 400 `invalid_body` | Request failed validation (`detail` = field errors) | Bug in Warlock; log it |
 | 502 `machine_create_failed` | Cloud boot failed | Show a transient error, allow retry |
 
-### 4.1 `GET /api/characters` — list the user's saved characters
+### 4.1 `GET /api/characters` - list the user's saved characters
 
 > **STATUS: live** at `https://mudmobile.com/api/characters`.
 
@@ -121,7 +121,7 @@ works from the browser; Warlock uses the Bearer token).
       "account": "myaccount",
       "game": "DR",
       "characterCode": "C001234567",
-      "characterName": "Tannod",
+      "characterName": "Yourcharacter",
       "lastUsedAt": "2026-06-15T18:04:11.000Z"
     }
   ]
@@ -132,13 +132,13 @@ works from the browser; Warlock uses the Bearer token).
   one account; group them in the UI and ask for the password once per account.
 - `game` is the EAccess game code (see glossary). `characterCode` is what SGE's launch step
   needs. `characterName` is for display.
-- An empty list (`{"characters": []}`) means the user hasn't set up any characters yet —
+- An empty list (`{"characters": []}`) means the user hasn't set up any characters yet -
   Warlock should point them to the **Play** tab on mudmobile.com (or let them type an account
   name + password and discover characters via SGE directly; see §5, note).
 
 **Errors:** `401`.
 
-### 4.1b `POST /api/characters` — register a newly discovered character
+### 4.1b `POST /api/characters` - register a newly discovered character
 
 > **STATUS: live** at `https://mudmobile.com/api/characters`.
 
@@ -147,17 +147,17 @@ Use this to add a character to the user's MUD Mobile picker after Warlock discov
 user with an empty `GET /api/characters` populates their list from Warlock instead of having
 to visit the dashboard. It is an **idempotent upsert** keyed on
 `(user, account, game, characterCode)`, so calling it again just refreshes the name /
-last-used time — safe to call on every successful SGE launch.
+last-used time - safe to call on every successful SGE launch.
 
 **Auth:** `Bearer wlk_…` (or dashboard cookie).
 
-**Request body** (no secrets — never send the password or game key):
+**Request body** (no secrets - never send the password or game key):
 ```json
 {
   "account": "myaccount",
   "game": "DR",
   "characterCode": "C001234567",
-  "characterName": "Tannod"
+  "characterName": "Yourcharacter"
 }
 ```
 Field rules: all four are non-empty strings (`account`/`characterCode`/`characterName` ≤ 64
@@ -172,7 +172,7 @@ EAccess character list; `game` is the game code you logged in with.
     "account": "myaccount",
     "game": "DR",
     "characterCode": "C001234567",
-    "characterName": "Tannod",
+    "characterName": "Yourcharacter",
     "lastUsedAt": "2026-06-17T18:04:11.000Z"
   }
 }
@@ -185,14 +185,14 @@ EAccess character list; `game` is the game code you logged in with.
 > `POST /api/characters`. Then the connect path (§4.2 onward) and future sessions see them in
 > `GET /api/characters`.
 
-### 4.1c `DELETE /api/characters/{id}` — remove a saved character
+### 4.1c `DELETE /api/characters/{id}` - remove a saved character
 
 **Auth:** `Bearer wlk_…` (or dashboard cookie). `{id}` is the `id` from a `GET`/`POST` result.
 
 **Response 200:** `{ "ok": true }`. **Errors:** `401`, `404 not_found` (unknown id or not the
 caller's profile).
 
-### 4.2 `POST /api/sessions` — boot a hosted Lich session
+### 4.2 `POST /api/sessions` - boot a hosted Lich session
 
 Call this **after** Warlock has done SGE and has the real `{gamehost, gameport, key}`.
 
@@ -202,20 +202,20 @@ Call this **after** Warlock has done SGE and has the real `{gamehost, gameport, 
 ```json
 {
   "game": "DR",
-  "character": "Tannod",
+  "character": "Yourcharacter",
   "gamehost": "dr.simutronics.net",
   "gameport": 11024,
   "keyHash": "3f2a…(64 lowercase hex)…"
 }
 ```
 Field rules (server-enforced):
-- `game` — non-empty string. Pass the game code from the character profile.
-- `character` — non-empty string. The character name (used for display + collision cleanup).
-- `gamehost` — **must** be a `*.play.net` or `*.simutronics.net` host (anti-SSRF allowlist).
+- `game` - non-empty string. Pass the game code from the character profile.
+- `character` - non-empty string. The character name (used for display + collision cleanup).
+- `gamehost` - **must** be a `*.play.net` or `*.simutronics.net` host (anti-SSRF allowlist).
   Use the `gamehost` value SGE returned verbatim. (GemStone → `*.play.net`,
   DragonRealms → `*.simutronics.net`.)
-- `gameport` — positive integer; the `gameport` SGE returned.
-- `keyHash` — `sha256(key)` as 64 lowercase hex chars. **Not** the key.
+- `gameport` - positive integer; the `gameport` SGE returned.
+- `keyHash` - `sha256(key)` as 64 lowercase hex chars. **Not** the key.
 
 **Response 200:**
 ```json
@@ -224,9 +224,9 @@ Field rules (server-enforced):
   "connect": { "host": "play.mudmobile.com", "port": 443, "tls": true }
 }
 ```
-- A 200 means the session row is already **active and routable** — the cloud machine has
+- A 200 means the session row is already **active and routable** - the cloud machine has
   been created (it's still cold-booting, but the router holds your connection through that;
-  see §6). **Do not poll for "ready" before connecting** — connect right away.
+  see §6). **Do not poll for "ready" before connecting** - connect right away.
 - Always use the returned `connect.host` / `connect.port` / `connect.tls`; don't hardcode
   them (they can change). They will currently be `play.mudmobile.com` / `443` / `true`.
 
@@ -236,7 +236,7 @@ Field rules (server-enforced):
 live session for that same character or key on the account. So a "reconnect" is just calling
 `POST /api/sessions` again.
 
-### 4.3 `GET /api/sessions/{sessionId}` — poll session status (optional)
+### 4.3 `GET /api/sessions/{sessionId}` - poll session status (optional)
 
 **Auth:** `Bearer wlk_…`
 
@@ -249,18 +249,18 @@ live session for that same character or key on the account. So a "reconnect" is 
   "ready": true,
   "readyAt": "2026-06-15T18:04:40.000Z",
   "game": "DR",
-  "character": "Tannod",
+  "character": "Yourcharacter",
   "createdAt": "2026-06-15T18:04:05.000Z"
 }
 ```
-- Purely informational (nice for a status spinner). **Not required** for connecting —
+- Purely informational (nice for a status spinner). **Not required** for connecting -
   routing depends only on the session being `active`, which it is by the time `POST` returns.
 - `ready`/`readyAt` reflect the runner's readiness callback and may lag or never arrive in
   some environments; don't gate connecting on it.
 
 **Errors:** `401`, `404 not_found`.
 
-### 4.4 `DELETE /api/sessions/{sessionId}` — end a session (optional but recommended)
+### 4.4 `DELETE /api/sessions/{sessionId}` - end a session (optional but recommended)
 
 **Auth:** `Bearer wlk_…`
 
@@ -268,25 +268,99 @@ live session for that same character or key on the account. So a "reconnect" is 
 
 **Errors:** `401`, `404 not_found`.
 
-The machine also self-destructs on disconnect/idle, so this is a courtesy/cleanup call —
+The machine also self-destructs on disconnect/idle, so this is a courtesy/cleanup call -
 but calling it on user-initiated disconnect frees the concurrency slot immediately (relevant
 for users at their limit who want to switch characters fast).
+
+### 4.5 Warlock settings sync - back up & sync your `.toml` settings
+
+> **STATUS: live** at `https://mudmobile.com/api/warlock/files`.
+
+Lets Warlock back up its own settings (`.toml`) to the user's MUD Mobile account and restore
+them on another machine, so a user's highlights/macros/layout/etc. follow them. These are the
+**Warlock client's** files - unrelated to the Lich scripts/config synced into the hosted machine
+(`/api/scripts`, `/api/config`); Warlock never runs on the hosted machine, so it pushes/pulls
+these itself.
+
+**Auth:** `Bearer wlk_…` device token (or dashboard cookie). All paths are under `/api/warlock`
+so future Warlock-specific endpoints can live alongside.
+
+**The hash (concurrency token).** Every file is identified by a content hash:
+`hash = sha256_hex(raw_file_bytes)` (64 lowercase hex). The server computes the same over the
+stored bytes. Writes are **compare-and-swap**: you send the hash of the version you started
+from (`baseHash`); the write only lands if it still matches the stored hash, otherwise you get
+`409` and decide. This is how two machines avoid silently clobbering each other.
+
+#### `GET /api/warlock/files` - list
+```json
+{ "files": [ { "path": "settings.toml", "size": 1820,
+              "modified": "2026-06-17T18:04:11.000Z", "hash": "3f2a…(64 hex)…" } ] }
+```
+Use `hash` + `modified` to detect what changed remotely without downloading each file.
+
+#### `GET /api/warlock/files/file?path=<path>` - read one
+```json
+{ "path": "settings.toml", "content": "…toml…",
+  "hash": "3f2a…", "modified": "2026-06-17T18:04:11.000Z" }
+```
+Store `hash` as the **base** for your next write of this file. `404` if it doesn't exist.
+
+#### `POST /api/warlock/files` - write one (compare-and-swap)
+Body (JSON):
+```json
+{ "path": "settings.toml", "content": "…toml…", "baseHash": "3f2a…", "overwrite": false }
+```
+- `baseHash` - the hash you last saw for this file. **Omit/null = create-only** (write only if
+  it doesn't exist yet).
+- `overwrite: true` - force; write regardless of the current hash (use after the user picks
+  "overwrite remote"). When true, `baseHash` is ignored.
+- `path` must end in `.toml`. Subdirectories are allowed (e.g. `profiles/main.toml`).
+
+**200** (written): `{ "ok": true, "path": "settings.toml", "hash": "<new hash>", "modified": "…" }`
+- Save the returned `hash` as your new base.
+
+**409** (conflict - remote moved on, nothing written):
+```json
+{ "error": "conflict", "currentHash": "9b1c…", "modified": "2026-06-17T18:30:00.000Z" }
+```
+- `GET` the file to fetch the remote `content` for a diff, then ask the user: **overwrite remote**
+  (re-`POST` with `overwrite: true`) or **take remote** (adopt the remote content + hash as your
+  new base).
+
+#### `DELETE /api/warlock/files/file?path=<path>` - remove one
+`{ "ok": true }`.
+
+**Errors (all):** `401`, `400 invalid_body` / `unsupported_type` (non-`.toml`).
+
+#### Suggested client sync model
+Keep, per file, the **base hash** of the last version you synced (alongside the local file).
+
+- **Push (upload local):** `POST` with `baseHash` = your stored base. `200` → store the new
+  hash. `409` → remote changed: show modified-at for both, offer a diff, let the user
+  overwrite remote (`overwrite: true`) or take remote.
+- **Pull (download remote):** before overwriting a local file, check whether it has local edits
+  (`sha256(local bytes) != stored base`). If clean, take remote and store its hash. If dirty,
+  prompt (keep local / take remote / diff) - same decision as a push conflict, other direction.
+- **Adds/deletes across machines:** diff the server's `GET /api/warlock/files` list against your
+  base snapshot - a path gone from the list was deleted remotely; a new path was added remotely.
+  (Membership reconciliation is the client's job; the server only does per-file CAS.)
+- **Every successful sync (push or pull): store the synced content's hash as the new base.**
 
 ---
 
 ## 5. SGE: done locally by Warlock
 
-Warlock already speaks SGE/EAccess — keep using your existing implementation. The only thing
+Warlock already speaks SGE/EAccess - keep using your existing implementation. The only thing
 this integration adds is *where the character/account identifiers come from* (the
 `GET /api/characters` list) and *where you connect afterward* (the router, not play.net).
 
 The SGE inputs/outputs you need:
 - **Inputs:** `account` + `password` (entered by the user) + `game` (code) + `characterCode`
-  — `account`, `game`, `characterCode` all come from the chosen `GET /api/characters` entry;
+  - `account`, `game`, `characterCode` all come from the chosen `GET /api/characters` entry;
   the user supplies only the password.
 - **Output:** `{ gamehost, gameport, key }` for the chosen character, exactly as today.
 - The launch step uses the **STORM** front-end designation (`L\t{characterCode}\tSTORM\n`),
-  which is what yields a Stormfront-protocol stream — the protocol the hosted Lich expects.
+  which is what yields a Stormfront-protocol stream - the protocol the hosted Lich expects.
 
 > **Note (no profiles yet / discovery):** If `GET /api/characters` is empty, or you want to
 > support accounts the user hasn't saved in MUD Mobile, Warlock can fall back to its native
@@ -308,10 +382,10 @@ After `POST /api/sessions` returns `connect`:
 
 1. **Open a socket** to `connect.host:connect.port`. If `connect.tls` is true (default,
    port 443), perform a standard TLS handshake first (SNI = `connect.host`; it's a normal
-   CA-valid cert, terminated at MUD Mobile's edge — verify it normally).
+   CA-valid cert, terminated at MUD Mobile's edge - verify it normally).
    - A plaintext endpoint also exists on the same host at **port 7000** if you ever need it,
      but prefer the TLS endpoint the API hands you.
-2. **Send your normal Stormfront handshake as the first thing** — i.e. the game **key** line
+2. **Send your normal Stormfront handshake as the first thing** - i.e. the game **key** line
    followed by your usual `/FE:` / version lines, exactly as Warlock sends to play.net. You
    do **not** need to change how you frame the key; the router is built to tolerate Warlock's
    framing:
@@ -322,7 +396,7 @@ After `POST /api/sessions` returns `connect`:
      it **byte-for-byte** to Lich. Nothing in the stream is rewritten.
 3. **Send the key promptly.** The router drops connections that send no first line within
    **15 seconds**.
-4. **Connect once and be patient — do NOT add a reconnect loop.** The cloud machine
+4. **Connect once and be patient - do NOT add a reconnect loop.** The cloud machine
    cold-boots in ~25–60s. The router *holds your connection* and retries dialing the machine
    internally for up to ~60–90s, so a patient client rides the boot transparently. A
    client-side reconnect loop will fight this and create duplicate/again-failing attempts.
@@ -352,7 +426,7 @@ if resp.status == 401: prompt_reconnect(); return
 chars = resp.json().characters
 choice = user_pick(chars)                # {account, game, characterCode, characterName}
 
-# 2. Local SGE (Warlock's existing engine) — password stays on this machine
+# 2. Local SGE (Warlock's existing engine) - password stays on this machine
 password = user_prompt_password(choice.account)
 sge = warlock_sge_login(account=choice.account, password=password,
                         game=choice.game, characterCode=choice.characterCode)
@@ -387,18 +461,23 @@ DELETE "https://mudmobile.com/api/sessions/" + sessionId
 
 ## 8. Work required on the MUD Mobile side (not Warlock)
 
-For completeness / coordination — the Warlock dev does not implement these, but the
+For completeness / coordination - the Warlock dev does not implement these, but the
 integration depends on them:
 
-1. ~~**Add `GET /api/characters`**~~ — **DONE / live.** Returns the authenticated user's
+1. ~~**Add `GET /api/characters`**~~ - **DONE / live.** Returns the authenticated user's
    `CharacterProfile` rows in the shape defined in §4.1, on the `wlk_` Bearer path (and the
    dashboard cookie) via the existing `authenticateUserOrToken` helper.
-2. ~~(Optional, future) An endpoint for Warlock to **create/update** a character profile~~ —
+2. ~~(Optional, future) An endpoint for Warlock to **create/update** a character profile~~ -
    **DONE / live.** `POST /api/characters` (upsert, §4.1b) and `DELETE /api/characters/{id}`
    (§4.1c) let Warlock register characters discovered via local SGE and remove stale ones.
+3. ~~A settings-sync surface so Warlock can back up / restore / sync its own `.toml` settings~~ -
+   **DONE / live.** `GET/POST /api/warlock/files` + `GET/DELETE /api/warlock/files/file` (§4.5),
+   with sha256 compare-and-swap on writes. Stored per-user under `users/{userId}/warlock/`
+   (separate from the Lich scripts/data synced into the runner) and editable in the dashboard
+   **Data → Warlock** tab.
 
-Everything else Warlock needs — device tokens, `POST/GET/DELETE /api/sessions`, the router
-wire protocol, the gamehost allowlist — already exists and is documented above as-built.
+Everything else Warlock needs - device tokens, `POST/GET/DELETE /api/sessions`, the router
+wire protocol, the gamehost allowlist - already exists and is documented above as-built.
 
 ---
 


### PR DESCRIPTION
## What

Implements the **`/api/warlock/files`** contract (spec §4.5): two-way sync of Warlock's per-character settings (the `.toml` files under `characters/`) with the user's MUD Mobile account, so highlights / macros / variables / window-layout follow them between machines.

## How

- **`MudMobileApi`** — `list` / `read` / `write` (compare-and-swap) / `delete` file endpoints, behind a small **`WarlockFilesApi`** interface so the sync engine is unit-testable without a real HTTP client.
- **`WarlockSettingsSync`** — the engine. Hashes each `.toml` with the existing `sha256Hex`, tracks a per-file **base hash** in a local `.warlock-sync-state.toml`, and reconciles each file as unchanged / push / pull / conflict via the server's per-file CAS. Membership (adds & deletes across machines) is reconciled client-side.
- **Per-character only.** `client.toml` (holds the `wlk_` device token + machine-local paths) and `connections.toml` deliberately stay local; only the `characters/` tree syncs.
- **`CharacterConfigStore.writeSectionFile`** — a lock-protected, **verbatim** write so a pulled file takes the same per-character file lock that in-app edits use (serializing the two) and refreshes the live in-memory config. Verbatim bytes keep the content hash exact so there's no spurious re-push.
- **Dashboard UI** — auto-sync when the dashboard appears (app start + return after disconnect) and right after a token is connected, a manual **"Sync settings"** action, and a side-by-side **conflict-resolution dialog** (Keep this computer's / Use MUD Mobile's / Later).

## Scope notes

- Deletes (`deleteLocal`) stay a direct atomic `fileSystem.delete` — a single atomic op with no read-modify-write to race.
- The sync engine and auto-sync are shared (KMP), but only the **desktop** sync UI/diff dialog is built here, matching the desktop focus of the existing dashboard work.

## Tests

`WarlockSettingsSyncTest` — 8 cases: push new file, pull remote-only, clean re-sync is a no-op (no redundant uploads), divergent edits → conflict, keep-local, take-remote, remote-deletion-removes-local, and a write-through case asserting a pulled `variables.toml` lands in `CharacterConfigStore`'s in-memory config.

Compiles on JVM / Android / metadata; ktlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)