### PR TITLE
Make status indicators skin-driven via SkinImage.name

### DIFF
--- a/compose/skin/skin.json
+++ b/compose/skin/skin.json
@@ -271,5 +271,22 @@
       "dangerIcon": { "color": { "light": "#C0392B", "dark": "#E06B60" } },
       "compassDarkIcon": { "color": { "light": "#BCC0C7", "dark": "#3F444D" } }
     }
+  },
+  "indicator": {
+    "children": {
+      "kneeling": { "image": { "name": "kneeling" } },
+      "prone": { "image": { "name": "prone" } },
+      "sitting": { "image": { "name": "sitting" } },
+      "standing": { "image": { "name": "standing" } },
+      "poisoned": { "image": { "name": "poisoned" } },
+      "diseased": { "image": { "name": "diseased" } },
+      "joined": { "image": { "name": "joined" } },
+      "bleeding": { "image": { "name": "local_hospital" } },
+      "dead": { "image": { "name": "death" } },
+      "invisible": { "image": { "name": "invisible" } },
+      "hidden": { "image": { "name": "hidden" } },
+      "webbed": { "image": { "name": "webbed" } },
+      "stunned": { "image": { "name": "stunned" } }
+    }
   }
 }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/model/SkinObject.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/model/SkinObject.kt
@@ -33,4 +33,7 @@ data class SkinImage(
     val data: String? = null,
     // Name of a file inside the skin .zip to load the image bytes from. Ignored when [data] is set.
     val file: String? = null,
+    // Name of a bundled Compose drawable resource (a `Res.allDrawableResources` key) to use as the
+    // image, for skin entries that reference a built-in asset instead of carrying their own bytes.
+    val name: String? = null,
 )

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopIndicatorView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopIndicatorView.kt
@@ -20,19 +20,10 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 import warlockfe.warlock3.compose.generated.resources.Res
-import warlockfe.warlock3.compose.generated.resources.death
-import warlockfe.warlock3.compose.generated.resources.diseased
-import warlockfe.warlock3.compose.generated.resources.hidden
-import warlockfe.warlock3.compose.generated.resources.invisible
-import warlockfe.warlock3.compose.generated.resources.joined
-import warlockfe.warlock3.compose.generated.resources.kneeling
-import warlockfe.warlock3.compose.generated.resources.local_hospital
-import warlockfe.warlock3.compose.generated.resources.poisoned
-import warlockfe.warlock3.compose.generated.resources.prone
-import warlockfe.warlock3.compose.generated.resources.sitting
-import warlockfe.warlock3.compose.generated.resources.standing
-import warlockfe.warlock3.compose.generated.resources.stunned
-import warlockfe.warlock3.compose.generated.resources.webbed
+import warlockfe.warlock3.compose.generated.resources.allDrawableResources
+import warlockfe.warlock3.compose.model.SkinObject
+import warlockfe.warlock3.compose.util.LocalSkin
+import warlockfe.warlock3.core.util.getIgnoringCase
 
 /**
  * The five grouped status slots on the right of the control bar. Each group shows at most one active
@@ -45,42 +36,30 @@ fun DesktopIndicatorView(
     indicators: Set<String>,
     modifier: Modifier = Modifier,
 ) {
-    // Posture and affliction share the first slot; the rest follow the design's grouping (6.4).
-    // Only the first matching status in a group is shown, so affliction is listed before posture:
-    // a posture (usually "standing") is almost always present and would otherwise permanently mask
-    // the more important poisoned/diseased warning.
-    val groups: List<List<Pair<String, DrawableResource>>> =
+    // Grouping and priority stay in code; the image used for each status is looked up from the skin's
+    // "indicator" section (status name -> SkinImage referencing a drawable). Posture and affliction
+    // share the first slot and only the first matching status in a group is shown, so affliction is
+    // listed before posture: a posture (usually "standing") is almost always present and would
+    // otherwise permanently mask the more important poisoned/diseased warning.
+    val groups: List<List<String>> =
         listOf(
-            listOf(
-                "poisoned" to Res.drawable.poisoned,
-                "diseased" to Res.drawable.diseased,
-                "kneeling" to Res.drawable.kneeling,
-                "prone" to Res.drawable.prone,
-                "sitting" to Res.drawable.sitting,
-                "standing" to Res.drawable.standing,
-            ),
-            listOf("joined" to Res.drawable.joined),
-            listOf(
-                "bleeding" to Res.drawable.local_hospital,
-                "dead" to Res.drawable.death,
-            ),
-            listOf(
-                "invisible" to Res.drawable.invisible,
-                "hidden" to Res.drawable.hidden,
-                "webbed" to Res.drawable.webbed,
-            ),
-            listOf("stunned" to Res.drawable.stunned),
+            listOf("poisoned", "diseased", "kneeling", "prone", "sitting", "standing"),
+            listOf("joined"),
+            listOf("bleeding", "dead"),
+            listOf("invisible", "hidden", "webbed"),
+            listOf("stunned"),
         )
 
     val chrome = gameChrome
+    val indicatorImages = LocalSkin.current.getIgnoringCase("indicator")?.children
     val shape = RoundedCornerShape(5.dp)
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         groups.forEach { group ->
-            val active = group.firstOrNull { indicators.contains(it.first) }
-            val accent = active?.let { indicatorAccent(it.first, chrome) } ?: inactiveAccent(chrome)
+            val activeKey = group.firstOrNull { indicators.contains(it) }
+            val accent = activeKey?.let { indicatorAccent(it, chrome) } ?: inactiveAccent(chrome)
             Box(
                 modifier =
                     Modifier
@@ -90,18 +69,23 @@ fun DesktopIndicatorView(
                         .padding(indicatorSize / 6f),
                 contentAlignment = Alignment.Center,
             ) {
-                if (active != null) {
+                val drawable = activeKey?.let { indicatorImages?.indicatorDrawable(it) }
+                if (activeKey != null && drawable != null) {
                     Image(
                         modifier = Modifier.fillMaxSize(),
-                        painter = painterResource(active.second),
+                        painter = painterResource(drawable),
                         colorFilter = accent.iconTint?.let { ColorFilter.tint(it) },
-                        contentDescription = active.first,
+                        contentDescription = activeKey,
                     )
                 }
             }
         }
     }
 }
+
+/** Resolves a status key to its drawable via the skin's "indicator" section (the image `name`). */
+private fun Map<String, SkinObject>.indicatorDrawable(status: String): DrawableResource? =
+    getIgnoringCase(status)?.image?.name?.let { Res.allDrawableResources[it] }
 
 private data class IndicatorAccent(
     val border: Color,


### PR DESCRIPTION
Stacked on #169 (uses the `gameChrome`/`GameChrome` accessor from that PR). GitHub will retarget this to `master` once #169 merges.

Moves the status-indicator image mapping into the skin.

## Changes
- **`SkinImage` gains a `name` field** that references a bundled Compose drawable resource (a `Res.allDrawableResources` key), alongside the existing `data`/`file`. This lets a skin entry point at a built-in asset instead of carrying its own bytes.
- **Default skin gets an `indicator` section** mapping each status to its drawable by name:
  ```json
  "indicator": { "children": {
    "poisoned": { "image": { "name": "poisoned" } },
    "bleeding": { "image": { "name": "local_hospital" } },
    "dead":     { "image": { "name": "death" } }, ...
  } }
  ```
- **`DesktopIndicatorView` resolves each status's image from the skin** (`Map<String, SkinObject>.indicatorDrawable`). Grouping, priority, and the chrome accent tinting stay in code (layout logic); only the status -> image mapping moved to the skin.

## Notes
- The drawables stay bundled and are referenced by name (no rasterization, vectors preserved). A custom skin can now remap any status to a different bundled drawable.
- Desktop only; the mobile `IndicatorView` still uses the drawables directly (possible follow-up).

## Verification
- Compile + ktlint clean; `SkinJsonTest` / `SkinZipLoaderTest` pass.
- All 13 status -> drawable mappings match the previous hardcoded ones exactly, and the packaged `skin.zip` contains the section -> **no visible change**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)