### PR TITLE
Add configurable action buttons with an Actions settings page

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -43,6 +43,7 @@ import warlockfe.warlock3.core.prefs.config.CharacterConfigStore
 import warlockfe.warlock3.core.prefs.config.ClientConfigStore
 import warlockfe.warlock3.core.prefs.config.ConfigMigration
 import warlockfe.warlock3.core.prefs.repositories.AccountRepository
+import warlockfe.warlock3.core.prefs.repositories.ActionRepository
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.AlterationRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterRepository
@@ -133,6 +134,7 @@ abstract class AppContainer(
         )
     val connectionSettingsRepository = ConnectionSettingsRepository(clientConfigStore)
     val aliasRepository = AliasRepository(characterConfigStore)
+    val actionRepository = ActionRepository(characterConfigStore)
     val alterationRepository = AlterationRepository(characterConfigStore)
     val commandHistoryRepository = CommandHistoryRepository(characterConfigStore, fileSystem, ioDispatcher)
 
@@ -209,6 +211,7 @@ abstract class AppContainer(
             presetRepository = presetRepository,
             characterSettingsRepository = characterSettingsRepository,
             aliasRepository = aliasRepository,
+            actionRepository = actionRepository,
             scriptManagerFactory = scriptManagerFactory,
             windowSettingsRepository = windowSettingRepository,
             progressBarSettingRepository = progressBarSettingRepository,

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -69,6 +69,9 @@ import warlockfe.warlock3.core.macro.MacroToken
 import warlockfe.warlock3.core.macro.ScrollEvent
 import warlockfe.warlock3.core.macro.parseMacro
 import warlockfe.warlock3.core.prefs.CompassStyle
+import warlockfe.warlock3.core.prefs.models.Action
+import warlockfe.warlock3.core.prefs.models.ActionBar
+import warlockfe.warlock3.core.prefs.repositories.ActionRepository
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterSettingsRepository
 import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
@@ -110,6 +113,7 @@ class GameViewModel(
     private val scriptManager: ScriptManager,
     val characterSettingsRepository: CharacterSettingsRepository,
     aliasRepository: AliasRepository,
+    actionRepository: ActionRepository,
     private val windowRegistry: WindowRegistry,
     private val progressBarSettingRepository: ProgressBarSettingRepository,
     private val clientSettingRepository: ClientSettingRepository,
@@ -256,6 +260,17 @@ class GameViewModel(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
             initialValue = emptyList(),
+        )
+
+    // The configured action buttons for the current character (merged with global): the resolved
+    // toolbar to draw plus the full pool so a group's children can be looked up by id.
+    val actionBar: StateFlow<ActionBar> =
+        observePerCharacter { characterId ->
+            actionRepository.observeForCharacter(characterId)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Lazily,
+            initialValue = ActionBar.EMPTY,
         )
 
     val presets = windowRegistry.presets
@@ -661,6 +676,14 @@ class GameViewModel(
     fun runScript(file: Path) {
         viewModelScope.launch(ioDispatcher) {
             scriptManager.startScript(client, file, ::commandHandler)
+        }
+    }
+
+    /** Run a leaf action button's inline WSL script. No-op for a group (which has no script). */
+    fun runActionScript(action: Action) {
+        val script = action.script ?: return
+        viewModelScope.launch(ioDispatcher) {
+            scriptManager.startScript(client, action.name, script, ::commandHandler)
         }
     }
 

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModelFactory.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModelFactory.kt
@@ -2,6 +2,7 @@ package warlockfe.warlock3.compose.ui.game
 
 import kotlinx.coroutines.CoroutineDispatcher
 import warlockfe.warlock3.core.client.WarlockClient
+import warlockfe.warlock3.core.prefs.repositories.ActionRepository
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterSettingsRepository
 import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
@@ -20,6 +21,7 @@ class GameViewModelFactory(
     private val presetRepository: PresetRepository,
     private val characterSettingsRepository: CharacterSettingsRepository,
     private val aliasRepository: AliasRepository,
+    private val actionRepository: ActionRepository,
     private val scriptManagerFactory: ScriptManagerFactory,
     private val windowSettingsRepository: WindowSettingsRepository,
     private val progressBarSettingRepository: ProgressBarSettingRepository,
@@ -41,6 +43,7 @@ class GameViewModelFactory(
             presetRepository = presetRepository,
             characterSettingsRepository = characterSettingsRepository,
             aliasRepository = aliasRepository,
+            actionRepository = actionRepository,
             windowRegistry = windowRegistry,
             progressBarSettingRepository = progressBarSettingRepository,
             clientSettingRepository = clientSettingRepository,

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/settings/ActionEditing.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/settings/ActionEditing.kt
@@ -1,0 +1,48 @@
+package warlockfe.warlock3.compose.ui.settings
+
+import warlockfe.warlock3.core.prefs.models.Action
+import kotlin.uuid.Uuid
+
+// Pure helpers shared by the mobile and desktop Actions settings editors. Actions form a flat pool
+// referenced by id, so editing the toolbar or a group's children is editing a List<Uuid>.
+
+/** Move the item at [from] to [to], returning a new list. No-op when an index is out of range. */
+internal fun <T> List<T>.moveItem(
+    from: Int,
+    to: Int,
+): List<T> {
+    if (from == to || from !in indices || to !in indices) return this
+    return toMutableList().apply { add(to, removeAt(from)) }
+}
+
+/** True if [target] is reachable from [start] by following group children in [pool] (cycle check). */
+internal fun actionReaches(
+    start: Uuid,
+    target: Uuid,
+    pool: Map<Uuid, Action>,
+): Boolean {
+    val visited = mutableSetOf<Uuid>()
+
+    fun dfs(id: Uuid): Boolean {
+        if (id == target) return true
+        if (!visited.add(id)) return false
+        return pool[id]?.children?.any { dfs(it) } ?: false
+    }
+
+    return dfs(start)
+}
+
+/**
+ * The actions that may be added as a child of the group [groupId] without creating a cycle: every
+ * pool action except the group itself and any action from which the group is already reachable.
+ */
+internal fun childCandidates(
+    groupId: Uuid,
+    pool: List<Action>,
+): List<Action> {
+    val byId = pool.associateBy { it.id }
+    return pool.filter { it.id != groupId && !actionReaches(it.id, groupId, byId) }
+}
+
+/** Resolve a list of action ids against the [pool], dropping any that no longer exist. */
+internal fun List<Uuid>.resolve(pool: Map<Uuid, Action>): List<Action> = mapNotNull { pool[it] }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsPage.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsPage.kt
@@ -11,4 +11,5 @@ enum class SettingsPage(
     Names("Names"),
     Aliases("Aliases"),
     Alterations("Alterations"),
+    Actions("Actions"),
 }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/ActionButtonMenu.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/ActionButtonMenu.kt
@@ -1,0 +1,179 @@
+package warlockfe.warlock3.compose.desktop.ui.game
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.HoverInteraction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.PopupMenu
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.separator
+import org.jetbrains.jewel.ui.theme.menuStyle
+import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
+import warlockfe.warlock3.core.prefs.models.Action
+import kotlin.uuid.Uuid
+
+/**
+ * A single action button on the desktop game screen. A leaf runs its script on click; a group opens a
+ * drill-down [PopupMenu] of the actions it references (resolved against [pool]).
+ */
+@Composable
+fun DesktopActionButton(
+    action: Action,
+    pool: Map<Uuid, Action>,
+    onRunLeaf: (Action) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box(modifier) {
+        WarlockOutlinedButton(
+            onClick = {
+                if (action.isGroup) expanded = true else onRunLeaf(action)
+            },
+            text = action.name.ifBlank { "(unnamed)" },
+        )
+        if (expanded) {
+            ActionDrillDownPopup(
+                root = action,
+                pool = pool,
+                onRunLeaf = onRunLeaf,
+                onDismiss = { expanded = false },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActionDrillDownPopup(
+    root: Action,
+    pool: Map<Uuid, Action>,
+    onRunLeaf: (Action) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    // Nested popups grab focus on desktop, so we navigate within one popup: each group drills in, the
+    // back row returns a level. The path holds the groups we've drilled through.
+    var path by remember(root.id) { mutableStateOf<List<Action>>(emptyList()) }
+    PopupMenu(
+        onDismissRequest = {
+            onDismiss()
+            true
+        },
+        horizontalAlignment = Alignment.Start,
+    ) {
+        val current = path.lastOrNull() ?: root
+        // Skip any child that is an ancestor on the path, so a reference cycle can't loop forever.
+        val ancestors = path.mapTo(mutableSetOf()) { it.id }
+        val children = current.children.mapNotNull { pool[it] }.filterNot { it.id in ancestors }
+        if (path.isNotEmpty()) {
+            passiveItem {
+                ActionNavMenuItem(
+                    label = current.name.ifBlank { "(unnamed)" },
+                    leading = "\u2190",
+                    onClick = { path = path.dropLast(1) },
+                )
+            }
+            separator()
+        }
+        children.forEach { child ->
+            if (child.isGroup) {
+                passiveItem {
+                    ActionNavMenuItem(
+                        label = child.name.ifBlank { "(unnamed)" },
+                        trailing = "\u203A",
+                        onClick = { path = path + child },
+                    )
+                }
+            } else {
+                selectableItem(
+                    selected = false,
+                    onClick = {
+                        onRunLeaf(child)
+                        onDismiss()
+                    },
+                ) {
+                    Text(child.name.ifBlank { "(unnamed)" })
+                }
+            }
+        }
+    }
+}
+
+/** A menu row that navigates within the popup (drill in/out) without closing it. */
+@Composable
+private fun ActionNavMenuItem(
+    label: String,
+    onClick: () -> Unit,
+    leading: String? = null,
+    trailing: String? = null,
+) {
+    val style = JewelTheme.menuStyle
+    val itemColors = style.colors.itemColors
+    val itemMetrics = style.metrics.itemMetrics
+    val interactionSource = remember { MutableInteractionSource() }
+    val hovered by interactionSource.collectIsHoveredAsState()
+    val pressed by interactionSource.collectIsPressedAsState()
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(interactionSource) {
+        interactionSource.interactions.collect { interaction ->
+            if (interaction is HoverInteraction.Enter) {
+                focusRequester.requestFocus()
+            }
+        }
+    }
+    val background =
+        when {
+            pressed -> itemColors.backgroundPressed
+            hovered -> itemColors.backgroundHovered
+            else -> itemColors.background
+        }
+    val contentColor =
+        when {
+            pressed -> itemColors.contentPressed
+            hovered -> itemColors.contentHovered
+            else -> itemColors.content
+        }
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester)
+                .background(background, RoundedCornerShape(itemMetrics.selectionCornerSize))
+                .clickable(interactionSource = interactionSource, indication = null, onClick = onClick)
+                .defaultMinSize(minHeight = itemMetrics.minHeight)
+                .padding(itemMetrics.contentPadding),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (leading != null) {
+            Text(text = leading, color = contentColor)
+        }
+        Text(
+            modifier = Modifier.weight(1f),
+            text = label,
+            color = contentColor,
+        )
+        if (trailing != null) {
+            Text(text = trailing, color = contentColor)
+        }
+    }
+}

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameBottomBar.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameBottomBar.kt
@@ -1,6 +1,7 @@
 package warlockfe.warlock3.compose.desktop.ui.game
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -62,6 +64,21 @@ fun DesktopGameBottomBar(
                             .onSizeChanged { contentHeight = with(density) { it.height.toDp() } },
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
+                    val actionBar by viewModel.actionBar.collectAsState()
+                    if (actionBar.toolbar.isNotEmpty()) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            actionBar.toolbar.forEach { action ->
+                                DesktopActionButton(
+                                    action = action,
+                                    pool = actionBar.actions,
+                                    onRunLeaf = viewModel::runActionScript,
+                                )
+                            }
+                        }
+                    }
                     DesktopWarlockEntry(
                         viewModel = viewModel,
                         entryFocusRequester = entryFocusRequester,

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopActionsView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopActionsView.kt
@@ -1,0 +1,251 @@
+package warlockfe.warlock3.compose.desktop.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.TextArea
+import warlockfe.warlock3.compose.desktop.shim.WarlockButton
+import warlockfe.warlock3.compose.desktop.shim.WarlockDialog
+import warlockfe.warlock3.compose.desktop.shim.WarlockListItem
+import warlockfe.warlock3.compose.desktop.shim.WarlockMenuButton
+import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
+import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
+import warlockfe.warlock3.compose.desktop.shim.WarlockTextField
+import warlockfe.warlock3.compose.ui.settings.childCandidates
+import warlockfe.warlock3.compose.ui.settings.moveItem
+import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.models.Action
+import warlockfe.warlock3.core.prefs.repositories.ActionRepository
+import kotlin.uuid.Uuid
+
+/**
+ * Desktop editor for the per-character action buttons: a toolbar section (the ordered buttons drawn
+ * on the game screen) over the flat pool of all defined actions. A leaf runs a WSL script; a group
+ * references other actions by id and opens a drill-down menu.
+ */
+@Composable
+fun DesktopActionsView(
+    currentCharacter: GameCharacter?,
+    allCharacters: List<GameCharacter>,
+    actionRepository: ActionRepository,
+    modifier: Modifier = Modifier,
+) {
+    var selectedCharacter by remember(currentCharacter) { mutableStateOf(currentCharacter) }
+    val currentCharacterId = selectedCharacter?.id ?: "global"
+    val pool by actionRepository.observePool(currentCharacterId).collectAsState(emptyList())
+    val toolbar by actionRepository.observeToolbar(currentCharacterId).collectAsState(emptyList())
+    val poolById = remember(pool) { pool.associateBy { it.id } }
+    var editingAction by remember { mutableStateOf<Action?>(null) }
+    val scope = rememberCoroutineScope()
+
+    SettingsListScaffold(
+        title = "Actions",
+        selectedCharacter = selectedCharacter,
+        characters = allCharacters,
+        onSelectCharacter = { selectedCharacter = it },
+        modifier = modifier.fillMaxSize(),
+    ) {
+        WarlockScrollableColumn(modifier = Modifier.fillMaxWidth().weight(1f)) {
+            Text("Button bar")
+            ActionIdListEditor(
+                ids = toolbar,
+                pool = poolById,
+                candidates = pool.filterNot { it.id in toolbar },
+                emptyText = "No buttons yet. Add an action below to the bar.",
+                onChange = { scope.launch { actionRepository.setToolbar(currentCharacterId, it) } },
+            )
+
+            Spacer(Modifier.height(24.dp))
+            Text("All actions")
+            if (pool.isEmpty()) {
+                Text("No actions defined yet.")
+            }
+            pool.forEach { action ->
+                WarlockListItem(
+                    headline = { Text(action.label()) },
+                    trailing = {
+                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                            WarlockOutlinedButton(onClick = { editingAction = action }, text = "Edit")
+                            WarlockOutlinedButton(
+                                onClick = { scope.launch { actionRepository.deleteAction(currentCharacterId, action.id) } },
+                                text = "Delete",
+                            )
+                        }
+                    },
+                )
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.End),
+        ) {
+            WarlockOutlinedButton(
+                onClick = { editingAction = Action(id = Uuid.random(), name = "", script = null) },
+                text = "New group",
+            )
+            WarlockButton(
+                onClick = { editingAction = Action(id = Uuid.random(), name = "", script = "") },
+                text = "New action",
+            )
+        }
+    }
+
+    editingAction?.let { action ->
+        DesktopEditActionDialog(
+            action = action,
+            pool = pool,
+            onSave = { updated ->
+                scope.launch {
+                    actionRepository.saveAction(currentCharacterId, updated)
+                    editingAction = null
+                }
+            },
+            onClose = { editingAction = null },
+        )
+    }
+}
+
+private fun Action.label(): String = name.ifBlank { "(unnamed)" } + if (isGroup) "  (group)" else ""
+
+@Composable
+private fun ActionIdListEditor(
+    ids: List<Uuid>,
+    pool: Map<Uuid, Action>,
+    candidates: List<Action>,
+    emptyText: String,
+    onChange: (List<Uuid>) -> Unit,
+) {
+    if (ids.isEmpty()) {
+        Text(emptyText)
+    }
+    ids.forEachIndexed { index, id ->
+        val action = pool[id]
+        WarlockListItem(
+            headline = { Text(action?.label() ?: "(missing action)") },
+            trailing = {
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    WarlockOutlinedButton(
+                        onClick = { onChange(ids.moveItem(index, index - 1)) },
+                        text = "Up",
+                        enabled = index > 0,
+                    )
+                    WarlockOutlinedButton(
+                        onClick = { onChange(ids.moveItem(index, index + 1)) },
+                        text = "Down",
+                        enabled = index < ids.lastIndex,
+                    )
+                    WarlockOutlinedButton(
+                        onClick = { onChange(ids.filterIndexed { i, _ -> i != index }) },
+                        text = "Remove",
+                    )
+                }
+            },
+        )
+    }
+    ActionPickerButton(candidates = candidates, onPick = { onChange(ids + it) })
+}
+
+@Composable
+private fun ActionPickerButton(
+    candidates: List<Action>,
+    onPick: (Uuid) -> Unit,
+) {
+    WarlockMenuButton(
+        anchor = { toggle ->
+            WarlockOutlinedButton(onClick = toggle, text = "Add", enabled = candidates.isNotEmpty())
+        },
+        horizontalAlignment = Alignment.Start,
+    ) { dismiss ->
+        candidates.forEach { action ->
+            selectableItem(
+                selected = false,
+                onClick = {
+                    dismiss()
+                    onPick(action.id)
+                },
+            ) {
+                Text(action.label())
+            }
+        }
+    }
+}
+
+@Composable
+private fun DesktopEditActionDialog(
+    action: Action,
+    pool: List<Action>,
+    onSave: (Action) -> Unit,
+    onClose: () -> Unit,
+) {
+    val isGroup = action.isGroup
+    val name = rememberTextFieldState(action.name)
+    val script = rememberTextFieldState(action.script ?: "")
+    var childIds by remember { mutableStateOf(action.children) }
+    val poolById = remember(pool) { pool.associateBy { it.id } }
+
+    WarlockDialog(
+        title = if (isGroup) "Edit group" else "Edit action",
+        onCloseRequest = onClose,
+        width = 520.dp,
+        height = 480.dp,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Name")
+            WarlockTextField(state = name, modifier = Modifier.fillMaxWidth())
+            if (isGroup) {
+                Text("Actions in this group")
+                WarlockScrollableColumn(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                    ActionIdListEditor(
+                        ids = childIds,
+                        pool = poolById,
+                        candidates = childCandidates(action.id, pool).filterNot { it.id in childIds },
+                        emptyText = "No actions in this group yet.",
+                        onChange = { childIds = it },
+                    )
+                }
+            } else {
+                Text("Script (WSL)")
+                TextArea(state = script, modifier = Modifier.fillMaxWidth().weight(1f))
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+            ) {
+                WarlockOutlinedButton(onClick = onClose, text = "Cancel")
+                WarlockButton(
+                    onClick = {
+                        onSave(
+                            action.copy(
+                                name = name.text.toString(),
+                                script = if (isGroup) null else script.text.toString(),
+                                children = if (isGroup) childIds else emptyList(),
+                            ),
+                        )
+                    },
+                    text = "Save",
+                    enabled = name.text.isNotBlank(),
+                )
+            }
+        }
+    }
+}

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsContent.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import warlockfe.warlock3.compose.ui.settings.SettingsPage
 import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.repositories.ActionRepository
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.AlterationRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterRepository
@@ -30,6 +31,7 @@ fun DesktopSettingsContent(
     nameRepository: NameRepositoryImpl,
     presetRepository: PresetRepository,
     aliasRepository: AliasRepository,
+    actionRepository: ActionRepository,
     alterationRepository: AlterationRepository,
     clientSettingRepository: ClientSettingRepository,
 ) {
@@ -99,6 +101,14 @@ fun DesktopSettingsContent(
                 currentCharacter = currentCharacter,
                 allCharacters = characters,
                 alterationRepository = alterationRepository,
+            )
+        }
+
+        SettingsPage.Actions -> {
+            DesktopActionsView(
+                currentCharacter = currentCharacter,
+                allCharacters = characters,
+                actionRepository = actionRepository,
             )
         }
     }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsDialog.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsDialog.kt
@@ -26,6 +26,7 @@ import org.jetbrains.jewel.ui.component.Divider
 import org.jetbrains.jewel.ui.component.Text
 import warlockfe.warlock3.compose.ui.settings.SettingsPage
 import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.repositories.ActionRepository
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.AlterationRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterRepository
@@ -51,6 +52,7 @@ fun DesktopSettingsDialog(
     alterationRepository: AlterationRepository,
     characterSettingsRepository: CharacterSettingsRepository,
     aliasRepository: AliasRepository,
+    actionRepository: ActionRepository,
     scriptDirRepository: ScriptDirRepository,
     clientSettingRepository: ClientSettingRepository,
     closeDialog: () -> Unit,
@@ -103,6 +105,7 @@ fun DesktopSettingsDialog(
                         nameRepository = nameRepository,
                         presetRepository = presetRepository,
                         aliasRepository = aliasRepository,
+                        actionRepository = actionRepository,
                         alterationRepository = alterationRepository,
                         clientSettingRepository = clientSettingRepository,
                     )

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/ActionMenu.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/ActionMenu.kt
@@ -1,0 +1,106 @@
+package warlockfe.warlock3.compose.ui.game
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import org.jetbrains.compose.resources.painterResource
+import warlockfe.warlock3.compose.generated.resources.Res
+import warlockfe.warlock3.compose.generated.resources.arrow_right
+import warlockfe.warlock3.core.prefs.models.Action
+import kotlin.uuid.Uuid
+
+/**
+ * A single action chip on the mobile command bar. A leaf runs its script; a group opens a drill-down
+ * [DropdownMenu] of the actions it references (resolved against [pool]).
+ */
+@Composable
+fun ActionChip(
+    action: Action,
+    pool: Map<Uuid, Action>,
+    onRunLeaf: (Action) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (action.isGroup) {
+        var expanded by remember { mutableStateOf(false) }
+        Box(modifier) {
+            AssistChip(
+                onClick = { expanded = true },
+                label = { Text(action.name.ifBlank { "(unnamed)" }) },
+                trailingIcon = {
+                    Icon(painter = painterResource(Res.drawable.arrow_right), contentDescription = null)
+                },
+            )
+            ActionDropdown(
+                group = action,
+                pool = pool,
+                expanded = expanded,
+                ancestors = setOf(action.id),
+                onRunLeaf = onRunLeaf,
+                onDismiss = { expanded = false },
+            )
+        }
+    } else {
+        AssistChip(
+            onClick = { onRunLeaf(action) },
+            label = { Text(action.name.ifBlank { "(unnamed)" }) },
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun ActionDropdown(
+    group: Action,
+    pool: Map<Uuid, Action>,
+    expanded: Boolean,
+    ancestors: Set<Uuid>,
+    onRunLeaf: (Action) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        // Skip any child already on the path to this group so a reference cycle can't recurse forever.
+        val children = group.children.mapNotNull { pool[it] }.filterNot { it.id in ancestors }
+        children.forEach { child ->
+            if (child.isGroup) {
+                var subExpanded by remember { mutableStateOf(false) }
+                Box {
+                    DropdownMenuItem(
+                        text = { Text(child.name.ifBlank { "(unnamed)" }) },
+                        trailingIcon = {
+                            Icon(painter = painterResource(Res.drawable.arrow_right), contentDescription = null)
+                        },
+                        onClick = { subExpanded = true },
+                    )
+                    ActionDropdown(
+                        group = child,
+                        pool = pool,
+                        expanded = subExpanded,
+                        ancestors = ancestors + child.id,
+                        onRunLeaf = { leaf ->
+                            onRunLeaf(leaf)
+                            onDismiss()
+                        },
+                        onDismiss = { subExpanded = false },
+                    )
+                }
+            } else {
+                DropdownMenuItem(
+                    text = { Text(child.name.ifBlank { "(unnamed)" }) },
+                    onClick = {
+                        onRunLeaf(child)
+                        onDismiss()
+                    },
+                )
+            }
+        }
+    }
+}

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
@@ -3,6 +3,7 @@ package warlockfe.warlock3.compose.ui.game
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -16,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
@@ -392,6 +394,21 @@ fun GameBottomBar(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
+                val actionBar by viewModel.actionBar.collectAsState()
+                if (actionBar.toolbar.isNotEmpty()) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        actionBar.toolbar.forEach { action ->
+                            ActionChip(
+                                action = action,
+                                pool = actionBar.actions,
+                                onRunLeaf = viewModel::runActionScript,
+                            )
+                        }
+                    }
+                }
                 WarlockEntry(
                     viewModel = viewModel,
                     entryFocusRequester = entryFocusRequester,

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/PhoneGameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/PhoneGameView.kt
@@ -7,10 +7,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -112,10 +110,6 @@ fun PhoneGameView(
     }
 }
 
-// Hardcoded placeholder macros for the assist-chip row; a future change can back these with the
-// user's configured macros/aliases.
-private val assistCommands = listOf("look", "attack", "search", "stance")
-
 @Suppress("ktlint:compose:vm-forwarding-check")
 @Composable
 private fun PhoneCommandBar(
@@ -124,16 +118,20 @@ private fun PhoneCommandBar(
     onMovement: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val actionBar by viewModel.actionBar.collectAsState()
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        Row(
-            modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            assistCommands.forEach { command ->
-                AssistChip(
-                    onClick = { viewModel.sendCommand(command) },
-                    label = { Text(command) },
-                )
+        if (actionBar.toolbar.isNotEmpty()) {
+            Row(
+                modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                actionBar.toolbar.forEach { action ->
+                    ActionChip(
+                        action = action,
+                        pool = actionBar.actions,
+                        onRunLeaf = viewModel::runActionScript,
+                    )
+                }
             }
         }
         Row(

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/ActionsView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/ActionsView.kt
@@ -1,0 +1,294 @@
+package warlockfe.warlock3.compose.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.painterResource
+import warlockfe.warlock3.compose.components.ScrollableColumn
+import warlockfe.warlock3.compose.generated.resources.Res
+import warlockfe.warlock3.compose.generated.resources.add
+import warlockfe.warlock3.compose.generated.resources.arrow_right
+import warlockfe.warlock3.compose.generated.resources.close
+import warlockfe.warlock3.compose.generated.resources.delete
+import warlockfe.warlock3.compose.generated.resources.edit
+import warlockfe.warlock3.compose.generated.resources.keyboard_double_arrow_down
+import warlockfe.warlock3.compose.generated.resources.keyboard_double_arrow_up
+import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.models.Action
+import warlockfe.warlock3.core.prefs.repositories.ActionRepository
+import kotlin.uuid.Uuid
+
+/**
+ * Edits the per-character action buttons. The top section is the toolbar (the ordered buttons shown
+ * on the game screen, a list of references into the pool); below it is the pool of all defined
+ * actions. A leaf action runs a WSL script; a group references other actions and opens a drill-down
+ * menu when pressed.
+ */
+@Composable
+fun ActionsView(
+    currentCharacter: GameCharacter?,
+    allCharacters: List<GameCharacter>,
+    actionRepository: ActionRepository,
+    modifier: Modifier = Modifier,
+) {
+    var selectedCharacter by remember(currentCharacter) { mutableStateOf(currentCharacter) }
+    val currentCharacterId = selectedCharacter?.id ?: "global"
+    val pool by actionRepository.observePool(currentCharacterId).collectAsState(emptyList())
+    val toolbar by actionRepository.observeToolbar(currentCharacterId).collectAsState(emptyList())
+    val poolById = remember(pool) { pool.associateBy { it.id } }
+    var editingAction by remember { mutableStateOf<Action?>(null) }
+    val scope = rememberCoroutineScope()
+
+    SettingsListScaffold(
+        title = "Actions",
+        selectedCharacter = selectedCharacter,
+        characters = allCharacters,
+        onSelectCharacter = { selectedCharacter = it },
+        modifier = modifier.fillMaxSize(),
+    ) {
+        ScrollableColumn(Modifier.fillMaxWidth().weight(1f)) {
+            Text("Button bar", style = MaterialTheme.typography.titleMedium)
+            ActionIdListEditor(
+                ids = toolbar,
+                pool = poolById,
+                candidates = pool.filterNot { it.id in toolbar },
+                emptyText = "No buttons yet. Add an action below to the bar.",
+                onChange = { scope.launch { actionRepository.setToolbar(currentCharacterId, it) } },
+            )
+
+            Spacer(Modifier.height(24.dp))
+            Text("All actions", style = MaterialTheme.typography.titleMedium)
+            if (pool.isEmpty()) {
+                Text(
+                    "No actions defined yet.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            pool.forEach { action ->
+                ListItem(
+                    leadingContent = groupIndicator(action),
+                    headlineContent = { Text(action.name.ifBlank { "(unnamed)" }) },
+                    supportingContent = { Text(if (action.isGroup) "Group" else "Script") },
+                    trailingContent = {
+                        Row {
+                            IconButton(onClick = { editingAction = action }) {
+                                Icon(painterResource(Res.drawable.edit), contentDescription = "Edit")
+                            }
+                            Spacer(Modifier.width(8.dp))
+                            IconButton(
+                                onClick = { scope.launch { actionRepository.deleteAction(currentCharacterId, action.id) } },
+                            ) {
+                                Icon(painterResource(Res.drawable.delete), contentDescription = "Delete")
+                            }
+                        }
+                    },
+                )
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.End),
+        ) {
+            OutlinedButton(
+                onClick = { editingAction = Action(id = Uuid.random(), name = "", script = null) },
+            ) {
+                Icon(painterResource(Res.drawable.add), contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("New group")
+            }
+            Button(
+                onClick = { editingAction = Action(id = Uuid.random(), name = "", script = "") },
+            ) {
+                Icon(painterResource(Res.drawable.add), contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("New action")
+            }
+        }
+    }
+
+    editingAction?.let { action ->
+        EditActionDialog(
+            action = action,
+            pool = pool,
+            onSave = { updated ->
+                scope.launch {
+                    actionRepository.saveAction(currentCharacterId, updated)
+                    editingAction = null
+                }
+            },
+            onClose = { editingAction = null },
+        )
+    }
+}
+
+private fun groupIndicator(action: Action): (@Composable () -> Unit)? =
+    if (action.isGroup) {
+        { Icon(painterResource(Res.drawable.arrow_right), contentDescription = null) }
+    } else {
+        null
+    }
+
+/**
+ * Edits an ordered list of action ids (the toolbar, or a group's children): each entry can be moved
+ * up/down or removed, and an "Add" dropdown appends an action picked from [candidates].
+ */
+@Composable
+private fun ActionIdListEditor(
+    ids: List<Uuid>,
+    pool: Map<Uuid, Action>,
+    candidates: List<Action>,
+    emptyText: String,
+    onChange: (List<Uuid>) -> Unit,
+) {
+    if (ids.isEmpty()) {
+        Text(
+            emptyText,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    ids.forEachIndexed { index, id ->
+        val action = pool[id]
+        ListItem(
+            leadingContent = action?.let { groupIndicator(it) },
+            headlineContent = { Text(action?.name?.ifBlank { "(unnamed)" } ?: "(missing action)") },
+            trailingContent = {
+                Row {
+                    IconButton(onClick = { onChange(ids.moveItem(index, index - 1)) }, enabled = index > 0) {
+                        Icon(painterResource(Res.drawable.keyboard_double_arrow_up), contentDescription = "Move up")
+                    }
+                    IconButton(
+                        onClick = { onChange(ids.moveItem(index, index + 1)) },
+                        enabled = index < ids.lastIndex,
+                    ) {
+                        Icon(painterResource(Res.drawable.keyboard_double_arrow_down), contentDescription = "Move down")
+                    }
+                    IconButton(onClick = { onChange(ids.filterIndexed { i, _ -> i != index }) }) {
+                        Icon(painterResource(Res.drawable.close), contentDescription = "Remove")
+                    }
+                }
+            },
+        )
+    }
+    ActionPickerButton(candidates = candidates, onPick = { onChange(ids + it) })
+}
+
+@Composable
+private fun ActionPickerButton(
+    candidates: List<Action>,
+    onPick: (Uuid) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        OutlinedButton(onClick = { expanded = true }, enabled = candidates.isNotEmpty()) {
+            Icon(painterResource(Res.drawable.add), contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text("Add")
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            candidates.forEach { action ->
+                DropdownMenuItem(
+                    text = { Text(action.name.ifBlank { "(unnamed)" }) },
+                    onClick = {
+                        expanded = false
+                        onPick(action.id)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EditActionDialog(
+    action: Action,
+    pool: List<Action>,
+    onSave: (Action) -> Unit,
+    onClose: () -> Unit,
+) {
+    val isGroup = action.isGroup
+    val name = rememberTextFieldState(action.name)
+    val script = rememberTextFieldState(action.script ?: "")
+    var childIds by remember { mutableStateOf(action.children) }
+    val poolById = remember(pool) { pool.associateBy { it.id } }
+
+    AlertDialog(
+        onDismissRequest = onClose,
+        title = { Text(if (isGroup) "Edit group" else "Edit action") },
+        confirmButton = {
+            TextButton(
+                enabled = name.text.isNotBlank(),
+                onClick = {
+                    onSave(
+                        action.copy(
+                            name = name.text.toString(),
+                            script = if (isGroup) null else script.text.toString(),
+                            children = if (isGroup) childIds else emptyList(),
+                        ),
+                    )
+                },
+            ) { Text("Save") }
+        },
+        dismissButton = { TextButton(onClick = onClose) { Text("Cancel") } },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                TextField(
+                    state = name,
+                    label = { Text("Name") },
+                    lineLimits = TextFieldLineLimits.SingleLine,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (isGroup) {
+                    Text("Actions in this group", style = MaterialTheme.typography.titleSmall)
+                    ActionIdListEditor(
+                        ids = childIds,
+                        pool = poolById,
+                        candidates = childCandidates(action.id, pool).filterNot { it.id in childIds },
+                        emptyText = "No actions in this group yet.",
+                        onChange = { childIds = it },
+                    )
+                } else {
+                    TextField(
+                        state = script,
+                        label = { Text("Script (WSL)") },
+                        lineLimits = TextFieldLineLimits.MultiLine(minHeightInLines = 3, maxHeightInLines = 10),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        },
+    )
+}

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsContent.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.repositories.ActionRepository
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.AlterationRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterRepository
@@ -30,6 +31,7 @@ fun SettingsContent(
     nameRepository: NameRepositoryImpl,
     presetRepository: PresetRepository,
     aliasRepository: AliasRepository,
+    actionRepository: ActionRepository,
     alterationRepository: AlterationRepository,
     clientSettingRepository: ClientSettingRepository,
     wraythImporter: WraythImporter,
@@ -101,6 +103,14 @@ fun SettingsContent(
                 currentCharacter = currentCharacter,
                 allCharacters = characters,
                 alterationRepository = alterationRepository,
+            )
+        }
+
+        SettingsPage.Actions -> {
+            ActionsView(
+                currentCharacter = currentCharacter,
+                allCharacters = characters,
+                actionRepository = actionRepository,
             )
         }
     }

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsScreen.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsScreen.kt
@@ -89,6 +89,7 @@ fun SettingsScreen(
                     nameRepository = appContainer.nameRepository,
                     presetRepository = appContainer.presetRepository,
                     aliasRepository = appContainer.aliasRepository,
+                    actionRepository = appContainer.actionRepository,
                     alterationRepository = appContainer.alterationRepository,
                     clientSettingRepository = appContainer.clientSettings,
                     wraythImporter = appContainer.wraythImporter,

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/CharacterConfigStore.kt
@@ -345,6 +345,7 @@ class CharacterConfigStore(
         when (val value = section.get(config)) {
             is List<*> -> value.isEmpty()
             is Map<*, *> -> value.isEmpty()
+            is ActionsFile -> value.toolbar.isEmpty() && value.actions.isEmpty()
             is CharacterSettingsConfig -> value == CharacterSettingsConfig()
             else -> true
         }
@@ -403,6 +404,19 @@ private enum class Section(
         },
         decodeInto = { toml, element, config ->
             config.copy(alterations = toml.decodeFromTomlElement(AlterationsFile.serializer(), element).alterations)
+        },
+    ),
+    ACTIONS(
+        fileName = "actions.toml",
+        // The actions pool and the toolbar share one file, so the change-detection key covers both.
+        get = { ActionsFile(it.toolbar, it.actions) },
+        clear = { it.copy(toolbar = emptyList(), actions = emptyList()) },
+        encode = { toml, config, template ->
+            toml.encodeWithTemplate(ActionsFile.serializer(), ActionsFile(config.toolbar, config.actions), template)
+        },
+        decodeInto = { toml, element, config ->
+            val file = toml.decodeFromTomlElement(ActionsFile.serializer(), element)
+            config.copy(toolbar = file.toolbar, actions = file.actions)
         },
     ),
     VARIABLES(
@@ -474,7 +488,7 @@ private enum class Section(
 }
 
 // Sections whose entries carry an `id` that may be generated on load.
-private val ID_SECTIONS = listOf(Section.HIGHLIGHTS, Section.NAMES, Section.ALIASES, Section.ALTERATIONS)
+private val ID_SECTIONS = listOf(Section.HIGHLIGHTS, Section.NAMES, Section.ALIASES, Section.ALTERATIONS, Section.ACTIONS)
 
 // Identity for comment carry-over: match array entries (highlights, names, ...) by their `id` so a
 // comment follows its entry when the list is reordered. Entries without an id fall back to position.
@@ -502,5 +516,6 @@ private fun CharacterConfig.withGeneratedIds(): Pair<CharacterConfig, Boolean> {
         names = names.fillMissingIds({ it.id }, { item, id -> item.copy(id = id) }),
         aliases = aliases.fillMissingIds({ it.id }, { item, id -> item.copy(id = id) }),
         alterations = alterations.fillMissingIds({ it.id }, { item, id -> item.copy(id = id) }),
+        actions = actions.fillMissingIds({ it.id }, { item, id -> item.copy(id = id) }),
     ) to changed
 }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigMappers.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigMappers.kt
@@ -1,6 +1,7 @@
 package warlockfe.warlock3.core.prefs.config
 
 import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.models.Action
 import warlockfe.warlock3.core.prefs.models.AliasEntity
 import warlockfe.warlock3.core.prefs.models.AlterationEntity
 import warlockfe.warlock3.core.prefs.models.Highlight
@@ -12,6 +13,24 @@ import warlockfe.warlock3.core.text.StyleDefinition
 import kotlin.uuid.Uuid
 
 private fun String?.toUuidOrRandom(): Uuid = this?.let { runCatching { Uuid.parse(it) }.getOrNull() } ?: Uuid.random()
+
+private fun String.toUuidOrNull(): Uuid? = runCatching { Uuid.parse(this) }.getOrNull()
+
+internal fun ActionConfig.toAction(): Action =
+    Action(
+        id = id.toUuidOrRandom(),
+        name = name,
+        script = script,
+        children = children.mapNotNull { it.toUuidOrNull() },
+    )
+
+internal fun Action.toConfig(): ActionConfig =
+    ActionConfig(
+        id = id.toString(),
+        name = name,
+        script = script,
+        children = children.map { it.toString() },
+    )
 
 internal fun HighlightConfig.toHighlight(): Highlight =
     Highlight(

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
@@ -61,6 +61,10 @@ data class CharacterConfig(
     val names: List<NameConfig> = emptyList(),
     val aliases: List<AliasConfig> = emptyList(),
     val alterations: List<AlterationConfig> = emptyList(),
+    // The pool of user-defined action buttons, and the ids of the actions shown on the game-screen
+    // button bar (in order). Both live in actions.toml.
+    val toolbar: List<String> = emptyList(),
+    val actions: List<ActionConfig> = emptyList(),
     val variables: Map<String, String> = emptyMap(),
     // Keyed by key-combo string (e.g. "ctrl alt f1"); value is the macro action.
     val macros: Map<String, String> = emptyMap(),
@@ -78,6 +82,22 @@ data class AliasConfig(
     val id: String? = null,
     val pattern: String = "",
     val replacement: String = "",
+)
+
+/**
+ * One action button in the flat per-character pool. A leaf has a [script] (a WSL script run when the
+ * button is pressed) and no children; a group has [children] (ids of other actions in the pool, shown
+ * as a drill-down menu) and no script. Give an action a stable [id] when hand-editing if anything
+ * references it from `toolbar` or another action's `children`; the Settings UI assigns ids itself.
+ */
+@Serializable
+data class ActionConfig(
+    val id: String? = null,
+    val name: String = "",
+    @TomlComment("WSL script run when pressed (a leaf). Omit and set 'children' for a group.")
+    val script: String? = null,
+    @TomlComment("Ids of the child actions shown when this group is pressed. Omit for a leaf.")
+    val children: List<String> = emptyList(),
 )
 
 @Serializable
@@ -156,6 +176,13 @@ internal data class AliasesFile(
 @Serializable
 internal data class AlterationsFile(
     val alterations: List<AlterationConfig> = emptyList(),
+)
+
+@Serializable
+internal data class ActionsFile(
+    @TomlComment("Ids of the actions shown on the game-screen button bar, in order.")
+    val toolbar: List<String> = emptyList(),
+    val actions: List<ActionConfig> = emptyList(),
 )
 
 @Serializable

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/models/Action.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/models/Action.kt
@@ -1,0 +1,33 @@
+package warlockfe.warlock3.core.prefs.models
+
+import kotlin.uuid.Uuid
+
+/**
+ * A user-defined action button. A leaf action ([script] non-null) runs a WSL script when pressed; a
+ * group action ([script] null) opens a drill-down menu of the actions referenced by [children].
+ *
+ * Actions live in a flat per-character pool and reference each other by id, so the same action can sit
+ * on the toolbar and inside one or more groups. References that don't resolve are skipped at render
+ * time, so a deleted action never breaks a group that still points at it.
+ */
+data class Action(
+    val id: Uuid,
+    val name: String,
+    val script: String?,
+    val children: List<Uuid> = emptyList(),
+) {
+    val isGroup: Boolean get() = script == null
+}
+
+/**
+ * The resolved actions for the game-screen button bar: the full [actions] pool keyed by id (for
+ * resolving a group's children) and the ordered [toolbar] of top-level actions to draw as buttons.
+ */
+data class ActionBar(
+    val actions: Map<Uuid, Action>,
+    val toolbar: List<Action>,
+) {
+    companion object {
+        val EMPTY = ActionBar(actions = emptyMap(), toolbar = emptyList())
+    }
+}

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ActionRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ActionRepository.kt
@@ -1,0 +1,103 @@
+package warlockfe.warlock3.core.prefs.repositories
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import warlockfe.warlock3.core.prefs.config.ActionConfig
+import warlockfe.warlock3.core.prefs.config.CharacterConfigStore
+import warlockfe.warlock3.core.prefs.config.GLOBAL_CHARACTER_ID
+import warlockfe.warlock3.core.prefs.config.toAction
+import warlockfe.warlock3.core.prefs.config.toConfig
+import warlockfe.warlock3.core.prefs.models.Action
+import warlockfe.warlock3.core.prefs.models.ActionBar
+import kotlin.uuid.Uuid
+
+/**
+ * Reads and writes the flat per-character pool of [Action]s plus the ordered toolbar of action ids,
+ * funnelling through [CharacterConfigStore] so writes never clobber other config sections.
+ */
+class ActionRepository(
+    private val store: CharacterConfigStore,
+) {
+    /**
+     * The resolved button bar for the game screen: the character's own actions merged with the global
+     * ones, plus the ordered toolbar (this character's toolbar first, then global). Toolbar/child ids
+     * that don't resolve to an action in the merged pool are skipped.
+     */
+    fun observeForCharacter(characterId: String): Flow<ActionBar> =
+        if (characterId == GLOBAL_CHARACTER_ID) {
+            store.observe(characterId).map { resolve(it.toolbar, it.actions) }
+        } else {
+            combine(store.observe(characterId), store.observe(GLOBAL_CHARACTER_ID)) { own, global ->
+                resolve(own.toolbar + global.toolbar, own.actions + global.actions)
+            }
+        }
+
+    /** This character's own action pool (no global merge), for the settings editor. */
+    fun observePool(characterId: String): Flow<List<Action>> =
+        store.observe(characterId).map { config -> config.actions.map { it.toAction() } }
+
+    /** This character's own toolbar ids (no global merge), for the settings editor. */
+    fun observeToolbar(characterId: String): Flow<List<Uuid>> =
+        store.observe(characterId).map { config -> config.toolbar.mapNotNull { it.toUuidOrNull() } }
+
+    /** Insert or replace one action in the pool (matched by id; an edit keeps its position). */
+    suspend fun saveAction(
+        characterId: String,
+        action: Action,
+    ) {
+        val config = action.toConfig()
+        store.mutate(characterId) { current ->
+            current.copy(actions = current.actions.upsert(config))
+        }
+    }
+
+    /**
+     * Remove an action and scrub its id from the toolbar and from every group's children, so no
+     * dangling reference is left behind in this character's config.
+     */
+    suspend fun deleteAction(
+        characterId: String,
+        id: Uuid,
+    ) {
+        val idString = id.toString()
+        store.mutate(characterId) { current ->
+            current.copy(
+                actions =
+                    current.actions
+                        .filterNot { it.id == idString }
+                        .map { it.copy(children = it.children.filterNot { child -> child == idString }) },
+                toolbar = current.toolbar.filterNot { it == idString },
+            )
+        }
+    }
+
+    /** Replace the toolbar membership and order for a character. */
+    suspend fun setToolbar(
+        characterId: String,
+        toolbar: List<Uuid>,
+    ) {
+        store.mutate(characterId) { current ->
+            current.copy(toolbar = toolbar.map { it.toString() })
+        }
+    }
+}
+
+private fun resolve(
+    toolbarIds: List<String>,
+    actionConfigs: List<ActionConfig>,
+): ActionBar {
+    val byId = actionConfigs.map { it.toAction() }.associateBy { it.id }
+    val toolbar = toolbarIds.mapNotNull { it.toUuidOrNull()?.let(byId::get) }
+    return ActionBar(actions = byId, toolbar = toolbar)
+}
+
+private fun String.toUuidOrNull(): Uuid? = runCatching { Uuid.parse(this) }.getOrNull()
+
+// Replace a matching action in place (so an edit keeps its position); a new one is appended. Ids are
+// unique, so matching on id alone is enough.
+private fun List<ActionConfig>.upsert(item: ActionConfig): List<ActionConfig> {
+    val existingIndex = indexOfFirst { it.id == item.id }
+    if (existingIndex < 0) return this + item
+    return mapIndexed { index, existing -> if (index == existingIndex) item else existing }
+}

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/script/ScriptManager.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/script/ScriptManager.kt
@@ -20,6 +20,14 @@ interface ScriptManager {
         commandHandler: suspend (String) -> SendCommandType,
     )
 
+    /** Run a WSL script from a raw string (e.g. an action button's inline script). */
+    suspend fun startScript(
+        client: WarlockClient,
+        name: String,
+        contents: String,
+        commandHandler: suspend (String) -> SendCommandType,
+    )
+
     fun findScriptInstance(description: String): ScriptInstance?
 
     fun scriptStateChanged(instance: ScriptInstance)

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/script/WarlockScriptEngineRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/script/WarlockScriptEngineRepository.kt
@@ -14,6 +14,13 @@ interface WarlockScriptEngineRepository {
         scriptManager: ScriptManager,
     ): ScriptLaunchResult
 
+    /** Build a script instance from a raw WSL string (e.g. an action button's inline script). */
+    suspend fun getScriptFromContents(
+        name: String,
+        contents: String,
+        scriptManager: ScriptManager,
+    ): ScriptLaunchResult
+
     fun supportsExtension(extension: String): Boolean
 }
 

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/repositories/ActionRepositoryTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/repositories/ActionRepositoryTest.kt
@@ -1,0 +1,138 @@
+package warlockfe.warlock3.core.prefs.repositories
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readByteArray
+import warlockfe.warlock3.core.prefs.config.CharacterConfigStore
+import warlockfe.warlock3.core.prefs.models.Action
+import java.nio.file.Files
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class ActionRepositoryTest {
+    private val fs = SystemFileSystem
+    private lateinit var dir: Path
+    private lateinit var configDir: String
+
+    @BeforeTest
+    fun setUp() {
+        dir = Path(Files.createTempDirectory("action-test").toAbsolutePath().toString())
+        configDir = dir.toString()
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        java.nio.file.Path
+            .of(dir.toString())
+            .deleteRecursively()
+    }
+
+    private fun newStore() = CharacterConfigStore(configDir, fs)
+
+    private fun readFile(path: Path): String = fs.source(path).buffered().use { it.readByteArray().decodeToString() }
+
+    private fun actionsFile(characterId: String): Path {
+        val (game, name) = characterId.split(":")
+        return Path(Path(Path(Path(configDir, "characters"), game), name), "actions.toml")
+    }
+
+    @Test
+    fun actions_roundTripWithToolbarAndGroup() =
+        runBlocking {
+            val store = newStore()
+            store.load()
+            val repo = ActionRepository(store)
+            val char = "gs4:tholan"
+            val look = Action(Uuid.random(), "Look", "put look")
+            val attack = Action(Uuid.random(), "Attack", "put attack")
+            val combat = Action(Uuid.random(), "Combat", script = null, children = listOf(attack.id))
+            repo.saveAction(char, look)
+            repo.saveAction(char, attack)
+            repo.saveAction(char, combat)
+            repo.setToolbar(char, listOf(look.id, combat.id))
+
+            // A fresh store reads it back identically.
+            val reloaded = newStore()
+            reloaded.load()
+            val bar = ActionRepository(reloaded).observeForCharacter(char).first()
+            assertEquals(3, bar.actions.size)
+            assertEquals(listOf("Look", "Combat"), bar.toolbar.map { it.name })
+            val group = bar.toolbar.first { it.isGroup }
+            assertEquals(listOf(attack.id), group.children)
+            assertEquals("put attack", bar.actions[group.children.single()]?.script)
+        }
+
+    @Test
+    fun actionsToml_isFlatWithInlineChildren() =
+        runBlocking {
+            val store = newStore()
+            store.load()
+            val repo = ActionRepository(store)
+            val child = Action(Uuid.random(), "Child", "put a")
+            val group = Action(Uuid.random(), "Group", script = null, children = listOf(child.id))
+            repo.saveAction("gs4:tholan", child)
+            repo.saveAction("gs4:tholan", group)
+            repo.setToolbar("gs4:tholan", listOf(group.id))
+
+            val text = readFile(actionsFile("gs4:tholan"))
+            assertTrue(text.contains("toolbar = ["), "expected a toolbar array, was:\n$text")
+            assertTrue(text.contains("[[actions]]"), "expected flat actions tables, was:\n$text")
+            assertFalse(
+                text.contains("[[actions.children]]"),
+                "children should be inline ids, not nested tables:\n$text",
+            )
+            assertTrue(text.contains("children = ["), "expected inline children id array:\n$text")
+        }
+
+    @Test
+    fun deleteAction_scrubsToolbarAndGroupReferences() =
+        runBlocking {
+            val store = newStore()
+            store.load()
+            val repo = ActionRepository(store)
+            val char = "gs4:tholan"
+            val child = Action(Uuid.random(), "Child", "put a")
+            val group = Action(Uuid.random(), "Group", script = null, children = listOf(child.id))
+            repo.saveAction(char, child)
+            repo.saveAction(char, group)
+            repo.setToolbar(char, listOf(child.id, group.id))
+
+            repo.deleteAction(char, child.id)
+
+            val bar = repo.observeForCharacter(char).first()
+            assertFalse(bar.actions.containsKey(child.id))
+            assertEquals(listOf(group.id), repo.observeToolbar(char).first())
+            assertEquals(emptyList<Uuid>(), bar.actions[group.id]?.children)
+        }
+
+    @Test
+    fun observeForCharacter_mergesGlobalAndCharacter_andSkipsDangling() =
+        runBlocking {
+            val store = newStore()
+            store.load()
+            val repo = ActionRepository(store)
+            val globalAction = Action(Uuid.random(), "GlobalLook", "put look")
+            val charAction = Action(Uuid.random(), "CharAttack", "put attack")
+            repo.saveAction("global", globalAction)
+            repo.setToolbar("global", listOf(globalAction.id))
+            repo.saveAction("gs4:tholan", charAction)
+            // Character toolbar references its own action plus a dangling id that must be skipped.
+            repo.setToolbar("gs4:tholan", listOf(charAction.id, Uuid.random()))
+
+            val bar = repo.observeForCharacter("gs4:tholan").first()
+            assertTrue(bar.actions.containsKey(globalAction.id))
+            assertTrue(bar.actions.containsKey(charAction.id))
+            // Character toolbar first (dangling skipped), then global.
+            assertEquals(listOf("CharAttack", "GlobalLook"), bar.toolbar.map { it.name })
+        }
+}

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/SettingsDialog.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/SettingsDialog.kt
@@ -3,6 +3,7 @@ package warlockfe.warlock3.app
 import androidx.compose.runtime.Composable
 import warlockfe.warlock3.compose.desktop.ui.settings.DesktopSettingsDialog
 import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.repositories.ActionRepository
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.AlterationRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterRepository
@@ -27,6 +28,7 @@ fun SettingsDialog(
     alterationRepository: AlterationRepository,
     characterSettingsRepository: CharacterSettingsRepository,
     aliasRepository: AliasRepository,
+    actionRepository: ActionRepository,
     scriptDirRepository: ScriptDirRepository,
     clientSettingRepository: ClientSettingRepository,
     closeDialog: () -> Unit,
@@ -42,6 +44,7 @@ fun SettingsDialog(
         alterationRepository = alterationRepository,
         characterSettingsRepository = characterSettingsRepository,
         aliasRepository = aliasRepository,
+        actionRepository = actionRepository,
         scriptDirRepository = scriptDirRepository,
         clientSettingRepository = clientSettingRepository,
         closeDialog = closeDialog,

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
@@ -209,6 +209,7 @@ fun DecoratedWindowScope.WarlockApp(
             nameRepository = appContainer.nameRepository,
             characterSettingsRepository = appContainer.characterSettingsRepository,
             aliasRepository = appContainer.aliasRepository,
+            actionRepository = appContainer.actionRepository,
             scriptDirRepository = appContainer.scriptDirRepository,
             alterationRepository = appContainer.alterationRepository,
             clientSettingRepository = appContainer.clientSettings,

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/ScriptManagerImpl.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/ScriptManagerImpl.kt
@@ -67,6 +67,23 @@ class ScriptManagerImpl(
         }
     }
 
+    override suspend fun startScript(
+        client: WarlockClient,
+        name: String,
+        contents: String,
+        commandHandler: suspend (String) -> SendCommandType,
+    ) {
+        when (val result = scriptEngineRepository.getScriptFromContents(name, contents, this)) {
+            is ScriptLaunchResult.Success -> {
+                startInstance(client, result.instance, null, commandHandler)
+            }
+
+            is ScriptLaunchResult.Failure -> {
+                client.print(StyledString(result.message, style = WarlockStyle.Error))
+            }
+        }
+    }
+
     private suspend fun startInstance(
         client: WarlockClient,
         instance: ScriptInstance,

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/WarlockScriptEngineRepositoryImpl.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/WarlockScriptEngineRepositoryImpl.kt
@@ -8,6 +8,7 @@ import warlockfe.warlock3.core.script.ScriptManager
 import warlockfe.warlock3.core.script.WarlockScriptEngineRepository
 import warlockfe.warlock3.scripting.util.extension
 import warlockfe.warlock3.scripting.util.nameWithoutExtension
+import warlockfe.warlock3.scripting.wsl.WslEngine
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.fetchAndIncrement
 
@@ -69,6 +70,20 @@ class WarlockScriptEngineRepositoryImpl(
         } else {
             ScriptLaunchResult.Failure("Could not find a script with that name")
         }
+    }
+
+    override suspend fun getScriptFromContents(
+        name: String,
+        contents: String,
+        scriptManager: ScriptManager,
+    ): ScriptLaunchResult {
+        // Inline scripts are WSL only; the JS engine has no string-backed instance.
+        val engine =
+            engines.filterIsInstance<WslEngine>().firstOrNull()
+                ?: return ScriptLaunchResult.Failure("WSL scripting engine is unavailable")
+        return ScriptLaunchResult.Success(
+            engine.createStringInstance(nextId.fetchAndIncrement(), name, contents, scriptManager),
+        )
     }
 
     private fun getEngineForExtension(extension: String): WarlockScriptEngine? {

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslContext.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslContext.kt
@@ -496,7 +496,8 @@ class WslContext(
     }
 
     suspend fun playSound(name: String) {
-        val file = scriptInstance.file.parent?.let { Path(it, name) } ?: Path(name)
+        // String-backed scripts have no file, so resolve relative to the script dir only when there is one.
+        val file = scriptInstance.file?.parent?.let { Path(it, name) } ?: Path(name)
         val filename = if (fileSystem.exists(file)) file.toString() else name
         val error = soundPlayer.playSound(filename)
         if (error == null) {

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslEngine.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslEngine.kt
@@ -36,4 +36,24 @@ class WslEngine(
             soundPlayer = soundPlayer,
             fileSystem = fileSystem,
         )
+
+    /** Build an instance that runs an in-memory WSL [content] string (e.g. an action button script). */
+    fun createStringInstance(
+        id: Long,
+        name: String,
+        content: String,
+        scriptManager: ScriptManager,
+    ): ScriptInstance =
+        WslScriptInstance(
+            id = id,
+            name = name,
+            file = null,
+            content = content,
+            highlightRepository = highlightRepository,
+            nameRepository = nameRepository,
+            variableRepository = variableRepository,
+            scriptManager = scriptManager,
+            soundPlayer = soundPlayer,
+            fileSystem = fileSystem,
+        )
 }

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslScript.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslScript.kt
@@ -5,6 +5,7 @@ import kotlinx.io.files.FileSystem
 import kotlinx.io.files.Path
 import org.antlr.v4.kotlinruntime.ANTLRErrorListener
 import org.antlr.v4.kotlinruntime.CharStream
+import org.antlr.v4.kotlinruntime.CharStreams
 import org.antlr.v4.kotlinruntime.CommonTokenStream
 import org.antlr.v4.kotlinruntime.Parser
 import org.antlr.v4.kotlinruntime.RecognitionException
@@ -18,16 +19,33 @@ import warlockfe.warlock3.scripting.util.toCharStream
 
 class WslScript(
     val name: String,
-    private val file: Path,
+    private val file: Path?,
     private val fileSystem: FileSystem,
+    // When set, the script is parsed from this in-memory string instead of [file] (e.g. an action
+    // button's inline script). Exactly one of [content]/[file] is expected to be present.
+    private val content: String? = null,
 ) {
     fun parse(): List<WslLine> {
-        val input: CharStream = file.toCharStream(fileSystem)
+        val input: CharStream =
+            when {
+                content != null -> CharStreams.fromString(content)
+                file != null -> file.toCharStream(fileSystem)
+                else -> throw WslParseException("Script \"$name\" has no source")
+            }
         val lexer = WslLexer(input)
         val parser = WslParser(CommonTokenStream(lexer))
         parser.addErrorListener(ErrorListener())
         val script = parser.script()
         return script.line().map { parseLine(it) }
+    }
+
+    companion object {
+        /** A script parsed from a raw string rather than a file on disk. */
+        fun fromString(
+            name: String,
+            content: String,
+            fileSystem: FileSystem,
+        ): WslScript = WslScript(name = name, file = null, fileSystem = fileSystem, content = content)
     }
 
     private fun parseLine(line: WslParser.LineContext): WslLine {

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslScriptInstance.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslScriptInstance.kt
@@ -27,15 +27,17 @@ import warlockfe.warlock3.core.util.parseArguments
 class WslScriptInstance(
     override val id: Long,
     override val name: String,
-    val file: Path,
+    val file: Path?,
     private val variableRepository: VariableRepository,
     private val highlightRepository: HighlightRepository,
     private val nameRepository: NameRepository,
     private val scriptManager: ScriptManager,
     private val soundPlayer: SoundPlayer,
     private val fileSystem: FileSystem,
+    // When set, the script runs from this in-memory string instead of [file].
+    private val content: String? = null,
 ) : ScriptInstance {
-    private val script: WslScript = WslScript(name, file, fileSystem)
+    private val script: WslScript = WslScript(name, file, fileSystem, content)
 
     override var status: ScriptStatus = ScriptStatus.NotStarted
         private set(newStatus) {

--- a/scripting/src/commonTest/kotlin/wsl/Fakes.kt
+++ b/scripting/src/commonTest/kotlin/wsl/Fakes.kt
@@ -35,6 +35,13 @@ class FakeScriptManager : ScriptManager {
         commandHandler: suspend (String) -> SendCommandType,
     ) = Unit
 
+    override suspend fun startScript(
+        client: WarlockClient,
+        name: String,
+        contents: String,
+        commandHandler: suspend (String) -> SendCommandType,
+    ) = Unit
+
     override fun findScriptInstance(description: String): ScriptInstance? = null
 
     override fun scriptStateChanged(instance: ScriptInstance) {


### PR DESCRIPTION
## What

Adds a row of user-configurable **action buttons** to the desktop and mobile game screens, plus a new per-character **Actions** settings page. An action has a name and is either:

- a **leaf** that runs a WSL script through the scripting engine when pressed, or
- a **group** that references other actions by id and opens a **drill-down popup** when pressed (recursively).

This replaces the hardcoded `look/attack/search/stance` assist chips that were flagged as placeholders.

## Data model

A flat, normalized model: a single per-character pool of actions plus an explicit ordered `toolbar` list of ids, stored together in a human-editable `actions.toml`. Groups reference their children by id; the same action can sit on the toolbar and inside one or more groups. Per-character with a global fallback, like highlights/aliases.

```toml
toolbar = ["heal", "combat-grp"]

[[actions]]
id = "heal"
name = "Heal"
script = "put cast 101"

[[actions]]
id = "combat-grp"
name = "Combat"
children = ["attack", "kick"]
```

## Changes

- **core**: `Action` model + `ActionBar`; `ActionConfig`/`toolbar` in the config schema; mappers; an `ACTIONS` section in `CharacterConfigStore`; `ActionRepository`.
- **scripting**: a WSL-only "run from string" path (`WslScript.fromString`, `WslEngine.createStringInstance`, `getScriptFromContents`, a third `startScript(client, name, contents, handler)` overload). The `createInstance(file)` interface and the JS engine are untouched.
- **compose**: an Actions settings page (mobile `ActionsView` + desktop `DesktopActionsView`) with a toolbar editor over the flat pool, leaf/group editors, and a reusable ordered id-list editor; action-button rows with drill-down popups on the desktop bottom bar and all mobile layouts; `GameViewModel.actionBar` + `runActionScript`.

## Reference integrity

- Dangling toolbar/child ids are skipped at render time.
- Deleting an action scrubs its id from the toolbar and every group's children.
- The drill-down popups and the group editor guard against reference cycles.

## Testing

- Compiles clean: `compose` JVM + Android, `desktopApp`, `core`, `scripting`.
- New `ActionRepositoryTest` (round-trip, flat-TOML-with-inline-children, delete-scrubs-references, global/character merge + dangling-skip); `core` + `scripting` JVM tests pass.
- `ktlintCheck` passes.

Note: the button bar is empty until actions are configured (the placeholder commands were removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)