### PR TITLE
Decompose three monolithic functions

### DIFF
--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -87,6 +88,7 @@ import warlockfe.warlock3.compose.util.SkinLoader
 import warlockfe.warlock3.core.prefs.PrefsDatabase
 import warlockfe.warlock3.core.prefs.ReleaseChannelSetting
 import warlockfe.warlock3.core.prefs.ThemeSetting
+import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
 import warlockfe.warlock3.core.prefs.repositories.MainWindowBounds
 import warlockfe.warlock3.core.sge.AutoConnectResult
 import warlockfe.warlock3.core.sge.SgeSettings
@@ -129,92 +131,15 @@ private class WarlockCommand : CliktCommand() {
         Logger.setLogWriters(platformLogWriter())
         ComposeFoundationFlags.isNewContextMenuEnabled = true
 
-        val loginOptions = mutableSetOf<String>()
-        if (key != null) {
-            loginOptions.add("key")
-        }
-        if (stdin) {
-            loginOptions.add("stdin")
-        }
-        if (inputFile != null) {
-            loginOptions.add("inputFile")
-        }
-        if (autoConnectName != null) {
-            loginOptions.add("connection")
-        }
-        if (salFile != null) {
-            loginOptions.add("sal")
-        }
-        if (loginOptions.size > 1) {
-            println("More than one login method was specified. Please only use one of the following methods: $loginOptions")
-            exitProcess(-1)
-        }
+        validateLoginOptions()
 
-        version?.let {
-            initializeSentry(version)
-        }
-        if (debug || version == null) {
-            System.setProperty(DEFAULT_LOG_LEVEL_KEY, "DEBUG")
-            Logger.setMinSeverity(Severity.Debug)
-        } else {
-            Logger.setMinSeverity(Severity.Info)
-        }
-        val logger = Logger.withTag("Main")
+        val logger = configureLogging()
 
         FileKit.init("warlock")
 
-        val credentials =
-            if (salFile != null) {
-                val file = File(salFile!!)
-                if (!file.exists()) {
-                    println("SAL file does not exist: $salFile")
-                    exitProcess(-1)
-                }
-                try {
-                    parseSalCredentials(file.readText()).also {
-                        logger.d { "Connecting to ${it.host}:${it.port} from .sal file" }
-                    }
-                } catch (e: Exception) {
-                    println("Failed to parse .sal file: ${e.message}")
-                    exitProcess(-1)
-                }
-            } else if (port != null && host != null && key != null) {
-                logger.d { "Connecting to $host:$port with $key" }
-                SimuGameCredentials(host = host!!, port = port!!, key = key!!)
-            } else if (port != null || host != null || key != null) {
-                println("If one of \"host\", \"port\", or \"key\" is specified, the other must be as well.")
-                exitProcess(-1)
-            } else {
-                null
-            }
+        val credentials = parseCredentials(logger)
 
-        val appDirs =
-            AppDirs {
-                appName = "warlock"
-                appAuthor = "WarlockFE"
-            }
-        val configDir = appDirs.getUserConfigDir()
-        File(configDir).mkdirs()
-        val databaseDirectory = kotlinx.io.files.Path(configDir)
-        migrateLegacyWindowsPrefsDb(configDir, logger)
-
-        val warlockDirs =
-            WarlockDirs(
-                homeDir = System.getProperty("user.home"),
-                configDir = appDirs.getUserConfigDir(),
-                dataDir = appDirs.getUserDataDir(),
-                logDir = appDirs.getUserLogDir(),
-            )
-
-        println("Loading preferences from $configDir")
-        val database =
-            openPrefsDatabase(
-                directory = databaseDirectory,
-                fileSystem = SystemFileSystem,
-                builderFactory = ::getPrefsDatabaseBuilder,
-            )
-
-        val appContainer = JvmAppContainer(database, warlockDirs, SystemFileSystem)
+        val appContainer = buildAppContainer(logger)
 
         appContainer.clientSettings
             .observeSkinFile()
@@ -260,115 +185,12 @@ private class WarlockCommand : CliktCommand() {
 
         val games =
             mutableStateListOf(
-                GameState().apply {
-                    if (credentials != null || stdin || inputFile != null) {
-                        val windowRegistry = appContainer.windowRegistryFactory.create()
-                        // TODO: move this somewhere we can control it
-                        runBlocking {
-                            try {
-                                val socket =
-                                    if (stdin) {
-                                        WarlockStreamSocket(System.`in`)
-                                    } else if (inputFile != null) {
-                                        val file = File(inputFile!!)
-                                        if (!file.exists()) {
-                                            logger.e { "Input file does not exist: $inputFile" }
-                                            exitProcess(1)
-                                        }
-                                        WarlockStreamSocket(file.inputStream())
-                                    } else {
-                                        NetworkSocket(Dispatchers.IO)
-                                            .also { socket ->
-                                                socket.connect(credentials!!.host, credentials.port)
-                                            }
-                                    }
-                                val client =
-                                    appContainer.warlockClientFactory.createClient(
-                                        windowRegistry = windowRegistry,
-                                        socket = socket,
-                                    )
-                                client.connect(credentials?.key ?: "")
-                                val viewModel =
-                                    appContainer.gameViewModelFactory.create(client, windowRegistry)
-                                setScreen(
-                                    GameScreen.ConnectedGameState(viewModel),
-                                )
-                            } catch (e: IOException) {
-                                logger.e(e) { "Failed to connect to Warlock" }
-                            }
-                        }
-                    } else if (autoConnectName != null) {
-                        runBlocking {
-                            val connection = appContainer.connectionRepository.getByName(autoConnectName!!)
-                            if (connection == null) {
-                                println("Invalid connection name: $autoConnectName")
-                                exitProcess(-1)
-                            }
-                            val sgeClient = appContainer.sgeClientFactory.create()
-                            val result = sgeClient.autoConnect(sgeSettings, connection)
-                            sgeClient.close()
-                            when (result) {
-                                is AutoConnectResult.Failure -> {
-                                    println(result.reason)
-                                    exitProcess(-1)
-                                }
-
-                                is AutoConnectResult.Success -> {
-                                    // TODO: merge with the above, and probably below
-                                    try {
-                                        appContainer.connectToGameUseCase(
-                                            credentials = result.credentials,
-                                            proxySettings = connection.proxySettings,
-                                            gameState = this@apply,
-                                        )
-                                    } catch (e: Exception) {
-                                        ensureActive()
-                                        println("Error connecting to server: ${e.message}")
-                                        exitProcess(-1)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
+                createInitialGameState(appContainer, credentials, sgeSettings, logger),
             )
 
-        // Workaround for https://issuetracker.google.com/issues/399134381
-        val existingHandler = Thread.getDefaultUncaughtExceptionHandler()
-        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
-            val cause = throwable.cause ?: throwable
-            val isKnownComposeBug =
-                cause is NoSuchElementException &&
-                    cause.message?.contains("Cannot find value for key") == true
+        installUncaughtExceptionWorkaround()
 
-            if (isKnownComposeBug) {
-                // Swallow silently — known upstream bug, see https://issuetracker.google.com/issues/399134381
-            } else {
-                existingHandler?.uncaughtException(thread, throwable)
-            }
-        }
-
-        val resolvedVersion = version ?: "0.0.0"
-        val versionChannel =
-            when {
-                resolvedVersion.contains("beta") -> "beta"
-                resolvedVersion.contains("alpha") -> "alpha"
-                else -> "latest"
-            }
-        val channelSetting = runBlocking { clientSettings.getReleaseChannel() }
-        val selectedChannel =
-            when (channelSetting) {
-                ReleaseChannelSetting.CURRENT -> versionChannel
-                ReleaseChannelSetting.STABLE -> "latest"
-                ReleaseChannelSetting.BETA -> "beta"
-                ReleaseChannelSetting.ALPHA -> "alpha"
-            }
-        val updater =
-            NucleusUpdater {
-                provider = GitHubProvider(owner = "sproctor", repo = "warlock3")
-                channel = selectedChannel
-                currentVersion = resolvedVersion
-            }
+        val updater = buildUpdater(clientSettings)
         val updateSupported = updater.isUpdateSupported()
 
         application {
@@ -384,8 +206,6 @@ private class WarlockCommand : CliktCommand() {
             WarlockDesktopTheme(isDark = darkMode) {
                 var showUpdateDialog by remember { mutableStateOf(false) }
                 var availableUpdate: UpdateInfo? by remember { mutableStateOf(null) }
-                var downloadProgress: Double? by remember { mutableStateOf(null) }
-                var downloadedFile: File? by remember { mutableStateOf(null) }
                 val scope = rememberCoroutineScope()
 
                 suspend fun checkUpdate() {
@@ -414,92 +234,14 @@ private class WarlockCommand : CliktCommand() {
                 }
 
                 if (showUpdateDialog) {
-                    DialogWindow(
-                        onCloseRequest = { showUpdateDialog = false },
-                        title = "Warlock update available",
-                        state = rememberDialogState(width = 400.dp, height = 300.dp),
-                    ) {
-                        Column(
-                            Modifier
-                                .fillMaxSize()
-                                .background(JewelTheme.globalColors.panelBackground)
-                                .padding(8.dp),
-                        ) {
-                            Text("Current version: ${updater.currentVersion}")
-                            if (updateSupported) {
-                                Text("Update version: ${availableUpdate?.version ?: "No update available"}")
-                            } else {
-                                Text("Automated updates are not supported for your installation")
-                            }
-                            downloadProgress?.let { percent ->
-                                Spacer(Modifier.padding(top = 8.dp))
-                                Text("Downloading: ${percent.toInt()}%")
-                                HorizontalProgressBar(
-                                    progress = (percent / 100.0).toFloat(),
-                                    modifier = Modifier.fillMaxWidth(),
-                                )
-                            }
-                            Spacer(Modifier.weight(1f))
-                            Row(Modifier.fillMaxWidth()) {
-                                Spacer(Modifier.weight(1f))
-                                val ignoreUpdates by clientSettings
-                                    .observeIgnoreUpdates()
-                                    .collectAsState(false)
-                                if (!ignoreUpdates) {
-                                    WarlockOutlinedButton(
-                                        onClick = {
-                                            scope.launch {
-                                                clientSettings.putIgnoreUpdates(true)
-                                                showUpdateDialog = false
-                                            }
-                                        },
-                                        text = "Ignore updates",
-                                    )
-                                } else {
-                                    WarlockOutlinedButton(
-                                        onClick = {
-                                            scope.launch {
-                                                clientSettings.putIgnoreUpdates(false)
-                                            }
-                                        },
-                                        text = "Stop ignoring updates",
-                                    )
-                                }
-                                Spacer(Modifier.padding(horizontal = 4.dp))
-                                WarlockOutlinedButton(
-                                    onClick = { showUpdateDialog = false },
-                                    text = "Close",
-                                )
-                                Spacer(Modifier.padding(horizontal = 4.dp))
-                                WarlockButton(
-                                    onClick = {
-                                        val info = availableUpdate ?: return@WarlockButton
-                                        val file = downloadedFile
-                                        if (file != null) {
-                                            updater.installAndRestart(file)
-                                            return@WarlockButton
-                                        }
-                                        scope.launch {
-                                            clientSettings.putIgnoreUpdates(false)
-                                            try {
-                                                updater.downloadUpdate(info).collect { progress ->
-                                                    downloadProgress = progress.percent
-                                                    progress.file?.let { downloadedFile = it }
-                                                }
-                                                downloadedFile?.let { updater.installAndRestart(it) }
-                                            } catch (e: Exception) {
-                                                ensureActive()
-                                                logger.e(e) { "Update download failed" }
-                                                downloadProgress = null
-                                            }
-                                        }
-                                    },
-                                    enabled = availableUpdate != null && updateSupported && downloadProgress == null,
-                                    text = if (downloadedFile != null) "Install & restart" else "Update",
-                                )
-                            }
-                        }
-                    }
+                    UpdateDialog(
+                        updater = updater,
+                        updateSupported = updateSupported,
+                        availableUpdate = availableUpdate,
+                        clientSettings = clientSettings,
+                        logger = logger,
+                        onDismiss = { showUpdateDialog = false },
+                    )
                 }
 
                 games.forEachIndexed { index, gameState ->
@@ -603,10 +345,322 @@ private class WarlockCommand : CliktCommand() {
             }
         }
     }
+
+    /** Fail fast if more than one mutually-exclusive login method was supplied on the command line. */
+    private fun validateLoginOptions() {
+        val loginOptions = mutableSetOf<String>()
+        if (key != null) {
+            loginOptions.add("key")
+        }
+        if (stdin) {
+            loginOptions.add("stdin")
+        }
+        if (inputFile != null) {
+            loginOptions.add("inputFile")
+        }
+        if (autoConnectName != null) {
+            loginOptions.add("connection")
+        }
+        if (salFile != null) {
+            loginOptions.add("sal")
+        }
+        if (loginOptions.size > 1) {
+            println("More than one login method was specified. Please only use one of the following methods: $loginOptions")
+            exitProcess(-1)
+        }
+    }
+
+    private fun configureLogging(): Logger {
+        version?.let {
+            initializeSentry(version)
+        }
+        if (debug || version == null) {
+            System.setProperty(DEFAULT_LOG_LEVEL_KEY, "DEBUG")
+            Logger.setMinSeverity(Severity.Debug)
+        } else {
+            Logger.setMinSeverity(Severity.Info)
+        }
+        return Logger.withTag("Main")
+    }
+
+    private fun parseCredentials(logger: Logger): SimuGameCredentials? =
+        if (salFile != null) {
+            val file = File(salFile!!)
+            if (!file.exists()) {
+                println("SAL file does not exist: $salFile")
+                exitProcess(-1)
+            }
+            try {
+                parseSalCredentials(file.readText()).also {
+                    logger.d { "Connecting to ${it.host}:${it.port} from .sal file" }
+                }
+            } catch (e: Exception) {
+                println("Failed to parse .sal file: ${e.message}")
+                exitProcess(-1)
+            }
+        } else if (port != null && host != null && key != null) {
+            logger.d { "Connecting to $host:$port with $key" }
+            SimuGameCredentials(host = host!!, port = port!!, key = key!!)
+        } else if (port != null || host != null || key != null) {
+            println("If one of \"host\", \"port\", or \"key\" is specified, the other must be as well.")
+            exitProcess(-1)
+        } else {
+            null
+        }
+
+    private fun buildAppContainer(logger: Logger): JvmAppContainer {
+        val appDirs =
+            AppDirs {
+                appName = "warlock"
+                appAuthor = "WarlockFE"
+            }
+        val configDir = appDirs.getUserConfigDir()
+        File(configDir).mkdirs()
+        val databaseDirectory = kotlinx.io.files.Path(configDir)
+        migrateLegacyWindowsPrefsDb(configDir, logger)
+
+        val warlockDirs =
+            WarlockDirs(
+                homeDir = System.getProperty("user.home"),
+                configDir = appDirs.getUserConfigDir(),
+                dataDir = appDirs.getUserDataDir(),
+                logDir = appDirs.getUserLogDir(),
+            )
+
+        println("Loading preferences from $configDir")
+        val database =
+            openPrefsDatabase(
+                directory = databaseDirectory,
+                fileSystem = SystemFileSystem,
+                builderFactory = ::getPrefsDatabaseBuilder,
+            )
+
+        return JvmAppContainer(database, warlockDirs, SystemFileSystem)
+    }
+
+    /** Build the initial window's [GameState], performing the blocking initial connection if one was requested. */
+    private fun createInitialGameState(
+        appContainer: JvmAppContainer,
+        credentials: SimuGameCredentials?,
+        sgeSettings: SgeSettings,
+        logger: Logger,
+    ): GameState =
+        GameState().apply {
+            if (credentials != null || stdin || inputFile != null) {
+                val windowRegistry = appContainer.windowRegistryFactory.create()
+                // TODO: move this somewhere we can control it
+                runBlocking {
+                    try {
+                        val socket =
+                            if (stdin) {
+                                WarlockStreamSocket(System.`in`)
+                            } else if (inputFile != null) {
+                                val file = File(inputFile!!)
+                                if (!file.exists()) {
+                                    logger.e { "Input file does not exist: $inputFile" }
+                                    exitProcess(1)
+                                }
+                                WarlockStreamSocket(file.inputStream())
+                            } else {
+                                NetworkSocket(Dispatchers.IO)
+                                    .also { socket ->
+                                        socket.connect(credentials!!.host, credentials.port)
+                                    }
+                            }
+                        val client =
+                            appContainer.warlockClientFactory.createClient(
+                                windowRegistry = windowRegistry,
+                                socket = socket,
+                            )
+                        client.connect(credentials?.key ?: "")
+                        val viewModel =
+                            appContainer.gameViewModelFactory.create(client, windowRegistry)
+                        setScreen(
+                            GameScreen.ConnectedGameState(viewModel),
+                        )
+                    } catch (e: IOException) {
+                        logger.e(e) { "Failed to connect to Warlock" }
+                    }
+                }
+            } else if (autoConnectName != null) {
+                runBlocking {
+                    val connection = appContainer.connectionRepository.getByName(autoConnectName!!)
+                    if (connection == null) {
+                        println("Invalid connection name: $autoConnectName")
+                        exitProcess(-1)
+                    }
+                    val sgeClient = appContainer.sgeClientFactory.create()
+                    val result = sgeClient.autoConnect(sgeSettings, connection)
+                    sgeClient.close()
+                    when (result) {
+                        is AutoConnectResult.Failure -> {
+                            println(result.reason)
+                            exitProcess(-1)
+                        }
+
+                        is AutoConnectResult.Success -> {
+                            // TODO: merge with the above, and probably below
+                            try {
+                                appContainer.connectToGameUseCase(
+                                    credentials = result.credentials,
+                                    proxySettings = connection.proxySettings,
+                                    gameState = this@apply,
+                                )
+                            } catch (e: Exception) {
+                                ensureActive()
+                                println("Error connecting to server: ${e.message}")
+                                exitProcess(-1)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    private fun buildUpdater(clientSettings: ClientSettingRepository): NucleusUpdater {
+        val resolvedVersion = version ?: "0.0.0"
+        val versionChannel =
+            when {
+                resolvedVersion.contains("beta") -> "beta"
+                resolvedVersion.contains("alpha") -> "alpha"
+                else -> "latest"
+            }
+        val channelSetting = runBlocking { clientSettings.getReleaseChannel() }
+        val selectedChannel =
+            when (channelSetting) {
+                ReleaseChannelSetting.CURRENT -> versionChannel
+                ReleaseChannelSetting.STABLE -> "latest"
+                ReleaseChannelSetting.BETA -> "beta"
+                ReleaseChannelSetting.ALPHA -> "alpha"
+            }
+        return NucleusUpdater {
+            provider = GitHubProvider(owner = "sproctor", repo = "warlock3")
+            channel = selectedChannel
+            currentVersion = resolvedVersion
+        }
+    }
+
+    // Workaround for https://issuetracker.google.com/issues/399134381
+    private fun installUncaughtExceptionWorkaround() {
+        val existingHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            val cause = throwable.cause ?: throwable
+            val isKnownComposeBug =
+                cause is NoSuchElementException &&
+                    cause.message?.contains("Cannot find value for key") == true
+
+            if (isKnownComposeBug) {
+                // Swallow silently — known upstream bug, see https://issuetracker.google.com/issues/399134381
+            } else {
+                existingHandler?.uncaughtException(thread, throwable)
+            }
+        }
+    }
 }
 
 @OptIn(ExperimentalResourceApi::class)
 fun main(args: Array<String>) = WarlockCommand().versionOption(version ?: "Development").main(args)
+
+@Composable
+private fun UpdateDialog(
+    updater: NucleusUpdater,
+    updateSupported: Boolean,
+    availableUpdate: UpdateInfo?,
+    clientSettings: ClientSettingRepository,
+    logger: Logger,
+    onDismiss: () -> Unit,
+) {
+    var downloadProgress: Double? by remember { mutableStateOf(null) }
+    var downloadedFile: File? by remember { mutableStateOf(null) }
+    val scope = rememberCoroutineScope()
+
+    DialogWindow(
+        onCloseRequest = onDismiss,
+        title = "Warlock update available",
+        state = rememberDialogState(width = 400.dp, height = 300.dp),
+    ) {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .background(JewelTheme.globalColors.panelBackground)
+                .padding(8.dp),
+        ) {
+            Text("Current version: ${updater.currentVersion}")
+            if (updateSupported) {
+                Text("Update version: ${availableUpdate?.version ?: "No update available"}")
+            } else {
+                Text("Automated updates are not supported for your installation")
+            }
+            downloadProgress?.let { percent ->
+                Spacer(Modifier.padding(top = 8.dp))
+                Text("Downloading: ${percent.toInt()}%")
+                HorizontalProgressBar(
+                    progress = (percent / 100.0).toFloat(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            Spacer(Modifier.weight(1f))
+            Row(Modifier.fillMaxWidth()) {
+                Spacer(Modifier.weight(1f))
+                val ignoreUpdates by clientSettings
+                    .observeIgnoreUpdates()
+                    .collectAsState(false)
+                if (!ignoreUpdates) {
+                    WarlockOutlinedButton(
+                        onClick = {
+                            scope.launch {
+                                clientSettings.putIgnoreUpdates(true)
+                                onDismiss()
+                            }
+                        },
+                        text = "Ignore updates",
+                    )
+                } else {
+                    WarlockOutlinedButton(
+                        onClick = {
+                            scope.launch {
+                                clientSettings.putIgnoreUpdates(false)
+                            }
+                        },
+                        text = "Stop ignoring updates",
+                    )
+                }
+                Spacer(Modifier.padding(horizontal = 4.dp))
+                WarlockOutlinedButton(
+                    onClick = onDismiss,
+                    text = "Close",
+                )
+                Spacer(Modifier.padding(horizontal = 4.dp))
+                WarlockButton(
+                    onClick = {
+                        val info = availableUpdate ?: return@WarlockButton
+                        val file = downloadedFile
+                        if (file != null) {
+                            updater.installAndRestart(file)
+                            return@WarlockButton
+                        }
+                        scope.launch {
+                            clientSettings.putIgnoreUpdates(false)
+                            try {
+                                updater.downloadUpdate(info).collect { progress ->
+                                    downloadProgress = progress.percent
+                                    progress.file?.let { downloadedFile = it }
+                                }
+                                downloadedFile?.let { updater.installAndRestart(it) }
+                            } catch (e: Exception) {
+                                ensureActive()
+                                logger.e(e) { "Update download failed" }
+                                downloadProgress = null
+                            }
+                        }
+                    },
+                    enabled = availableUpdate != null && updateSupported && downloadProgress == null,
+                    text = if (downloadedFile != null) "Install & restart" else "Update",
+                )
+            }
+        }
+    }
+}
 
 private fun GameState.getTitle(): Flow<String> =
     when (val screen = this.screen) {

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslCommands.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslCommands.kt
@@ -16,115 +16,28 @@ import warlockfe.warlock3.scripting.util.toBigDecimalOrNull
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.seconds
 
+// The command table. Trivial one-liners stay inline; anything with real logic lives in a named
+// `private suspend fun` below so each command is navigable and the table stays readable.
 val wslCommands =
     CaseInsensitiveMap<suspend (WslContext, String) -> Unit>()
         .apply {
             putAll(
                 mapOf(
-                    "addtextlistener" to { context, argString ->
-                        val (variableName, pattern) = argString.splitFirstWord()
-                        if (variableName.isEmpty()) {
-                            throw WslRuntimeException("Not enough arguments to AddTextListener")
-                        }
-                        context.addListener(variableName) {
-                            if (pattern == null || it.contains(other = pattern, ignoreCase = true)) {
-                                context.setScriptVariable(variableName, WslString(it))
-                            }
-                        }
-                    },
-                    "addtextlistenerre" to { context, argString ->
-                        val (variableName, pattern) = argString.splitFirstWord()
-                        if (variableName.isEmpty() || pattern == null) {
-                            throw WslRuntimeException("Not enough arguments to AddTextListener")
-                        }
-                        val regex =
-                            parseRegex(pattern) ?: throw WslRuntimeException("Invalid regex passed to AddTextListenerRe")
-
-                        context.addListener(variableName) {
-                            val match = regex.find(it)
-                            if (match != null) {
-                                context.setScriptVariable(variableName, WslString(match.value))
-                            }
-                        }
-                    },
+                    "addtextlistener" to ::addTextListener,
+                    "addtextlistenerre" to ::addTextListenerRe,
                     "addtohighlightnames" to ::addName,
                     "addtohighlightstrings" to ::addHighlight,
-                    "cleartextlisteners" to { context, _ ->
-                        context.clearListeners()
-                    },
-                    "counter" to { context, args ->
-                        val (operator, operandString) = args.splitFirstWord()
-                        val operand =
-                            operandString?.let {
-                                it.toBigDecimalOrNull() ?: throw WslRuntimeException("Counter operand must be a number")
-                            } ?: BigDecimal.ONE
-                        val current = context.lookupVariable("c")?.toNumber() ?: BigDecimal.ZERO
-                        val result =
-                            when (operator.lowercase()) {
-                                "set" -> {
-                                    operand
-                                }
-
-                                "add" -> {
-                                    current + operand
-                                }
-
-                                "subtract" -> {
-                                    current - operand
-                                }
-
-                                "multiply" -> {
-                                    current * operand
-                                }
-
-                                "divide" -> {
-                                    if (operand.isZero()) {
-                                        throw WslRuntimeException("Cannot divide by 0")
-                                    }
-                                    current / operand
-                                }
-
-                                else -> {
-                                    throw WslRuntimeException("Unsupported counter operator")
-                                }
-                            }
-                        context.setScriptVariable("c", WslNumber(result))
-                    },
-                    "debug" to { context, args ->
-                        context.log(ScriptLoggingLevel.DEBUG, args)
-                    },
-                    "debuglevel" to { context, args ->
-                        val level = args.firstArgument()
-                        level.toIntOrNull()?.let {
-                            if (it !in 0..50) {
-                                throw WslRuntimeException("debug level must be between 0 and 50")
-                            }
-                            context.setLoggingLevel(it)
-                        } ?: ScriptLoggingLevel.fromString(level)?.let {
-                            context.setLoggingLevel(it.level)
-                        } ?: throw WslRuntimeException("Invalid logging level")
-                    },
-                    "delay" to { context, args ->
-                        val arg = args.firstArgument()
-                        val duration = arg.toDoubleOrNull() ?: 1.0
-                        delay(duration.seconds)
-                        context.scriptInstance.waitWhenSuspended()
-                    },
+                    "cleartextlisteners" to { context, _ -> context.clearListeners() },
+                    "counter" to ::counter,
+                    "debug" to { context, args -> context.log(ScriptLoggingLevel.DEBUG, args) },
+                    "debuglevel" to ::setDebugLevel,
+                    "delay" to ::delayCommand,
                     "deletefromhighlightnames" to ::deleteName,
                     "deletefromhighlightstrings" to ::deleteHighlight,
-                    "deletevariable" to { context, args ->
-                        val name = args.firstArgument()
-                        context.deleteStoredVariable(name)
-                    },
-                    "echo" to { context, args ->
-                        context.echo(args)
-                    },
-                    "error" to { context, args ->
-                        context.log(ScriptLoggingLevel.ERROR, args)
-                    },
-                    "exit" to { context, _ ->
-                        context.stop()
-                    },
+                    "deletevariable" to { context, args -> context.deleteStoredVariable(args.firstArgument()) },
+                    "echo" to { context, args -> context.echo(args) },
+                    "error" to { context, args -> context.log(ScriptLoggingLevel.ERROR, args) },
+                    "exit" to { context, _ -> context.stop() },
                     "gosub" to { context, argStr ->
                         val (label, args) = argStr.splitFirstWord()
                         if (label.isEmpty()) {
@@ -139,38 +52,16 @@ val wslCommands =
                         }
                         context.goto(label)
                     },
-                    "info" to { context, args ->
-                        context.log(ScriptLoggingLevel.INFO, args)
-                    },
+                    "info" to { context, args -> context.log(ScriptLoggingLevel.INFO, args) },
                     "local" to { context, args ->
                         val (name, value) = args.splitFirstWord()
-
                         if (name.isBlank()) {
                             throw WslRuntimeException("Invalid arguments to var")
                         }
                         context.setLocalVariable(name, WslString(value ?: ""))
                     },
-                    "log" to { context, args ->
-                        val (levelStr, rest) = args.splitFirstWord()
-                        val level =
-                            levelStr.toIntOrNull()
-                                ?: ScriptLoggingLevel.fromString(levelStr)?.level
-                                ?: throw WslRuntimeException("Invalid logging level")
-                        context.log(level, rest ?: "")
-                    },
-                    "mapadd" to { context, argString ->
-                        val (name, rest) = argString.splitFirstWord()
-                        val (key, value) =
-                            rest?.splitFirstWord()
-                                ?: throw WslRuntimeException("bad arguments passed to MapAdd")
-                        val variable =
-                            context.lookupVariable(name) ?: WslMap(emptyMap()).also { context.setScriptVariable(name, it) }
-                        if (variable.isMap()) {
-                            variable.setProperty(key, WslString(value ?: ""))
-                        } else {
-                            throw WslRuntimeException("Trying to set a property on a non-map variable")
-                        }
-                    },
+                    "log" to ::logCommand,
+                    "mapadd" to ::mapAdd,
                     "match" to { context, args ->
                         val (label, text) = args.splitFirstWord()
                         if (text?.isBlank() != false) {
@@ -194,156 +85,50 @@ val wslCommands =
                         context.putCommand(args)
                         context.waitForNav()
                     },
-                    "nextroom" to { context, _ ->
-                        context.waitForNav()
-                    },
-                    "pause" to { context, args ->
-                        val arg = args.firstArgument()
-                        val duration = arg.toDoubleOrNull() ?: 1.0
-                        context.waitForRoundTime()
-                        delay(duration.seconds)
-                        context.scriptInstance.waitWhenSuspended()
-                    },
-                    "play" to { context, args ->
-                        val name = args.firstArgument()
-                        context.playSound(name)
-                    },
+                    "nextroom" to { context, _ -> context.waitForNav() },
+                    "pause" to ::pauseCommand,
+                    "play" to { context, args -> context.playSound(args.firstArgument()) },
                     "print" to { context, args ->
                         val (stream, rest) = args.splitFirstWord()
                         rest?.let {
                             context.printToStream(stream, it)
                         }
                     },
-                    "put" to { context, args ->
-                        context.putCommand(args)
-                    },
-                    "random" to { context, args ->
-                        val argList = args.split(Regex("[ \t]+"))
-                        val min = argList[0].toIntOrNull() ?: throw WslRuntimeException("Invalid arguments to random")
-                        val max =
-                            argList.getOrNull(1)?.toIntOrNull()
-                                ?: throw WslRuntimeException("Invalid arguments to random")
-                        if (min >= max) {
-                            throw WslRuntimeException("Invalid arguments to random: min must be less than max")
-                        }
-                        context.setScriptVariable(
-                            name = "r",
-                            value = WslNumber(Random.nextInt(min, max).toBigDecimal()),
-                        )
-                    },
-                    "run" to { context, args ->
-                        context.runCommand(args)
-                    },
+                    "put" to { context, args -> context.putCommand(args) },
+                    "random" to ::randomCommand,
+                    "run" to { context, args -> context.runCommand(args) },
                     "removetextlistener" to { context, args ->
                         parseArguments(args).forEach { arg ->
                             context.removeListener(arg)
                         }
                     },
-                    "return" to { context, _ ->
-                        context.gosubReturn()
-                    },
-                    "save" to { context, args ->
-                        context.setScriptVariable("s", WslString(args))
-                    },
-                    "send" to { context, args ->
-                        context.sendCommand(args)
-                    },
-                    "setarray" to { context, args ->
-                        val (name, rest) = args.splitFirstWord()
-                        val variable =
-                            context.lookupVariable(name) ?: WslMap(emptyMap()).also { context.setScriptVariable(name, it) }
-                        if (!variable.isMap()) {
-                            throw WslRuntimeException("Trying to set a property on a non-map variable")
-                        }
-                        variable.setProperty("0", WslString(rest ?: ""))
-                        rest?.let { parseArguments(it) }?.forEachIndexed { index, arg ->
-                            variable.setProperty((index + 1).toString(), WslString(arg))
-                        }
-                    },
+                    "return" to { context, _ -> context.gosubReturn() },
+                    "save" to { context, args -> context.setScriptVariable("s", WslString(args)) },
+                    "send" to { context, args -> context.sendCommand(args) },
+                    "setarray" to ::setArray,
                     "setvariable" to { context, args ->
                         val (name, value) = args.splitFirstWord()
-
                         if (name.isBlank()) {
                             throw WslRuntimeException("Invalid arguments to SetVariable")
                         }
-                        // cx.scriptDebug(1, "setVariable: $name=$value")
                         context.setStoredVariable(name, value ?: "")
                     },
-                    "shift" to { context, _ ->
-                        var i = 1
-                        while (true) {
-                            val nextName = (i + 1).toString()
-                            val nextVar = context.lookupVariable(nextName)
-                            if (nextVar != null) {
-                                context.setScriptVariable(i.toString(), nextVar)
-                            } else {
-                                context.deleteScriptVariable(i.toString())
-                                break
-                            }
-                            i++
-                        }
-                        val allArgs = context.lookupVariable("0").toString()
-                        val breakIndex = findArgumentBreak(allArgs)
-                        context.setScriptVariable(
-                            name = "0",
-                            value =
-                                WslString(
-                                    if (breakIndex >= 0) {
-                                        allArgs.substring(breakIndex + 1)
-                                    } else {
-                                        ""
-                                    },
-                                ),
-                        )
-                    },
-                    "timer" to { context, args ->
-                        val command = args.firstArgument()
-                        when (command) {
-                            "start" -> {
-                                context.setScriptVariable("t", WslTimer())
-                            }
-
-                            "stop" -> {
-                                val timer = context.lookupVariable("t")
-                                if (timer is WslTimer) {
-                                    context.setScriptVariable("t", WslNumber(timer.toNumber()))
-                                } else {
-                                    // TODO warn that timer isn't running
-                                }
-                            }
-
-                            "clear" -> {
-                                context.deleteScriptVariable("t")
-                            }
-                        }
-                    },
+                    "shift" to ::shiftCommand,
+                    "timer" to ::timerCommand,
                     "typeahead" to { context, args ->
-                        val typeahead = args.firstArgument()
-                        typeahead.toIntOrNull()?.let { context.setTypeahead(it) }
+                        args.firstArgument().toIntOrNull()?.let { context.setTypeahead(it) }
                     },
-                    "unsetlocal" to { context, args ->
-                        val (name, _) = args.splitFirstWord()
-                        context.deleteLocalVariable(name)
-                    },
-                    "unsetvar" to { context, args ->
-                        val (name, _) = args.splitFirstWord()
-                        context.deleteScriptVariable(name)
-                    },
+                    "unsetlocal" to { context, args -> context.deleteLocalVariable(args.splitFirstWord().first) },
+                    "unsetvar" to { context, args -> context.deleteScriptVariable(args.splitFirstWord().first) },
                     "var" to { context, args ->
                         val (name, value) = args.splitFirstWord()
-
                         if (name.isBlank()) {
                             throw WslRuntimeException("Invalid arguments to var")
                         }
-                        // cx.scriptDebug(1, "setVariable: $name=$value")
                         context.setScriptVariable(name, WslString(value ?: ""))
                     },
-                    "wait" to { context, _ ->
-                        context.waitForPrompt()
-                    },
-                    "waitfor" to { context, args ->
-                        context.waitForText(args, ignoreCase = true)
-                    },
+                    "wait" to { context, _ -> context.waitForPrompt() },
+                    "waitfor" to { context, args -> context.waitForText(args, ignoreCase = true) },
                     "waitforre" to { context, args ->
                         context.waitForRegex(
                             parseRegex(args) ?: throw WslRuntimeException("Invalid regex in WaitForRe"),
@@ -376,6 +161,234 @@ private fun ifNCommand(n: Int): suspend (WslContext, String) -> Unit =
             context.executeCommand(args)
         }
     }
+
+private suspend fun addTextListener(
+    context: WslContext,
+    argString: String,
+) {
+    val (variableName, pattern) = argString.splitFirstWord()
+    if (variableName.isEmpty()) {
+        throw WslRuntimeException("Not enough arguments to AddTextListener")
+    }
+    context.addListener(variableName) {
+        if (pattern == null || it.contains(other = pattern, ignoreCase = true)) {
+            context.setScriptVariable(variableName, WslString(it))
+        }
+    }
+}
+
+private suspend fun addTextListenerRe(
+    context: WslContext,
+    argString: String,
+) {
+    val (variableName, pattern) = argString.splitFirstWord()
+    if (variableName.isEmpty() || pattern == null) {
+        throw WslRuntimeException("Not enough arguments to AddTextListener")
+    }
+    val regex =
+        parseRegex(pattern) ?: throw WslRuntimeException("Invalid regex passed to AddTextListenerRe")
+
+    context.addListener(variableName) {
+        val match = regex.find(it)
+        if (match != null) {
+            context.setScriptVariable(variableName, WslString(match.value))
+        }
+    }
+}
+
+private suspend fun counter(
+    context: WslContext,
+    args: String,
+) {
+    val (operator, operandString) = args.splitFirstWord()
+    val operand =
+        operandString?.let {
+            it.toBigDecimalOrNull() ?: throw WslRuntimeException("Counter operand must be a number")
+        } ?: BigDecimal.ONE
+    val current = context.lookupVariable("c")?.toNumber() ?: BigDecimal.ZERO
+    val result =
+        when (operator.lowercase()) {
+            "set" -> {
+                operand
+            }
+
+            "add" -> {
+                current + operand
+            }
+
+            "subtract" -> {
+                current - operand
+            }
+
+            "multiply" -> {
+                current * operand
+            }
+
+            "divide" -> {
+                if (operand.isZero()) {
+                    throw WslRuntimeException("Cannot divide by 0")
+                }
+                current / operand
+            }
+
+            else -> {
+                throw WslRuntimeException("Unsupported counter operator")
+            }
+        }
+    context.setScriptVariable("c", WslNumber(result))
+}
+
+private suspend fun setDebugLevel(
+    context: WslContext,
+    args: String,
+) {
+    val level = args.firstArgument()
+    level.toIntOrNull()?.let {
+        if (it !in 0..50) {
+            throw WslRuntimeException("debug level must be between 0 and 50")
+        }
+        context.setLoggingLevel(it)
+    } ?: ScriptLoggingLevel.fromString(level)?.let {
+        context.setLoggingLevel(it.level)
+    } ?: throw WslRuntimeException("Invalid logging level")
+}
+
+private suspend fun delayCommand(
+    context: WslContext,
+    args: String,
+) {
+    val duration = args.firstArgument().toDoubleOrNull() ?: 1.0
+    delay(duration.seconds)
+    context.scriptInstance.waitWhenSuspended()
+}
+
+private suspend fun pauseCommand(
+    context: WslContext,
+    args: String,
+) {
+    val duration = args.firstArgument().toDoubleOrNull() ?: 1.0
+    context.waitForRoundTime()
+    delay(duration.seconds)
+    context.scriptInstance.waitWhenSuspended()
+}
+
+private suspend fun logCommand(
+    context: WslContext,
+    args: String,
+) {
+    val (levelStr, rest) = args.splitFirstWord()
+    val level =
+        levelStr.toIntOrNull()
+            ?: ScriptLoggingLevel.fromString(levelStr)?.level
+            ?: throw WslRuntimeException("Invalid logging level")
+    context.log(level, rest ?: "")
+}
+
+private suspend fun mapAdd(
+    context: WslContext,
+    argString: String,
+) {
+    val (name, rest) = argString.splitFirstWord()
+    val (key, value) =
+        rest?.splitFirstWord()
+            ?: throw WslRuntimeException("bad arguments passed to MapAdd")
+    val variable =
+        context.lookupVariable(name) ?: WslMap(emptyMap()).also { context.setScriptVariable(name, it) }
+    if (variable.isMap()) {
+        variable.setProperty(key, WslString(value ?: ""))
+    } else {
+        throw WslRuntimeException("Trying to set a property on a non-map variable")
+    }
+}
+
+private suspend fun randomCommand(
+    context: WslContext,
+    args: String,
+) {
+    val argList = args.split(Regex("[ \t]+"))
+    val min = argList[0].toIntOrNull() ?: throw WslRuntimeException("Invalid arguments to random")
+    val max =
+        argList.getOrNull(1)?.toIntOrNull()
+            ?: throw WslRuntimeException("Invalid arguments to random")
+    if (min >= max) {
+        throw WslRuntimeException("Invalid arguments to random: min must be less than max")
+    }
+    context.setScriptVariable(
+        name = "r",
+        value = WslNumber(Random.nextInt(min, max).toBigDecimal()),
+    )
+}
+
+private suspend fun setArray(
+    context: WslContext,
+    args: String,
+) {
+    val (name, rest) = args.splitFirstWord()
+    val variable =
+        context.lookupVariable(name) ?: WslMap(emptyMap()).also { context.setScriptVariable(name, it) }
+    if (!variable.isMap()) {
+        throw WslRuntimeException("Trying to set a property on a non-map variable")
+    }
+    variable.setProperty("0", WslString(rest ?: ""))
+    rest?.let { parseArguments(it) }?.forEachIndexed { index, arg ->
+        variable.setProperty((index + 1).toString(), WslString(arg))
+    }
+}
+
+private suspend fun shiftCommand(
+    context: WslContext,
+    args: String,
+) {
+    var i = 1
+    while (true) {
+        val nextName = (i + 1).toString()
+        val nextVar = context.lookupVariable(nextName)
+        if (nextVar != null) {
+            context.setScriptVariable(i.toString(), nextVar)
+        } else {
+            context.deleteScriptVariable(i.toString())
+            break
+        }
+        i++
+    }
+    val allArgs = context.lookupVariable("0").toString()
+    val breakIndex = findArgumentBreak(allArgs)
+    context.setScriptVariable(
+        name = "0",
+        value =
+            WslString(
+                if (breakIndex >= 0) {
+                    allArgs.substring(breakIndex + 1)
+                } else {
+                    ""
+                },
+            ),
+    )
+}
+
+private suspend fun timerCommand(
+    context: WslContext,
+    args: String,
+) {
+    when (args.firstArgument()) {
+        "start" -> {
+            context.setScriptVariable("t", WslTimer())
+        }
+
+        "stop" -> {
+            val timer = context.lookupVariable("t")
+            if (timer is WslTimer) {
+                context.setScriptVariable("t", WslNumber(timer.toNumber()))
+            } else {
+                // TODO warn that timer isn't running
+            }
+        }
+
+        "clear" -> {
+            context.deleteScriptVariable("t")
+        }
+    }
+}
 
 private suspend fun addHighlight(
     context: WslContext,

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -76,6 +76,7 @@ import warlockfe.warlock3.wrayth.protocol.WraythDialogWindowEvent
 import warlockfe.warlock3.wrayth.protocol.WraythDirectionEvent
 import warlockfe.warlock3.wrayth.protocol.WraythEndCmdList
 import warlockfe.warlock3.wrayth.protocol.WraythEolEvent
+import warlockfe.warlock3.wrayth.protocol.WraythEvent
 import warlockfe.warlock3.wrayth.protocol.WraythHandledEvent
 import warlockfe.warlock3.wrayth.protocol.WraythIndicatorEvent
 import warlockfe.warlock3.wrayth.protocol.WraythLeftEvent
@@ -292,452 +293,7 @@ class WraythClient(
                         logComplete { line }
                         debug(line)
                         val events = protocolHandler.parseLine(line)
-                        events.forEach { event ->
-                            when (event) {
-                                WraythHandledEvent -> {}
-
-                                is WraythModeEvent -> {
-                                    if (event.id.equals("cmgr", true)) {
-                                        parseText = false
-                                    }
-                                }
-
-                                is WraythStreamEvent -> {
-                                    componentId = null
-                                    flushBuffer(true)
-                                    currentStream = getStream(event.id ?: "main")
-                                }
-
-                                is WraythClearStreamEvent -> {
-                                    getStream(event.id).clear()
-                                }
-
-                                is WraythDataReceivedEvent -> {
-                                    bufferText(StyledString(event.text))
-                                }
-
-                                is WraythEolEvent -> {
-                                    // We're working under the assumption that an end tag is always on the same line as the start tag
-                                    flushBuffer(event.ignoreWhenBlank)
-                                }
-
-                                is WraythAppEvent -> {
-                                    val game = event.game
-                                    val character = event.character
-                                    if (game != null && character != null) {
-                                        val characterId = "${event.game}:${event.character}".lowercase()
-                                        _characterId.value = characterId
-                                        logMutex.withLock {
-                                            logName = "${event.game}_${event.character}"
-                                            logBuffer.forEach { it() }
-                                            logBuffer.clear()
-                                        }
-                                        if (characterRepository.getCharacter(characterId) == null) {
-                                            characterRepository.saveCharacter(
-                                                GameCharacter(
-                                                    id = characterId,
-                                                    gameCode = game,
-                                                    name = character,
-                                                ),
-                                            )
-                                        }
-                                        _gameName.value = game
-                                        _characterName.value = character
-                                    }
-                                }
-
-                                is WraythOutputEvent -> {
-                                    outputStyle = event.style
-                                }
-
-                                is WraythStyleEvent -> {
-                                    currentStyle = event.style
-                                }
-
-                                is WraythPushStyleEvent -> {
-                                    styleStack.addLast(event.style)
-                                }
-
-                                WraythPopStyleEvent -> {
-                                    styleStack.removeLastOrNull()
-                                }
-
-                                is WraythPromptEvent -> {
-                                    currentTypeAhead.update { max(0, it - 1) }
-                                    styleStack.clear()
-                                    componentId = null
-                                    currentStyle = null
-                                    currentStream = null
-                                    if (!isPrompting) {
-                                        getMainStream().appendPartial(
-                                            StyledString(event.text, listOfNotNull(outputStyle)),
-                                            isPrompt = true,
-                                        )
-                                        isPrompting = true
-                                    }
-                                    notifyListeners(ClientPromptEvent)
-                                }
-
-                                is WraythTimeEvent -> {
-                                    val newTime = Instant.fromEpochSeconds(event.time)
-                                    val now = Clock.System.now()
-                                    val adjustedTime = now + delta
-                                    if (event.time > adjustedTime.epochSeconds) {
-                                        // We're in the previous second
-                                        delta = newTime - now
-                                    } else if (event.time < adjustedTime.epochSeconds) {
-                                        // We're in the next second
-                                        delta = newTime + 1.seconds - now
-                                    }
-                                }
-
-                                is WraythRoundTimeEvent -> {
-                                    event.time.toLongOrNull()?.let {
-                                        _roundTimeEnd.value = it
-                                    }
-                                }
-
-                                is WraythCastTimeEvent -> {
-                                    event.time.toLongOrNull()?.let {
-                                        _castTimeEnd.value = it
-                                    }
-                                }
-
-                                is WraythIndicatorEvent -> {
-                                    if (event.visible) {
-                                        _indicators.update { it + event.iconId }
-                                    } else {
-                                        _indicators.update { it - event.iconId }
-                                    }
-                                }
-
-                                is WraythSettingsInfoEvent -> {
-                                    gameCode = event.instance
-
-                                    // We don't actually handle server settings
-
-                                    // Not 100% where this belongs. connections hang until and empty command is sent
-                                    // This must be in response to either mode, playerId, or settingsInfo, so
-                                    // we put it here until someone discovers something else
-                                    sendCommandDirect("")
-                                    sendCommandDirect("_STATE CHATMODE OFF")
-                                }
-
-                                is WraythDialogDataEvent -> {
-                                    if (event.id == null) {
-                                        dialogDataId?.let { windowRegistry.getOrCreateDialog(it).updateState() }
-                                    }
-                                    dialogDataId = event.id
-                                    if (event.clear && event.id != null) {
-                                        this@WraythClient.windowRegistry.getOrCreateDialog(event.id).clear()
-                                    }
-                                }
-
-                                is WraythDialogObjectEvent -> {
-                                    // TODO: record this data somewhere
-                                    // val data = event.data
-                                    // if (data is DialogObject.ProgressBar) {
-                                    //    _properties.value = _properties.value +
-                                    // (data.id to data.value.value.toString()) +
-                                    //            ((data.id + "text") to (data.text ?: ""))
-                                    // }
-                                    dialogDataId?.let {
-                                        windowRegistry.getOrCreateDialog(it).setObject(event.data)
-                                    }
-                                }
-
-                                is WraythCompassEndEvent -> {
-                                    notifyListeners(ClientCompassEvent(directions.toPersistentHashSet()))
-                                    directions.clear()
-                                }
-
-                                is WraythDirectionEvent -> {
-                                    directions += event.direction
-                                }
-
-                                is WraythLeftEvent -> {
-                                    _leftHand.value = event.value
-                                }
-
-                                is WraythRightEvent -> {
-                                    _rightHand.value = event.value
-                                }
-
-                                is WraythSpellEvent -> {
-                                    _spellHand.value = event.value
-                                }
-
-                                is WraythComponentDefinitionEvent -> {
-                                    // Should not happen on main stream, so don't clear prompt
-                                    // TODO: Should currentStyle be used here? is it per stream?
-                                    bufferText(
-                                        text =
-                                            StyledString(
-                                                persistentListOf(
-                                                    StyledStringVariable(
-                                                        name = event.id,
-                                                        styles = styleStack.toPersistentList(),
-                                                    ),
-                                                ),
-                                            ),
-                                    )
-                                    componentId = event.id
-                                    elementBuffer = StyledString()
-                                }
-
-                                is WraythComponentStartEvent -> {
-                                    componentId = event.id
-                                    elementBuffer = StyledString()
-                                }
-
-                                WraythComponentEndEvent -> {
-                                    if (componentId != null) {
-                                        // Either replace the component in the map with the new value
-                                        //  or remove the component from the map (if we got an empty one)
-                                        componentsMutex.withLock {
-                                            components =
-                                                if (elementBuffer?.substrings.isNullOrEmpty()) {
-                                                    components.remove(componentId!!)
-                                                } else {
-                                                    components.put(componentId!!, elementBuffer!!)
-                                                }
-                                        }
-                                        val newValue = elementBuffer ?: StyledString()
-                                        windowRegistry.getStreams().forEach { stream ->
-                                            stream.updateComponent(componentId!!, newValue)
-                                        }
-                                        elementBuffer = null
-                                        componentId = null
-                                    } else {
-                                        // mismatched component tags?
-                                    }
-                                }
-
-                                WraythNavEvent -> {
-                                    notifyListeners(ClientNavEvent)
-                                }
-
-                                is WraythBackgroundEvent -> {
-                                    var updatedWindow: WindowInfo? = null
-                                    _windowInfo.update { currentWindowInfo ->
-                                        val index = currentWindowInfo.indexOfFirst { it.name == event.windowName }
-                                        if (index != -1) {
-                                            val window = currentWindowInfo[index]
-                                            val backgroundImage =
-                                                if (event.image != null) {
-                                                    ClientBackgroundImage(
-                                                        image = resolveBackgroundImage(event.image),
-                                                        mode = event.mode,
-                                                        gradientStart = event.gradientStart,
-                                                        gradientEnd = event.gradientEnd,
-                                                        opacity = event.opacity,
-                                                        horizontalAlignment = event.horizontalAlignment,
-                                                        verticalAlignment = event.verticalAlignment,
-                                                    )
-                                                } else {
-                                                    null
-                                                }
-                                            updatedWindow =
-                                                window.copy(
-                                                    backgroundImage = backgroundImage,
-                                                )
-                                            val updatedInfo = currentWindowInfo.toMutableList()
-                                            updatedInfo[index] = updatedWindow
-                                            updatedInfo
-                                        } else {
-                                            currentWindowInfo
-                                        }
-                                    }
-                                    updatedWindow?.let { notifyListeners(ClientWindowInfoEvent(it)) }
-                                }
-
-                                is WraythStreamWindowEvent -> {
-                                    val window = event.window
-                                    if (windows[event.window.name] == null && window.name != "main") {
-                                        sendCommandDirect("_swclose s${event.window.name}")
-                                    }
-                                    addWindow(window)
-                                }
-
-                                is WraythDialogWindowEvent -> {
-                                    val window = event.window
-                                    if (window.resident) {
-                                        lateinit var info: WindowInfo
-                                        _windowInfo.update { windowInfo ->
-                                            val existing = windowInfo.firstOrNull { it.name == window.id }
-                                            info =
-                                                WindowInfo(
-                                                    name = window.id,
-                                                    title = window.title,
-                                                    subtitle = null,
-                                                    windowType = WindowType.DIALOG,
-                                                    showTimestamps = false,
-                                                    backgroundImage = existing?.backgroundImage,
-                                                )
-                                            windowInfo.replaceOrAdd(info) { it.name == info.name }
-                                        }
-                                        notifyListeners(ClientWindowInfoEvent(info))
-                                    }
-                                }
-
-                                is WraythActionEvent -> {
-                                    bufferText(
-                                        StyledString(
-                                            text = event.text,
-                                            style = WarlockStyle.Link(WarlockAction.SendCommand(event.command)),
-                                        ),
-                                    )
-                                }
-
-                                is WraythOpenUrlEvent -> {
-                                    try {
-                                        val url = resolve(baseUri, Uri.parse(event.url))
-                                        notifyListeners(ClientOpenUrlEvent(url))
-                                    } catch (_: Exception) {
-                                        // Silently ignore exceptions
-                                    }
-                                }
-
-                                is WraythUpdateVerbsEvent -> {
-                                    sendCommandDirect("_menu update 1")
-                                }
-
-                                is WraythStartCmdList -> {
-                                    // ignore for now
-                                }
-
-                                is WraythEndCmdList -> {
-                                    cliCoords =
-                                        cliCoords.mutate { map ->
-                                            cliCache.forEach { cli ->
-                                                map[cli.coord] = cli
-                                            }
-                                        }
-                                    cliCache.clear()
-                                }
-
-                                is WraythCliEvent -> {
-                                    cliCache.add(event.cmd)
-                                }
-
-                                is WraythPushCmdEvent -> {
-                                    val cmd = event.cmd
-                                    if (cmd.coord != null) {
-                                        val action =
-                                            WarlockAction.SendCommandWithLookup {
-                                                val cmdDef = cliCoords[cmd.coord]
-                                                if (cmdDef != null) {
-                                                    replaceTemplateSymbols(
-                                                        text = cmdDef.command,
-                                                        cmdNoun = cmd.noun,
-                                                        cmdId = cmd.exist,
-                                                        eventNoun = null,
-                                                    )
-                                                } else {
-                                                    print(
-                                                        StyledString(
-                                                            "Could not find cli for coord: ${cmd.coord}",
-                                                            WarlockStyle.Error,
-                                                        ),
-                                                    )
-                                                    ""
-                                                }
-                                            }
-                                        styleStack.addLast(
-                                            WarlockStyle.Link(action),
-                                        )
-                                    } else if (cmd.exist != null) {
-                                        styleStack.addLast(
-                                            WarlockStyle.Link(
-                                                WarlockAction.OpenMenu {
-                                                    val menuId = menuCount++
-                                                    _menuData.value = WarlockMenuData(menuId, emptyList())
-                                                    currentCmd = cmd
-                                                    scope.launch {
-                                                        sendCommandDirect("_menu #${cmd.exist} $menuId")
-                                                    }
-                                                    menuId
-                                                },
-                                            ),
-                                        )
-                                    } else {
-                                        styleStack.addLast(WarlockStyle(""))
-                                    }
-                                }
-
-                                is WraythMenuStartEvent -> {
-                                    event.id?.let {
-                                        currentMenuId = it
-                                    }
-                                }
-
-                                is WraythMenuItemEvent -> {
-                                    cliCoords[event.coord]?.let { command ->
-                                        val cmd = currentCmd
-                                        if (cmd != null) {
-                                            cachedMenuItems.add(
-                                                WarlockMenuItem(
-                                                    label =
-                                                        replaceTemplateSymbols(
-                                                            text = command.menu,
-                                                            cmdNoun = cmd.noun,
-                                                            cmdId = cmd.exist,
-                                                            eventNoun = event.noun,
-                                                        ),
-                                                    category = command.category,
-                                                    action = {
-                                                        sendCommand(
-                                                            replaceTemplateSymbols(
-                                                                text = command.command,
-                                                                cmdNoun = cmd.noun,
-                                                                cmdId = cmd.exist,
-                                                                eventNoun = event.noun,
-                                                            ),
-                                                        )
-                                                    },
-                                                ),
-                                            )
-                                        }
-                                    }
-                                }
-
-                                is WraythMenuEndEvent -> {
-                                    _menuData.update { menu ->
-                                        if (menu.id != currentMenuId) {
-                                            menu
-                                        } else {
-                                            menu.copy(items = cachedMenuItems.toPersistentList())
-                                        }
-                                    }
-                                    cachedMenuItems.clear()
-                                }
-
-                                is WraythUnhandledTagEvent -> {
-                                    // debug("Unhandled tag: ${event.tag}")
-                                }
-
-                                is WraythParseErrorEvent -> {
-                                    getMainStream().appendLine(
-                                        StyledString(
-                                            "parse error: ${event.text}",
-                                            WarlockStyle.Error,
-                                        ),
-                                    )
-                                }
-
-                                is WraythResourceEvent -> {
-                                    flushBuffer(true)
-                                    gameCode?.filter { it.isLetter() }?.lowercase()?.let { code ->
-                                        val url = "https://www.play.net/bfe/$code-art/${event.picture}.jpg"
-                                        logger.d { "Got resource: $url" }
-                                        (currentStream ?: getMainStream()).appendResource(url)
-                                        if (currentStream.isMainStream) {
-                                            isPrompting = false
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        events.forEach { handleEvent(it) }
                     } else {
                         // This is the strange mode to read books and create characters
                         val text = socket.readAvailable()
@@ -756,6 +312,465 @@ class WraythClient(
                     disconnected()
                     break
                 }
+            }
+        }
+    }
+
+    private suspend fun handleEvent(event: WraythEvent) {
+        when (event) {
+            WraythHandledEvent -> {}
+
+            is WraythModeEvent -> {
+                if (event.id.equals("cmgr", true)) {
+                    parseText = false
+                }
+            }
+
+            is WraythStreamEvent -> {
+                componentId = null
+                flushBuffer(true)
+                currentStream = getStream(event.id ?: "main")
+            }
+
+            is WraythClearStreamEvent -> {
+                getStream(event.id).clear()
+            }
+
+            is WraythDataReceivedEvent -> {
+                bufferText(StyledString(event.text))
+            }
+
+            is WraythEolEvent -> {
+                // We're working under the assumption that an end tag is always on the same line as the start tag
+                flushBuffer(event.ignoreWhenBlank)
+            }
+
+            is WraythAppEvent -> {
+                val game = event.game
+                val character = event.character
+                if (game != null && character != null) {
+                    val characterId = "${event.game}:${event.character}".lowercase()
+                    _characterId.value = characterId
+                    logMutex.withLock {
+                        logName = "${event.game}_${event.character}"
+                        logBuffer.forEach { it() }
+                        logBuffer.clear()
+                    }
+                    if (characterRepository.getCharacter(characterId) == null) {
+                        characterRepository.saveCharacter(
+                            GameCharacter(
+                                id = characterId,
+                                gameCode = game,
+                                name = character,
+                            ),
+                        )
+                    }
+                    _gameName.value = game
+                    _characterName.value = character
+                }
+            }
+
+            is WraythOutputEvent -> {
+                outputStyle = event.style
+            }
+
+            is WraythStyleEvent -> {
+                currentStyle = event.style
+            }
+
+            is WraythPushStyleEvent -> {
+                styleStack.addLast(event.style)
+            }
+
+            WraythPopStyleEvent -> {
+                styleStack.removeLastOrNull()
+            }
+
+            is WraythPromptEvent -> {
+                currentTypeAhead.update { max(0, it - 1) }
+                styleStack.clear()
+                componentId = null
+                currentStyle = null
+                currentStream = null
+                if (!isPrompting) {
+                    getMainStream().appendPartial(
+                        StyledString(event.text, listOfNotNull(outputStyle)),
+                        isPrompt = true,
+                    )
+                    isPrompting = true
+                }
+                notifyListeners(ClientPromptEvent)
+            }
+
+            is WraythTimeEvent -> {
+                val newTime = Instant.fromEpochSeconds(event.time)
+                val now = Clock.System.now()
+                val adjustedTime = now + delta
+                if (event.time > adjustedTime.epochSeconds) {
+                    // We're in the previous second
+                    delta = newTime - now
+                } else if (event.time < adjustedTime.epochSeconds) {
+                    // We're in the next second
+                    delta = newTime + 1.seconds - now
+                }
+            }
+
+            is WraythRoundTimeEvent -> {
+                event.time.toLongOrNull()?.let {
+                    _roundTimeEnd.value = it
+                }
+            }
+
+            is WraythCastTimeEvent -> {
+                event.time.toLongOrNull()?.let {
+                    _castTimeEnd.value = it
+                }
+            }
+
+            is WraythIndicatorEvent -> {
+                if (event.visible) {
+                    _indicators.update { it + event.iconId }
+                } else {
+                    _indicators.update { it - event.iconId }
+                }
+            }
+
+            is WraythSettingsInfoEvent -> {
+                gameCode = event.instance
+
+                // We don't actually handle server settings
+
+                // Not 100% where this belongs. connections hang until and empty command is sent
+                // This must be in response to either mode, playerId, or settingsInfo, so
+                // we put it here until someone discovers something else
+                sendCommandDirect("")
+                sendCommandDirect("_STATE CHATMODE OFF")
+            }
+
+            is WraythDialogDataEvent -> {
+                if (event.id == null) {
+                    dialogDataId?.let { windowRegistry.getOrCreateDialog(it).updateState() }
+                }
+                dialogDataId = event.id
+                if (event.clear && event.id != null) {
+                    this@WraythClient.windowRegistry.getOrCreateDialog(event.id).clear()
+                }
+            }
+
+            is WraythDialogObjectEvent -> {
+                // TODO: record this data somewhere
+                // val data = event.data
+                // if (data is DialogObject.ProgressBar) {
+                //    _properties.value = _properties.value +
+                // (data.id to data.value.value.toString()) +
+                //            ((data.id + "text") to (data.text ?: ""))
+                // }
+                dialogDataId?.let {
+                    windowRegistry.getOrCreateDialog(it).setObject(event.data)
+                }
+            }
+
+            is WraythCompassEndEvent -> {
+                notifyListeners(ClientCompassEvent(directions.toPersistentHashSet()))
+                directions.clear()
+            }
+
+            is WraythDirectionEvent -> {
+                directions += event.direction
+            }
+
+            is WraythLeftEvent -> {
+                _leftHand.value = event.value
+            }
+
+            is WraythRightEvent -> {
+                _rightHand.value = event.value
+            }
+
+            is WraythSpellEvent -> {
+                _spellHand.value = event.value
+            }
+
+            is WraythComponentDefinitionEvent -> {
+                // Should not happen on main stream, so don't clear prompt
+                // TODO: Should currentStyle be used here? is it per stream?
+                bufferText(
+                    text =
+                        StyledString(
+                            persistentListOf(
+                                StyledStringVariable(
+                                    name = event.id,
+                                    styles = styleStack.toPersistentList(),
+                                ),
+                            ),
+                        ),
+                )
+                componentId = event.id
+                elementBuffer = StyledString()
+            }
+
+            is WraythComponentStartEvent -> {
+                componentId = event.id
+                elementBuffer = StyledString()
+            }
+
+            WraythComponentEndEvent -> {
+                if (componentId != null) {
+                    // Either replace the component in the map with the new value
+                    //  or remove the component from the map (if we got an empty one)
+                    componentsMutex.withLock {
+                        components =
+                            if (elementBuffer?.substrings.isNullOrEmpty()) {
+                                components.remove(componentId!!)
+                            } else {
+                                components.put(componentId!!, elementBuffer!!)
+                            }
+                    }
+                    val newValue = elementBuffer ?: StyledString()
+                    windowRegistry.getStreams().forEach { stream ->
+                        stream.updateComponent(componentId!!, newValue)
+                    }
+                    elementBuffer = null
+                    componentId = null
+                } else {
+                    // mismatched component tags?
+                }
+            }
+
+            WraythNavEvent -> {
+                notifyListeners(ClientNavEvent)
+            }
+
+            is WraythBackgroundEvent -> {
+                handleBackground(event)
+            }
+
+            is WraythStreamWindowEvent -> {
+                val window = event.window
+                if (windows[event.window.name] == null && window.name != "main") {
+                    sendCommandDirect("_swclose s${event.window.name}")
+                }
+                addWindow(window)
+            }
+
+            is WraythDialogWindowEvent -> {
+                val window = event.window
+                if (window.resident) {
+                    lateinit var info: WindowInfo
+                    _windowInfo.update { windowInfo ->
+                        val existing = windowInfo.firstOrNull { it.name == window.id }
+                        info =
+                            WindowInfo(
+                                name = window.id,
+                                title = window.title,
+                                subtitle = null,
+                                windowType = WindowType.DIALOG,
+                                showTimestamps = false,
+                                backgroundImage = existing?.backgroundImage,
+                            )
+                        windowInfo.replaceOrAdd(info) { it.name == info.name }
+                    }
+                    notifyListeners(ClientWindowInfoEvent(info))
+                }
+            }
+
+            is WraythActionEvent -> {
+                bufferText(
+                    StyledString(
+                        text = event.text,
+                        style = WarlockStyle.Link(WarlockAction.SendCommand(event.command)),
+                    ),
+                )
+            }
+
+            is WraythOpenUrlEvent -> {
+                try {
+                    val url = resolve(baseUri, Uri.parse(event.url))
+                    notifyListeners(ClientOpenUrlEvent(url))
+                } catch (_: Exception) {
+                    // Silently ignore exceptions
+                }
+            }
+
+            is WraythUpdateVerbsEvent -> {
+                sendCommandDirect("_menu update 1")
+            }
+
+            is WraythStartCmdList -> {
+                // ignore for now
+            }
+
+            is WraythEndCmdList -> {
+                cliCoords =
+                    cliCoords.mutate { map ->
+                        cliCache.forEach { cli ->
+                            map[cli.coord] = cli
+                        }
+                    }
+                cliCache.clear()
+            }
+
+            is WraythCliEvent -> {
+                cliCache.add(event.cmd)
+            }
+
+            is WraythPushCmdEvent -> {
+                handlePushCmd(event)
+            }
+
+            is WraythMenuStartEvent -> {
+                event.id?.let {
+                    currentMenuId = it
+                }
+            }
+
+            is WraythMenuItemEvent -> {
+                handleMenuItem(event)
+            }
+
+            is WraythMenuEndEvent -> {
+                _menuData.update { menu ->
+                    if (menu.id != currentMenuId) {
+                        menu
+                    } else {
+                        menu.copy(items = cachedMenuItems.toPersistentList())
+                    }
+                }
+                cachedMenuItems.clear()
+            }
+
+            is WraythUnhandledTagEvent -> {
+                // debug("Unhandled tag: ${event.tag}")
+            }
+
+            is WraythParseErrorEvent -> {
+                getMainStream().appendLine(
+                    StyledString(
+                        "parse error: ${event.text}",
+                        WarlockStyle.Error,
+                    ),
+                )
+            }
+
+            is WraythResourceEvent -> {
+                flushBuffer(true)
+                gameCode?.filter { it.isLetter() }?.lowercase()?.let { code ->
+                    val url = "https://www.play.net/bfe/$code-art/${event.picture}.jpg"
+                    logger.d { "Got resource: $url" }
+                    (currentStream ?: getMainStream()).appendResource(url)
+                    if (currentStream.isMainStream) {
+                        isPrompting = false
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun handleBackground(event: WraythBackgroundEvent) {
+        var updatedWindow: WindowInfo? = null
+        _windowInfo.update { currentWindowInfo ->
+            val index = currentWindowInfo.indexOfFirst { it.name == event.windowName }
+            if (index != -1) {
+                val window = currentWindowInfo[index]
+                val backgroundImage =
+                    if (event.image != null) {
+                        ClientBackgroundImage(
+                            image = resolveBackgroundImage(event.image),
+                            mode = event.mode,
+                            gradientStart = event.gradientStart,
+                            gradientEnd = event.gradientEnd,
+                            opacity = event.opacity,
+                            horizontalAlignment = event.horizontalAlignment,
+                            verticalAlignment = event.verticalAlignment,
+                        )
+                    } else {
+                        null
+                    }
+                updatedWindow =
+                    window.copy(
+                        backgroundImage = backgroundImage,
+                    )
+                val updatedInfo = currentWindowInfo.toMutableList()
+                updatedInfo[index] = updatedWindow
+                updatedInfo
+            } else {
+                currentWindowInfo
+            }
+        }
+        updatedWindow?.let { notifyListeners(ClientWindowInfoEvent(it)) }
+    }
+
+    private fun handlePushCmd(event: WraythPushCmdEvent) {
+        val cmd = event.cmd
+        if (cmd.coord != null) {
+            val action =
+                WarlockAction.SendCommandWithLookup {
+                    val cmdDef = cliCoords[cmd.coord]
+                    if (cmdDef != null) {
+                        replaceTemplateSymbols(
+                            text = cmdDef.command,
+                            cmdNoun = cmd.noun,
+                            cmdId = cmd.exist,
+                            eventNoun = null,
+                        )
+                    } else {
+                        print(
+                            StyledString(
+                                "Could not find cli for coord: ${cmd.coord}",
+                                WarlockStyle.Error,
+                            ),
+                        )
+                        ""
+                    }
+                }
+            styleStack.addLast(
+                WarlockStyle.Link(action),
+            )
+        } else if (cmd.exist != null) {
+            styleStack.addLast(
+                WarlockStyle.Link(
+                    WarlockAction.OpenMenu {
+                        val menuId = menuCount++
+                        _menuData.value = WarlockMenuData(menuId, emptyList())
+                        currentCmd = cmd
+                        scope.launch {
+                            sendCommandDirect("_menu #${cmd.exist} $menuId")
+                        }
+                        menuId
+                    },
+                ),
+            )
+        } else {
+            styleStack.addLast(WarlockStyle(""))
+        }
+    }
+
+    private fun handleMenuItem(event: WraythMenuItemEvent) {
+        cliCoords[event.coord]?.let { command ->
+            val cmd = currentCmd
+            if (cmd != null) {
+                cachedMenuItems.add(
+                    WarlockMenuItem(
+                        label =
+                            replaceTemplateSymbols(
+                                text = command.menu,
+                                cmdNoun = cmd.noun,
+                                cmdId = cmd.exist,
+                                eventNoun = event.noun,
+                            ),
+                        category = command.category,
+                        action = {
+                            sendCommand(
+                                replaceTemplateSymbols(
+                                    text = command.command,
+                                    cmdNoun = cmd.noun,
+                                    cmdId = cmd.exist,
+                                    eventNoun = event.noun,
+                                ),
+                            )
+                        },
+                    ),
+                )
             }
         }
     }


### PR DESCRIPTION
Behavior-preserving decompositions of the three largest / most deeply-nested functions in the codebase. No logic changes — pure extraction. Found via a readability scan; this is the "three monoliths" follow-up to #160.

## Changes

**1. `WslCommands.kt` — `wslCommands` map**
The ~340-line map literal (≈50 handlers crammed as inline lambdas, nested 4 levels deep) becomes a compact table. Large/complex handlers (`counter`, `shift`, `timer`, the two text-listeners, `random`, `setarray`, `mapadd`, `debuglevel`, `log`, `delay`, `pause`) move into named `private suspend fun`s referenced as `::name`; trivial one-liners stay inline. Two dead commented-out debug lines removed.

**2. `WraythClient.connect()`**
The ~445-line `when (event)` dispatch was buried ~7 levels deep inside `connect()` (`launch` → `while` → `try` → `if` → `forEach` → `when`). It's lifted verbatim into a `handleEvent()` member, so `connect()` now reads as a ~44-line lifecycle (handshake → read loop → disconnect). The three largest arms become `handlePushCmd` / `handleBackground` / `handleMenuItem`.

**3. `Main.kt` — `WarlockCommand.run()`**
The ~480-line monolith (arg validation + logging + DB setup + DI + connection + updater + the whole Compose tree) now reads as an orchestration sequence. Extracted: `validateLoginOptions`, `configureLogging`, `parseCredentials`, `buildAppContainer`, `createInitialGameState`, `buildUpdater`, `installUncaughtExceptionWorkaround`, and a top-level `@Composable UpdateDialog` lifted out of the `application {}` tree.

The large diff churn is from moving code, not changing it.

## Verification
- ✅ `:scripting:jvmTest` passes (`WslCommandsTest` exercises the command table).
- ✅ `:scripting`, `:wrayth`, `:desktopApp` compile for **JVM + Android**.
- ✅ ktlint clean on all touched source sets.
- ⚠️ iOS not built locally (needs a macOS host); these files are desktop/common/scripting only and don't touch iOS-specific code.

## Notes
- Independent of #160 and based on `master`. The only shared file with #160 is `Main.kt`, but this PR deliberately leaves the skin-loading block untouched (that's #160's), so conflicts should be minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)