### PR TITLE
Use the shared DialogProgressBar for mobile dialog windows

### DIFF
--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogContent.kt
@@ -1,6 +1,5 @@
 package warlockfe.warlock3.compose.ui.window
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -12,16 +11,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.drawText
-import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
@@ -54,7 +48,7 @@ fun DialogContent(
                 }
 
                 is DialogObject.ProgressBar -> {
-                    ProgressBar(
+                    DialogProgressBar(
                         skinObject = skinObject,
                         data = data,
                     )
@@ -110,43 +104,6 @@ fun DialogContent(
                     }
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun ProgressBar(
-    skinObject: SkinObject?,
-    data: DialogObject.ProgressBar,
-) {
-    val colorGroup = skinObject.getColorGroup()
-    val percent = data.value.value
-    val textMeasurer = rememberTextMeasurer()
-    val font = MaterialTheme.typography.labelSmall
-    Canvas(modifier = Modifier) {
-        drawRect(
-            color = colorGroup.background,
-            topLeft = Offset(1f, 1f),
-            size = Size(height = size.height - 2f, width = size.width - 2f),
-        )
-        drawRect(
-            color = colorGroup.bar,
-            topLeft = Offset(1f, 1f),
-            size = Size(width = (size.width - 2f) * percent / 100, height = size.height - 2f),
-        )
-        data.text?.let { text ->
-            val measuredText =
-                textMeasurer.measure(
-                    text = text,
-                    constraints = Constraints(maxWidth = size.width.toInt()),
-                    maxLines = 1,
-                    style = font,
-                )
-            drawText(
-                textLayoutResult = measuredText,
-                color = colorGroup.text,
-                topLeft = Offset(x = (size.width - measuredText.size.width) / 2f, y = (size.height - measuredText.size.height) / 2f),
-            )
         }
     }
 }


### PR DESCRIPTION
## Summary

The phone/tablet vital bars lacked the rounded corners and spacing the desktop bars have. The cause: there were **two** progress-bar implementations.

- The desktop redesign introduced a shared **`DialogProgressBar`** (`commonMain/ui/window/DialogProgressBar.kt`): `drawRoundRect` with a `2.dp` corner radius, a `2.dp` horizontal inset on each side, and a dark halo behind light labels. Desktop calls it.
- Mobile's `DialogContent` kept its **own private `ProgressBar`**, predating the shared component: plain `drawRect` (square corners), a hardcoded `1f` inset (bars touch their slot edges, so no visible spacing), and no label halo.

This switches mobile to call the shared `DialogProgressBar` and deletes the duplicate private implementation (and its now-unused imports). `DialogProgressBar` already lives in `commonMain`, so no production code moved -- mobile just stops reimplementing it.

## Result
Android/iOS dialog windows (vital bars, etc.) now render with the same rounded corners, 2.dp spacing, and light-label halo as desktop.

## Test plan
- [x] `:compose:compileAndroidMain` (commonMain + shared mobile source set)
- [x] `:compose:ktlintCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)