### PR TITLE
Fix regex group-count preview in mobile HighlightsView

### DIFF
--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/HighlightsView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/HighlightsView.kt
@@ -308,7 +308,7 @@ fun EditHighlightDialog(
                 val groupCount =
                     if (isRegex) {
                         try {
-                            Regex("$pattern|").find("")?.groups?.size ?: 1
+                            Regex("${pattern.text}|").find("")?.groups?.size ?: 1
                         } catch (e: Exception) {
                             error = e.message ?: "Invalid regex"
                             1


### PR DESCRIPTION
## Bug
In the mobile highlight editor, `pattern` is the Pattern `TextField`'s `TextFieldState`, but the capture-group preview did:

```kotlin
Regex("$pattern|").find("")?.groups?.size ?: 1
```

`"$pattern"` interpolates the `TextFieldState` object's `toString()`, not the typed text. For a **regex** highlight, that group count drives how many per-group style rows are shown (and the adjacent validity check), so both were computed against the wrong string instead of the user's actual pattern.

## Fix
Use `${pattern.text}`, matching the desktop version (`DesktopHighlightsView`):

```kotlin
Regex("${pattern.text}|").find("")?.groups?.size ?: 1
```

One-line change. ✅ `:compose:compileAndroidMain` compiles; ktlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)