### PR TITLE
Per-module cleanups and dead-code removal

### DIFF
--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/AlterationsView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/AlterationsView.kt
@@ -153,7 +153,6 @@ fun EditAlterationDialog(
     val pattern = rememberTextFieldState(alteration.pattern)
     val sourceStream = rememberTextFieldState(alteration.sourceStream ?: "")
     val replacement = rememberTextFieldState(alteration.result ?: "")
-    var keepOriginal by remember { mutableStateOf(alteration.keepOriginal) }
     var ignoreCase by remember { mutableStateOf(alteration.ignoreCase) }
     var patternError by remember { mutableStateOf<String?>(null) }
 
@@ -172,7 +171,7 @@ fun EditAlterationDialog(
                             destinationStream = null,
                             result = replacement.text.toString().ifBlank { null },
                             ignoreCase = ignoreCase,
-                            keepOriginal = keepOriginal,
+                            keepOriginal = alteration.keepOriginal,
                         ),
                     )
                 },
@@ -222,16 +221,6 @@ fun EditAlterationDialog(
                     label = { Text("Apply alteration to stream (leave blank for any)") },
                     lineLimits = TextFieldLineLimits.SingleLine,
                 )
-//                TextField(
-//                    value = destinationStream,
-//                    label = { Text("Destination stream (leave blank to leave text on the source stream)") },
-//                    onValueChange = {
-//                        destinationStream = it
-//                        if (it.isBlank()) {
-//                            keepOriginal = false
-//                        }
-//                    }
-//                )
                 Row {
                     Checkbox(checked = ignoreCase, onCheckedChange = { ignoreCase = it })
                     Text(
@@ -239,15 +228,6 @@ fun EditAlterationDialog(
                         modifier = Modifier.align(Alignment.CenterVertically),
                     )
                 }
-//                if (destinationStream.isNotBlank()) {
-//                    Row {
-//                        Checkbox(checked = keepOriginal, onCheckedChange = { keepOriginal = it })
-//                        Text(
-//                            text = "Keep original text",
-//                            modifier = Modifier.align(Alignment.CenterVertically)
-//                        )
-//                    }
-//                }
             }
         },
     )

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/NamesView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/NamesView.kt
@@ -225,11 +225,6 @@ fun EditNameDialog(
                             Text("First letter of name is lowercase")
                         }
                     },
-//                    leadingIcon = {
-//                        if (hasLowercase) {
-//
-//                        }
-//                    }
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     ColorTextField(

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/MudMobileApi.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/MudMobileApi.kt
@@ -2,6 +2,7 @@ package warlockfe.warlock3.core.mudmobile
 
 import co.touchlab.kermit.Logger
 import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -30,10 +31,10 @@ class MudMobileApi(
     private val json = Json { ignoreUnknownKeys = true }
 
     suspend fun getCharacters(token: String): CharactersResult =
-        runCatching {
+        request("getCharacters", networkError = { CharactersResult.Error(it) }) {
             val response =
                 httpClient.get("$baseUrl/api/characters") {
-                    header(HttpHeaders.Authorization, "Bearer $token")
+                    bearer(token)
                 }
             when (response.status.value) {
                 in 200..299 -> {
@@ -49,9 +50,6 @@ class MudMobileApi(
                     CharactersResult.Error(errorMessage(response))
                 }
             }
-        }.getOrElse { e ->
-            logger.e(e) { "getCharacters failed" }
-            CharactersResult.Error(e.message ?: "Network error")
         }
 
     /**
@@ -66,21 +64,21 @@ class MudMobileApi(
         characterCode: String,
         characterName: String,
     ): CreateCharacterResult =
-        runCatching {
-            val requestBody =
-                json.encodeToString(
-                    CreateCharacterRequest(
-                        account = account,
-                        game = game,
-                        characterCode = characterCode,
-                        characterName = characterName,
-                    ),
-                )
+        request("createCharacter", networkError = { CreateCharacterResult.Error(it) }) {
             val response =
                 httpClient.post("$baseUrl/api/characters") {
-                    header(HttpHeaders.Authorization, "Bearer $token")
+                    bearer(token)
                     contentType(ContentType.Application.Json)
-                    setBody(requestBody)
+                    setBody(
+                        json.encodeToString(
+                            CreateCharacterRequest(
+                                account = account,
+                                game = game,
+                                characterCode = characterCode,
+                                characterName = characterName,
+                            ),
+                        ),
+                    )
                 }
             when (response.status.value) {
                 in 200..299 -> {
@@ -96,9 +94,6 @@ class MudMobileApi(
                     CreateCharacterResult.Error(errorMessage(response))
                 }
             }
-        }.getOrElse { e ->
-            logger.e(e) { "createCharacter failed" }
-            CreateCharacterResult.Error(e.message ?: "Network error")
         }
 
     /** Remove a saved character. Returns true on a 2xx (or 404, already gone). */
@@ -106,15 +101,10 @@ class MudMobileApi(
         token: String,
         id: String,
     ): Boolean =
-        runCatching {
-            val response =
-                httpClient.delete("$baseUrl/api/characters/$id") {
-                    header(HttpHeaders.Authorization, "Bearer $token")
-                }
-            response.status.value in 200..299 || response.status.value == 404
-        }.getOrElse { e ->
-            logger.d(e) { "deleteCharacter failed" }
-            false
+        request("deleteCharacter", logAtError = false, networkError = { false }) {
+            httpClient
+                .delete("$baseUrl/api/characters/$id") { bearer(token) }
+                .isSuccessOrGone()
         }
 
     suspend fun createSession(
@@ -125,22 +115,22 @@ class MudMobileApi(
         gameport: Int,
         keyHash: String,
     ): CreateSessionResult =
-        runCatching {
-            val requestBody =
-                json.encodeToString(
-                    CreateSessionRequest(
-                        game = game,
-                        character = character,
-                        gamehost = gamehost,
-                        gameport = gameport,
-                        keyHash = keyHash,
-                    ),
-                )
+        request("createSession", networkError = { CreateSessionResult.Error(it) }) {
             val response =
                 httpClient.post("$baseUrl/api/sessions") {
-                    header(HttpHeaders.Authorization, "Bearer $token")
+                    bearer(token)
                     contentType(ContentType.Application.Json)
-                    setBody(requestBody)
+                    setBody(
+                        json.encodeToString(
+                            CreateSessionRequest(
+                                game = game,
+                                character = character,
+                                gamehost = gamehost,
+                                gameport = gameport,
+                                keyHash = keyHash,
+                            ),
+                        ),
+                    )
                 }
             when (response.status.value) {
                 in 200..299 -> {
@@ -165,9 +155,6 @@ class MudMobileApi(
                     CreateSessionResult.Error(errorMessage(response))
                 }
             }
-        }.getOrElse { e ->
-            logger.e(e) { "createSession failed" }
-            CreateSessionResult.Error(e.message ?: "Network error")
         }
 
     /** Poll a session's status (informational; used to wait for readiness). */
@@ -175,10 +162,10 @@ class MudMobileApi(
         token: String,
         sessionId: String,
     ): SessionStatusResult =
-        runCatching {
+        request("getSession", logAtError = false, networkError = { SessionStatusResult.Error(it) }) {
             val response =
                 httpClient.get("$baseUrl/api/sessions/$sessionId") {
-                    header(HttpHeaders.Authorization, "Bearer $token")
+                    bearer(token)
                 }
             when (response.status.value) {
                 in 200..299 -> {
@@ -198,9 +185,6 @@ class MudMobileApi(
                     SessionStatusResult.Error(errorMessage(response))
                 }
             }
-        }.getOrElse { e ->
-            logger.d(e) { "getSession failed" }
-            SessionStatusResult.Error(e.message ?: "Network error")
         }
 
     /** Best-effort cleanup. Returns true on a 2xx. A 404 (already gone) is treated as success. */
@@ -208,25 +192,20 @@ class MudMobileApi(
         token: String,
         sessionId: String,
     ): Boolean =
-        runCatching {
-            val response =
-                httpClient.delete("$baseUrl/api/sessions/$sessionId") {
-                    header(HttpHeaders.Authorization, "Bearer $token")
-                }
-            response.status.value in 200..299 || response.status.value == 404
-        }.getOrElse { e ->
-            logger.d(e) { "deleteSession failed" }
-            false
+        request("deleteSession", logAtError = false, networkError = { false }) {
+            httpClient
+                .delete("$baseUrl/api/sessions/$sessionId") { bearer(token) }
+                .isSuccessOrGone()
         }
 
     // --- Warlock settings sync (`/api/warlock/files`) -------------------------------------------
 
     /** List the user's stored settings files (path + content hash + modified time). */
     override suspend fun listWarlockFiles(token: String): ListWarlockFilesResult =
-        runCatching {
+        request("listWarlockFiles", networkError = { ListWarlockFilesResult.Error(it) }) {
             val response =
                 httpClient.get("$baseUrl/api/warlock/files") {
-                    header(HttpHeaders.Authorization, "Bearer $token")
+                    bearer(token)
                 }
             when (response.status.value) {
                 in 200..299 -> {
@@ -242,9 +221,6 @@ class MudMobileApi(
                     ListWarlockFilesResult.Error(errorMessage(response))
                 }
             }
-        }.getOrElse { e ->
-            logger.e(e) { "listWarlockFiles failed" }
-            ListWarlockFilesResult.Error(e.message ?: "Network error")
         }
 
     /** Read one settings file's content + hash. */
@@ -252,10 +228,10 @@ class MudMobileApi(
         token: String,
         path: String,
     ): ReadWarlockFileResult =
-        runCatching {
+        request("readWarlockFile", networkError = { ReadWarlockFileResult.Error(it) }) {
             val response =
                 httpClient.get("$baseUrl/api/warlock/files/file") {
-                    header(HttpHeaders.Authorization, "Bearer $token")
+                    bearer(token)
                     parameter("path", path)
                 }
             when (response.status.value) {
@@ -276,9 +252,6 @@ class MudMobileApi(
                     ReadWarlockFileResult.Error(errorMessage(response))
                 }
             }
-        }.getOrElse { e ->
-            logger.e(e) { "readWarlockFile failed" }
-            ReadWarlockFileResult.Error(e.message ?: "Network error")
         }
 
     /**
@@ -293,21 +266,21 @@ class MudMobileApi(
         baseHash: String?,
         overwrite: Boolean,
     ): WriteWarlockFileResult =
-        runCatching {
-            val requestBody =
-                json.encodeToString(
-                    WriteWarlockFileRequest(
-                        path = path,
-                        content = content,
-                        baseHash = baseHash,
-                        overwrite = overwrite,
-                    ),
-                )
+        request("writeWarlockFile", networkError = { WriteWarlockFileResult.Error(it) }) {
             val response =
                 httpClient.post("$baseUrl/api/warlock/files") {
-                    header(HttpHeaders.Authorization, "Bearer $token")
+                    bearer(token)
                     contentType(ContentType.Application.Json)
-                    setBody(requestBody)
+                    setBody(
+                        json.encodeToString(
+                            WriteWarlockFileRequest(
+                                path = path,
+                                content = content,
+                                baseHash = baseHash,
+                                overwrite = overwrite,
+                            ),
+                        ),
+                    )
                 }
             when (response.status.value) {
                 in 200..299 -> {
@@ -334,9 +307,6 @@ class MudMobileApi(
                     WriteWarlockFileResult.Error(errorMessage(response))
                 }
             }
-        }.getOrElse { e ->
-            logger.e(e) { "writeWarlockFile failed" }
-            WriteWarlockFileResult.Error(e.message ?: "Network error")
         }
 
     /** Delete one settings file. Returns true on a 2xx (or 404, already gone). */
@@ -344,17 +314,39 @@ class MudMobileApi(
         token: String,
         path: String,
     ): Boolean =
-        runCatching {
-            val response =
-                httpClient.delete("$baseUrl/api/warlock/files/file") {
-                    header(HttpHeaders.Authorization, "Bearer $token")
+        request("deleteWarlockFile", logAtError = false, networkError = { false }) {
+            httpClient
+                .delete("$baseUrl/api/warlock/files/file") {
+                    bearer(token)
                     parameter("path", path)
-                }
-            response.status.value in 200..299 || response.status.value == 404
-        }.getOrElse { e ->
-            logger.d(e) { "deleteWarlockFile failed" }
-            false
+                }.isSuccessOrGone()
         }
+
+    /**
+     * Run an API call, mapping any thrown exception to a network-error result of type [T]. Inline so
+     * the suspending [block] runs in the caller's coroutine. [logAtError] picks the log level (the
+     * informational best-effort calls log at debug).
+     */
+    private inline fun <T> request(
+        logLabel: String,
+        logAtError: Boolean = true,
+        networkError: (message: String) -> T,
+        block: () -> T,
+    ): T =
+        runCatching { block() }.getOrElse { e ->
+            if (logAtError) {
+                logger.e(e) { "$logLabel failed" }
+            } else {
+                logger.d(e) { "$logLabel failed" }
+            }
+            networkError(e.message ?: "Network error")
+        }
+
+    private fun HttpRequestBuilder.bearer(token: String) {
+        header(HttpHeaders.Authorization, "Bearer $token")
+    }
+
+    private fun HttpResponse.isSuccessOrGone(): Boolean = status.value in 200..299 || status.value == 404
 
     private suspend fun parseError(response: HttpResponse): MudMobileErrorBody? =
         runCatching { json.decodeFromString<MudMobileErrorBody>(response.bodyAsText()) }.getOrNull()

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
@@ -493,41 +493,23 @@ internal val CONFIG_ELEMENT_KEY: (TomlElement) -> Any? = { element ->
 
 private fun CharacterConfig.withGeneratedIds(): Pair<CharacterConfig, Boolean> {
     var changed = false
-    val highlights =
-        highlights.map { highlight ->
-            if (highlight.id.isNullOrBlank()) {
+
+    fun <T> List<T>.fillMissingIds(
+        getId: (T) -> String?,
+        withId: (T, String) -> T,
+    ): List<T> =
+        map { item ->
+            if (getId(item).isNullOrBlank()) {
                 changed = true
-                highlight.copy(id = Uuid.random().toString())
+                withId(item, Uuid.random().toString())
             } else {
-                highlight
+                item
             }
         }
-    val names =
-        names.map { name ->
-            if (name.id.isNullOrBlank()) {
-                changed = true
-                name.copy(id = Uuid.random().toString())
-            } else {
-                name
-            }
-        }
-    val aliases =
-        aliases.map { alias ->
-            if (alias.id.isNullOrBlank()) {
-                changed = true
-                alias.copy(id = Uuid.random().toString())
-            } else {
-                alias
-            }
-        }
-    val alterations =
-        alterations.map { alteration ->
-            if (alteration.id.isNullOrBlank()) {
-                changed = true
-                alteration.copy(id = Uuid.random().toString())
-            } else {
-                alteration
-            }
-        }
-    return copy(highlights = highlights, names = names, aliases = aliases, alterations = alterations) to changed
+    return copy(
+        highlights = highlights.fillMissingIds({ it.id }, { item, id -> item.copy(id = id) }),
+        names = names.fillMissingIds({ it.id }, { item, id -> item.copy(id = id) }),
+        aliases = aliases.fillMissingIds({ it.id }, { item, id -> item.copy(id = id) }),
+        alterations = alterations.fillMissingIds({ it.id }, { item, id -> item.copy(id = id) }),
+    ) to changed
 }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ConnectionRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ConnectionRepository.kt
@@ -32,17 +32,6 @@ class ConnectionRepository(
         }
     }
 
-    suspend fun rename(
-        oldName: String,
-        newName: String,
-    ) {
-        store.mutateConnections { registry ->
-            registry.copy(
-                connections = registry.connections.map { if (it.name == oldName) it.copy(name = newName) else it },
-            )
-        }
-    }
-
     suspend fun renameById(
         id: String,
         newName: String,

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/util/MapHelpers.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/util/MapHelpers.kt
@@ -11,11 +11,4 @@ fun <T : Any> Map<String, T>.toCaseInsensitiveMap(): CaseInsensitiveMap<T> =
         putAll(this@toCaseInsensitiveMap)
     }
 
-fun <T> Map<String, T>.getIgnoringCase(key: String): T? {
-    entries.forEach { entry ->
-        if (entry.key.equals(key, true)) {
-            return entry.value
-        }
-    }
-    return null
-}
+fun <T> Map<String, T>.getIgnoringCase(key: String): T? = entries.firstOrNull { it.key.equals(key, ignoreCase = true) }?.value

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
@@ -44,6 +44,23 @@ fun DecoratedWindowScope.WarlockApp(
     val characters by appContainer.characterRepository.observeAllCharacters().collectAsState(emptyList())
     val transfer = appContainer.settingsTransferUseCase
     val scope = rememberCoroutineScope()
+
+    // Run a settings export/import in the background, reporting its result message (the block returns
+    // the success/info message; any exception becomes "$errorPrefix: <message>").
+    fun runTransfer(
+        errorPrefix: String,
+        block: suspend () -> String,
+    ) {
+        scope.launch {
+            transferMessage =
+                try {
+                    block()
+                } catch (e: Exception) {
+                    "$errorPrefix: ${e.message}"
+                }
+        }
+    }
+
     var showAboutDialog by remember { mutableStateOf(false) }
     var sideBarVisible by remember { mutableStateOf(false) }
     val wraythFileLauncher =
@@ -80,30 +97,16 @@ fun DecoratedWindowScope.WarlockApp(
         showUpdateDialog = showUpdateDialog,
         showAboutDialog = { showAboutDialog = !showAboutDialog },
         exportSettings = { file ->
-            scope.launch {
-                transferMessage =
-                    try {
-                        file.writeText(transfer.exportAll())
-                        "Settings exported successfully"
-                    } catch (e: Exception) {
-                        "Failed to export settings: ${e.message}"
-                    }
+            runTransfer("Failed to export settings") {
+                file.writeText(transfer.exportAll())
+                "Settings exported successfully"
             }
         },
         exportCharacterSettings = { file ->
-            scope.launch {
-                val character = currentCharacter
-                transferMessage =
-                    if (character == null) {
-                        "No character selected to export"
-                    } else {
-                        try {
-                            file.writeText(transfer.exportCharacter(character.id))
-                            "Character exported successfully"
-                        } catch (e: Exception) {
-                            "Failed to export character: ${e.message}"
-                        }
-                    }
+            runTransfer("Failed to export character") {
+                val character = currentCharacter ?: return@runTransfer "No character selected to export"
+                file.writeText(transfer.exportCharacter(character.id))
+                "Character exported successfully"
             }
         },
         importSettings = { file ->
@@ -145,14 +148,9 @@ fun DecoratedWindowScope.WarlockApp(
                 onCancel = { pendingImport = null },
                 onImport = { targetCharacterId, mode ->
                     pendingImport = null
-                    scope.launch {
-                        transferMessage =
-                            try {
-                                transfer.importCharacter(import.character, targetCharacterId, mode)
-                                "Character imported successfully"
-                            } catch (e: Exception) {
-                                "Failed to import character: ${e.message}"
-                            }
+                    runTransfer("Failed to import character") {
+                        transfer.importCharacter(import.character, targetCharacterId, mode)
+                        "Character imported successfully"
                     }
                 },
             )
@@ -165,14 +163,9 @@ fun DecoratedWindowScope.WarlockApp(
                 onCancel = { pendingImport = null },
                 onImport = { resolutions ->
                     pendingImport = null
-                    scope.launch {
-                        transferMessage =
-                            try {
-                                transfer.importFull(import.export, resolutions)
-                                "Settings imported successfully"
-                            } catch (e: Exception) {
-                                "Failed to import settings: ${e.message}"
-                            }
+                    runTransfer("Failed to import settings") {
+                        transfer.importFull(import.export, resolutions)
+                        "Settings imported successfully"
                     }
                 },
             )

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslContext.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslContext.kt
@@ -275,20 +275,14 @@ class WslContext(
     }
 
     suspend fun goto(label: String) {
-        var index =
-            lines.indexOfFirst { line ->
-                line.labels.any { it.equals(other = label, ignoreCase = true) }
-            }
-        if (index == -1) {
-            index =
-                lines.indexOfFirst { line ->
-                    line.labels.any { it.equals(other = "labelError", ignoreCase = true) }
-                }
+        var index = findLabel(label)
+        if (index != -1) {
+            log(ScriptLoggingLevel.DEBUG, "goto \"$label\" line $index")
+        } else {
+            index = findLabel("labelError")
             if (index != -1) {
                 log(ScriptLoggingLevel.DEBUG, "goto \"labelError\" line $index")
             }
-        } else {
-            log(ScriptLoggingLevel.DEBUG, "goto \"$label\" line $index")
         }
         if (index == -1) {
             throw WslRuntimeException("Could not find label \"$label\".")
@@ -296,14 +290,16 @@ class WslContext(
         currentFrame.goto(index)
     }
 
+    private fun findLabel(label: String): Int =
+        lines.indexOfFirst { line ->
+            line.labels.any { it.equals(other = label, ignoreCase = true) }
+        }
+
     fun gosub(
         label: String,
         args: String,
     ) {
-        val lineIndex =
-            lines.indexOfFirst { line ->
-                line.labels.any { it.equals(other = label, ignoreCase = true) }
-            }
+        val lineIndex = findLabel(label)
         if (lineIndex == -1) {
             throw WslRuntimeException("Could not find label \"$label\".")
         }

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslScript.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslScript.kt
@@ -53,9 +53,9 @@ class WslScript(
     private fun parseIfExpression(ifExpression: WslParser.IfExpressionContext): WslStatement.ConditionalStatement =
         WslStatement.ConditionalStatement(
             parseExpression(ifExpression.expression()),
-            parseCommand(ifExpression.command(0) ?: throw WslParseException("Invalid if expression")),
+            parseCommand(ifExpression.command(0).orParseError("Invalid if expression")),
             ifExpression.ELSE()?.let {
-                parseCommand(ifExpression.command(1) ?: throw WslParseException("Else expression missing command"))
+                parseCommand(ifExpression.command(1).orParseError("Else expression missing command"))
             },
         )
 
@@ -87,7 +87,7 @@ class WslScript(
 
     private fun parseEquality(equality: WslParser.EqualityContext): WslEquality =
         WslEquality(
-            comparison = parseComparison(equality.comparison(0) ?: throw WslParseException("Invalid equality expression")),
+            comparison = parseComparison(equality.comparison(0).orParseError("Invalid equality expression")),
             otherComparisons =
                 equality.equalityOperator().mapIndexed { index, context ->
                     val operator =
@@ -98,14 +98,14 @@ class WslScript(
                         }
                     Pair(
                         operator,
-                        parseComparison(equality.comparison(index + 1) ?: throw WslParseException("Invalid equality expression")),
+                        parseComparison(equality.comparison(index + 1).orParseError("Invalid equality expression")),
                     )
                 },
         )
 
     private fun parseComparison(comparison: WslParser.ComparisonContext): WslComparison =
         WslComparison(
-            infixExpression = parseInfixExpression(comparison.infixExpression(0) ?: throw WslParseException("Invalid infix expression")),
+            infixExpression = parseInfixExpression(comparison.infixExpression(0).orParseError("Invalid infix expression")),
             otherInfixExpressions =
                 comparison.comparisonOperator().mapIndexed { index, context ->
                     val operator =
@@ -118,7 +118,7 @@ class WslScript(
                         }
                     Pair(
                         operator,
-                        parseInfixExpression(comparison.infixExpression(index + 1) ?: throw WslParseException("Invalid infix expression")),
+                        parseInfixExpression(comparison.infixExpression(index + 1).orParseError("Invalid infix expression")),
                     )
                 },
         )
@@ -127,7 +127,7 @@ class WslScript(
         WslInfixExpression(
             additiveExpression =
                 parseAdditiveExpression(
-                    infixExpression.additiveExpression(0) ?: throw WslParseException("Invalid additive expression"),
+                    infixExpression.additiveExpression(0).orParseError("Invalid additive expression"),
                 ),
             otherAdditiveExpressions =
                 infixExpression.infixOperator().mapIndexed { index, context ->
@@ -140,7 +140,7 @@ class WslScript(
                     Pair(
                         operator,
                         parseAdditiveExpression(
-                            infixExpression.additiveExpression(index + 1) ?: throw WslParseException("Invalid additive expression"),
+                            infixExpression.additiveExpression(index + 1).orParseError("Invalid additive expression"),
                         ),
                     )
                 },
@@ -150,7 +150,7 @@ class WslScript(
         WslAdditiveExpression(
             multiplicativeExpression =
                 parseMultiplicativeExpression(
-                    additiveExpression.multiplicativeExpression(0) ?: throw WslParseException("Invalid multiplicative expression"),
+                    additiveExpression.multiplicativeExpression(0).orParseError("Invalid multiplicative expression"),
                 ),
             otherMultiplicativeExpressions =
                 additiveExpression.additiveOperator().mapIndexed { index, opContext ->
@@ -163,8 +163,9 @@ class WslScript(
                     Pair(
                         operator,
                         parseMultiplicativeExpression(
-                            additiveExpression.multiplicativeExpression(index + 1)
-                                ?: throw WslParseException("Invalid multiplicative expression"),
+                            additiveExpression
+                                .multiplicativeExpression(index + 1)
+                                .orParseError("Invalid multiplicative expression"),
                         ),
                     )
                 },
@@ -176,7 +177,7 @@ class WslScript(
         WslMultiplicativeExpression(
             prefixUnaryExpression =
                 parsePrefixUnaryExpression(
-                    multiplicativeExpression.prefixUnaryExpression(0) ?: throw WslParseException("Invalid multiplicative expression"),
+                    multiplicativeExpression.prefixUnaryExpression(0).orParseError("Invalid multiplicative expression"),
                 ),
             otherUnaryExpressions =
                 multiplicativeExpression.multiplicativeOperator().mapIndexed { index, opContext ->
@@ -189,8 +190,9 @@ class WslScript(
                     Pair(
                         operator,
                         parsePrefixUnaryExpression(
-                            multiplicativeExpression.prefixUnaryExpression(index + 1)
-                                ?: throw WslParseException("Invalid multiplicative expression"),
+                            multiplicativeExpression
+                                .prefixUnaryExpression(index + 1)
+                                .orParseError("Invalid multiplicative expression"),
                         ),
                     )
                 },
@@ -265,7 +267,7 @@ class WslScript(
 
                 numberLiteral != null -> {
                     WslNumber(
-                        numberLiteral.text.toBigDecimalOrNull() ?: throw WslParseException("Could not parse number"),
+                        numberLiteral.text.toBigDecimalOrNull().orParseError("Could not parse number"),
                     )
                 }
 
@@ -709,3 +711,5 @@ private class ErrorListener : ANTLRErrorListener {
         e: RecognitionException?,
     ): Unit = throw WslParseException("Syntax error: line $line:$charPositionInLine $msg")
 }
+
+private fun <T : Any> T?.orParseError(message: String): T = this ?: throw WslParseException(message)

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/SgeClientImpl.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/SgeClientImpl.kt
@@ -187,87 +187,87 @@ class SgeClientImpl(
 
     private fun parseServerResponse(line: String): SgeResponse =
         when (line[0]) {
-            'A' -> {
-                // response from login attempt
-                logger.d { "A line ($line)" }
-                logger.d {
-                    val bytes =
-                        line
-                            .toByteArray()
-                            .map { it.toInt().toString(radix = 16).padStart(2, '0') }
-                    "as bytes: $bytes"
-                }
-                val tokens = line.split('\t')
-                when {
-                    tokens.size < 3 -> SgeResponse.SgeErrorResponse(SgeError.UNKNOWN_ERROR)
-                    tokens[2] == "PASSWORD" -> SgeResponse.SgeErrorResponse(SgeError.INVALID_PASSWORD)
-                    tokens[2] == "REJECT" -> SgeResponse.SgeErrorResponse(SgeError.ACCOUNT_REJECTED)
-                    tokens[2] == "NORECORD" -> SgeResponse.SgeErrorResponse(SgeError.INVALID_ACCOUNT)
-                    tokens[1].equals(username, true) -> SgeResponse.SgeLoginSucceededResponse
-                    else -> SgeResponse.SgeErrorResponse(SgeError.UNKNOWN_ERROR)
-                }
-            }
+            'A' -> parseLoginResponse(line)
 
-            // response for request for games
-            'M' -> {
-                val games = ArrayList<SgeGame>()
-                // tab delineated list of games, dropping the M
-                val tokens = line.split("\t").drop(1)
-                for (i in 1 until tokens.size step 2) {
-                    val gameCode = tokens[i - 1]
-                    val gameName = tokens[i]
-                    games.add(SgeGame(gameName, gameCode, null))
-                }
-                SgeResponse.SgeGameListResponse(games)
-            }
+            'M' -> parseGameList(line)
 
             // We're ignoring the details. Some might be interesting if your account is deactivated
-            'G' -> {
-                SgeResponse.SgeGameDetailsResponse
-            }
+            'G' -> SgeResponse.SgeGameDetailsResponse
 
-            'C' -> {
-                val characters = ArrayList<SgeCharacter>()
-                val tokens = line.split("\t").drop(5)
-                for (i in 1 until tokens.size step 2) {
-                    characters.add(SgeCharacter(tokens[i], tokens[i - 1]))
-                }
-                SgeResponse.SgeCharacterListResponse(characters)
-            }
+            'C' -> parseCharacterList(line)
 
-            'L' -> {
-                // status\tproperties
-                val tokens = line.split("\t")
-                when (tokens[1]) {
-                    "OK" -> {
-                        val properties = mutableMapOf<String, String>()
-                        for (element in tokens.drop(2)) {
-                            val property = element.split("=")
-                            properties[property[0]] = property[1]
-                        }
-                        SgeResponse.SgeReadyToPlayResponse(properties)
-                    }
-
-                    "PROBLEM" -> {
-                        SgeResponse.SgeErrorResponse(SgeError.ACCOUNT_EXPIRED)
-                    }
-
-                    else -> {
-                        SgeResponse.SgeErrorResponse(SgeError.UNKNOWN_ERROR)
-                    }
-                }
-            }
+            'L' -> parseReadyToPlay(line)
 
             // The server replies with a bare "?" when it cannot parse the command we sent
             // (e.g. a malformed login). Surface it as an error instead of waiting for a timeout.
-            '?' -> {
-                SgeResponse.SgeErrorResponse(SgeError.UNKNOWN_ERROR)
+            '?' -> SgeResponse.SgeErrorResponse(SgeError.UNKNOWN_ERROR)
+
+            else -> SgeResponse.SgeUnrecognizedResponse
+        }
+
+    private fun parseLoginResponse(line: String): SgeResponse {
+        logger.d { "A line ($line)" }
+        logger.d {
+            val bytes =
+                line
+                    .toByteArray()
+                    .map { it.toInt().toString(radix = 16).padStart(2, '0') }
+            "as bytes: $bytes"
+        }
+        val tokens = line.split('\t')
+        return when {
+            tokens.size < 3 -> SgeResponse.SgeErrorResponse(SgeError.UNKNOWN_ERROR)
+            tokens[2] == "PASSWORD" -> SgeResponse.SgeErrorResponse(SgeError.INVALID_PASSWORD)
+            tokens[2] == "REJECT" -> SgeResponse.SgeErrorResponse(SgeError.ACCOUNT_REJECTED)
+            tokens[2] == "NORECORD" -> SgeResponse.SgeErrorResponse(SgeError.INVALID_ACCOUNT)
+            tokens[1].equals(username, true) -> SgeResponse.SgeLoginSucceededResponse
+            else -> SgeResponse.SgeErrorResponse(SgeError.UNKNOWN_ERROR)
+        }
+    }
+
+    private fun parseGameList(line: String): SgeResponse {
+        val games = ArrayList<SgeGame>()
+        // tab delineated list of games, dropping the M
+        val tokens = line.split("\t").drop(1)
+        for (i in 1 until tokens.size step 2) {
+            val gameCode = tokens[i - 1]
+            val gameName = tokens[i]
+            games.add(SgeGame(gameName, gameCode, null))
+        }
+        return SgeResponse.SgeGameListResponse(games)
+    }
+
+    private fun parseCharacterList(line: String): SgeResponse {
+        val characters = ArrayList<SgeCharacter>()
+        val tokens = line.split("\t").drop(5)
+        for (i in 1 until tokens.size step 2) {
+            characters.add(SgeCharacter(tokens[i], tokens[i - 1]))
+        }
+        return SgeResponse.SgeCharacterListResponse(characters)
+    }
+
+    private fun parseReadyToPlay(line: String): SgeResponse {
+        // status\tproperties
+        val tokens = line.split("\t")
+        return when (tokens[1]) {
+            "OK" -> {
+                val properties = mutableMapOf<String, String>()
+                for (element in tokens.drop(2)) {
+                    val property = element.split("=")
+                    properties[property[0]] = property[1]
+                }
+                SgeResponse.SgeReadyToPlayResponse(properties)
+            }
+
+            "PROBLEM" -> {
+                SgeResponse.SgeErrorResponse(SgeError.ACCOUNT_EXPIRED)
             }
 
             else -> {
-                SgeResponse.SgeUnrecognizedResponse
+                SgeResponse.SgeErrorResponse(SgeError.UNKNOWN_ERROR)
             }
         }
+    }
 
     private suspend fun readline(): String? {
         // TODO: should we implement readline for this?


### PR DESCRIPTION
Behavior-preserving per-module cleanups from the readability scan, plus dead-code removal. No logic changes.

## Changes

**core**
- **MudMobileApi** — added an inline `request(...)` envelope (the shared `runCatching { … }.getOrElse { log; Error }` wrapper), a `bearer(token)` header extension, and `isSuccessOrGone()`; all 11 methods route through them while keeping their own status codes/result types.
- Removed dead `ConnectionRepository.rename` (no callers — only `renameById` is used).
- Simplified `MapHelpers.getIgnoringCase` to a one-liner (`firstOrNull`).
- Deduped `CharacterConfigStore.withGeneratedIds` (4 copy-paste blocks → one local generic `fillMissingIds`).

**scripting**
- `WslScript` — `orParseError` extension replacing the 13 repeated `?: throw WslParseException(...)`.
- `WslContext` — extracted shared `findLabel()` (used 3×) and flattened `goto`.

**wrayth**
- `SgeClientImpl.parseServerResponse` — split into per-code parsers (`parseLoginResponse`/`parseGameList`/`parseCharacterList`/`parseReadyToPlay`), leaving a clean dispatch `when`.

**desktopApp + dead code**
- `WarlockApp` — `runTransfer(errorPrefix) { … }` helper collapsing the 4 export/import `scope.launch { try/catch → transferMessage }` callbacks.
- Removed dead code: `AlterationsView`'s frozen `keepOriginal` + two commented-out blocks; `NamesView`'s commented-out `leadingIcon`.

Net **−304 / +228** across 10 files.

## Verification
- ✅ All modules compile (**JVM + Android**); `desktopApp` + `androidApp` compile.
- ✅ `:core:jvmTest` and `:scripting:jvmTest` pass.
- ✅ ktlint clean across all touched source sets.
- ⚠️ iOS not built locally (needs macOS); no iOS-specific code changed.

## Deliberately deferred (noted, with reasons)
- **CharacterConfigStore** 5-parallel-`when` enum refactor + **TomlFileStore** atomic-write dedup — larger, higher-risk cross-cutting changes.
- **wrayth DialogObject bounds** (6 handlers) — a real dedup needs a shared `bounds` field on `DialogObject` (model change); helper-only is marginal.
- **TitleBarView vs AppMenuBar** menu dedup — larger menu-descriptor refactor (macOS-vs-not, within desktop).
- **WslScript** full 6-method generic dedup (awkward with ANTLR's typed accessors — did the `orParseError` fallback), plus cosmetic `unescapeXml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)