### PR TITLE
Polish dialog content: link buttons, label font, halo fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,4 +12,4 @@ ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
 ij_kotlin_packages_to_use_import_on_demand = unset
 ktlint_function_naming_ignore_when_annotated_with = Composable
 ktlint_standard_discouraged-comment-location = disabled
-compose_allowed_composition_locals = LocalSkin,LocalWindowComponent,LocalProgressBarColors,LocalDarkTheme
+compose_allowed_composition_locals = LocalSkin,LocalWindowComponent,LocalProgressBarColors,LocalDarkTheme,LocalStyleMap

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogProgressBar.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogProgressBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.takeOrElse
@@ -40,6 +41,7 @@ private val barCornerRadius = 2.dp
 fun DialogProgressBar(
     skinObject: SkinObject?,
     data: DialogObject.ProgressBar,
+    style: TextStyle,
     modifier: Modifier = Modifier,
     barColorOverride: WarlockColor = WarlockColor.Unspecified,
     backgroundColorOverride: WarlockColor = WarlockColor.Unspecified,
@@ -80,11 +82,7 @@ fun DialogProgressBar(
                     text = text,
                     constraints = Constraints(maxWidth = size.width.toInt()),
                     maxLines = 1,
-                    style =
-                        TextStyle(
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Medium,
-                        ),
+                    style = style,
                 )
             val topLeft =
                 Offset(
@@ -109,10 +107,14 @@ fun DialogProgressBar(
                         ),
                 )
             }
+            // Reuses the same measured text as the halo stroke above; the Android text paint is
+            // shared between draws and a null drawStyle is a no-op there, so pass Fill explicitly or
+            // the label would be stroked white (a white outline) instead of filled.
             drawText(
                 textLayoutResult = measuredText,
                 color = textColor,
                 topLeft = topLeft,
+                drawStyle = Fill,
             )
         }
     }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/LocalStyleMap.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/LocalStyleMap.kt
@@ -1,0 +1,11 @@
+package warlockfe.warlock3.compose.util
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import warlockfe.warlock3.core.text.StyleDefinition
+
+/**
+ * The resolved style presets for the active character: the skin's default presets overridden by the
+ * user's saved presets (the same map that styles stream text, e.g. the user-configurable "link"
+ * preset). Provided where the presets flow is available; defaults to empty.
+ */
+val LocalStyleMap = staticCompositionLocalOf<Map<String, StyleDefinition>> { emptyMap() }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
@@ -51,6 +51,7 @@ import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.generated.resources.circle
 import warlockfe.warlock3.compose.generated.resources.circle_filled
 import warlockfe.warlock3.compose.ui.game.GameViewModel
+import warlockfe.warlock3.compose.util.LocalStyleMap
 import warlockfe.warlock3.compose.util.SAFE_DEFAULT_STYLE
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.core.client.WarlockAction
@@ -186,6 +187,7 @@ fun DesktopGameView(
                         settings = progressBarSettings,
                         saveColors = viewModel::saveProgressBarColors,
                     ),
+                LocalStyleMap provides presets,
             ) {
                 DesktopGameTextWindows(
                     modifier = Modifier.weight(1f).padding(2.dp),

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopDialogContent.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopDialogContent.kt
@@ -14,17 +14,23 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.LinkAnnotation
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
+import org.jetbrains.jewel.ui.component.Link
 import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.styling.LinkColors
+import org.jetbrains.jewel.ui.component.styling.LinkStyle
+import org.jetbrains.jewel.ui.component.styling.LinkUnderlineBehavior
 import org.jetbrains.jewel.ui.theme.defaultButtonStyle
+import org.jetbrains.jewel.ui.theme.linkStyle
 import warlockfe.warlock3.compose.desktop.components.DesktopColorPickerDialog
 import warlockfe.warlock3.compose.model.SkinObject
 import warlockfe.warlock3.compose.ui.window.DialogButton
@@ -32,6 +38,7 @@ import warlockfe.warlock3.compose.ui.window.DialogImage
 import warlockfe.warlock3.compose.ui.window.DialogObjectLayout
 import warlockfe.warlock3.compose.ui.window.DialogProgressBar
 import warlockfe.warlock3.compose.util.LocalSkin
+import warlockfe.warlock3.compose.util.LocalStyleMap
 import warlockfe.warlock3.compose.util.getColorGroup
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.core.client.DialogObject
@@ -40,11 +47,13 @@ import warlockfe.warlock3.core.text.WarlockColor
 import warlockfe.warlock3.core.util.getIgnoringCase
 import kotlin.io.encoding.Base64
 
-private val labelStyle =
-    TextStyle(
-        fontSize = 10.sp,
-        fontWeight = FontWeight.Medium,
-    )
+private val labelStyle
+    @Composable
+    get() =
+        JewelTheme.defaultTextStyle.copy(
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium,
+        )
 
 @Composable
 fun DesktopDialogContent(
@@ -173,6 +182,7 @@ private fun ProgressBarWithColorMenu(
             barColorOverride = barColor,
             backgroundColorOverride = backgroundColor,
             textColorOverride = textColor,
+            style = labelStyle,
         )
     }
 
@@ -222,25 +232,35 @@ private fun Link(
     data: DialogObject.Link,
     executeCommand: (String) -> Unit,
 ) {
-    val colorGroup = skinObject.getColorGroup()
-    Box(modifier = Modifier.padding(horizontal = 4.dp)) {
-        Text(
-            modifier = Modifier.align(Alignment.Center),
-            text =
-                buildAnnotatedString {
-                    pushLink(
-                        LinkAnnotation.Clickable("action") {
-                            executeCommand(data.cmd ?: "")
-                        },
-                    )
-                    append(data.value)
-                    pop()
-                },
-            color = colorGroup.text,
-            style = labelStyle,
-            maxLines = 1,
+    // A dialog link uses its skin-defined text color, falling back to the user-configurable "link"
+    // preset (the same one that styles links in the text stream), then to Jewel's themed link color.
+    // It keeps that color across the interactive states (the always-on underline is the affordance),
+    // dims a little while pressed, and fades further when disabled.
+    val linkPreset = LocalStyleMap.current.getIgnoringCase("link")
+    val presetColor = linkPreset?.textColor.toColor().takeOrElse { JewelTheme.linkStyle.colors.content }
+    val linkColor = skinObject.getColorGroup().text.takeOrElse { presetColor }
+    val colors =
+        LinkColors(
+            content = linkColor,
+            contentHovered = linkColor,
+            contentFocused = linkColor,
+            contentPressed = linkColor.copy(alpha = 0.7f),
+            contentVisited = linkColor,
+            contentDisabled = linkColor.copy(alpha = 0.4f),
         )
-    }
+    Link(
+        modifier = Modifier.padding(horizontal = 6.dp),
+        text = data.value ?: "",
+        onClick = { executeCommand(data.cmd ?: "") },
+        textStyle = labelStyle,
+        style =
+            LinkStyle(
+                colors = colors,
+                metrics = JewelTheme.linkStyle.metrics,
+                icons = JewelTheme.linkStyle.icons,
+                underlineBehavior = LinkUnderlineBehavior.ShowAlways,
+            ),
+    )
 }
 
 @Composable

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogContent.kt
@@ -7,14 +7,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.text.LinkAnnotation
-import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -51,6 +53,7 @@ fun DialogContent(
                     DialogProgressBar(
                         skinObject = skinObject,
                         data = data,
+                        style = MaterialTheme.typography.labelSmall,
                     )
                 }
 
@@ -98,7 +101,7 @@ fun DialogContent(
                             modifier = Modifier.align(Alignment.Center),
                             text = data.value ?: "",
                             color = MaterialTheme.colorScheme.onPrimaryContainer,
-                            style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                            style = MaterialTheme.typography.labelSmall,
                             maxLines = 1,
                         )
                     }
@@ -119,7 +122,7 @@ private fun Label(
             modifier = Modifier.align(Alignment.Center),
             text = data.value ?: "",
             color = colorGroup.text,
-            style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
+            style = MaterialTheme.typography.labelSmall,
             maxLines = 1,
         )
     }
@@ -131,23 +134,20 @@ private fun Link(
     data: DialogObject.Link,
     executeCommand: (String) -> Unit,
 ) {
-    val colorGroup = skinObject.getColorGroup()
-    Box(modifier = Modifier.padding(horizontal = 4.dp)) {
+    // Render a dialog link as a low-emphasis text button: no fill or border at rest, a primary-tinted
+    // state layer on hover/press, and a primary-colored label (falling back to any skin-defined color).
+    val accent = MaterialTheme.colorScheme.primary
+    val content = skinObject.getColorGroup().text.takeOrElse { accent }
+    TextButton(
+        modifier = Modifier.padding(horizontal = 6.dp),
+        onClick = { executeCommand(data.cmd ?: "") },
+    ) {
         Text(
-            modifier = Modifier.align(Alignment.Center),
-            text =
-                buildAnnotatedString {
-                    pushLink(
-                        LinkAnnotation.Clickable("action") {
-                            executeCommand(data.cmd ?: "")
-                        },
-                    )
-                    append(data.value)
-                    pop()
-                },
-            color = colorGroup.text,
-            style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
+            text = data.value ?: "",
+            color = content,
+            style = MaterialTheme.typography.labelSmall,
             maxLines = 1,
+            textDecoration = TextDecoration.Underline,
         )
     }
 }


### PR DESCRIPTION
Stacked on #174 (base is `mobile-shared-progress-bar`, not `master`, because the mobile `DialogContent` changes here build on that branch's progress-bar migration). It will re-target `master` automatically once #174 merges.

## Changes

**`DialogProgressBar` (commonMain)**
- Takes the label `TextStyle` from the caller, so each platform controls the font.
- Fixes the vital-bar label rendering as a **white outline on Android**. The fill draw reused the halo's measured text; Android's text paint is shared between draws and `setDrawStyle(null)` is a no-op there, so the fill inherited the halo's `Stroke`. Now passes `drawStyle = Fill` explicitly. (Desktop/Skia was unaffected.)

**Desktop dialog links** (`DesktopDialogContent`)
- Rendered as a Jewel `Link` (always-underlined, themed) instead of an unstyled annotated-string link (which got no color/underline).
- Color precedence: the dialog object's skin color → the **user-configurable "link" preset** (the same preset that styles stream-text links) → Jewel's themed link color.
- The resolved presets reach the dialog through a new `LocalStyleMap` composition local, provided by `DesktopGameView` alongside `LocalProgressBarColors`. Added to the compose-rules allowlist in `.editorconfig`.

**Mobile dialog links** (`DialogContent`)
- Rendered as a Material `TextButton` with an underline.

**Misc**
- Desktop dialog label style now derives from `JewelTheme.defaultTextStyle`.

## Test plan
- [x] `:compose:compileKotlinJvm`
- [x] `:compose:compileAndroidMain`
- [x] `:compose:ktlintCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)