### PR TITLE
Add a per-connection window title setting

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -217,6 +217,7 @@ abstract class AppContainer(
             progressBarSettingRepository = progressBarSettingRepository,
             clientSettingRepository = clientSettings,
             commandHistoryRepository = commandHistoryRepository,
+            connectionRepository = connectionRepository,
             ioDispatcher = ioDispatcher,
         )
     }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
@@ -396,6 +396,15 @@ class DashboardViewModel(
         }
     }
 
+    fun updateWindowTitle(
+        id: String,
+        windowTitle: String?,
+    ) {
+        viewModelScope.launch {
+            connectionRepository.saveWindowTitle(id, windowTitle)
+        }
+    }
+
     /** Persist a new ordering of the saved-connections list (after a drag-to-reorder). */
     fun reorderConnections(orderedIds: List<String>) {
         viewModelScope.launch {

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -76,6 +76,7 @@ import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterSettingsRepository
 import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
 import warlockfe.warlock3.core.prefs.repositories.CommandHistoryRepository
+import warlockfe.warlock3.core.prefs.repositories.ConnectionRepository
 import warlockfe.warlock3.core.prefs.repositories.DEFAULT_MAX_TYPE_AHEAD
 import warlockfe.warlock3.core.prefs.repositories.MAX_TYPE_AHEAD_KEY
 import warlockfe.warlock3.core.prefs.repositories.MacroRepository
@@ -118,6 +119,7 @@ class GameViewModel(
     private val progressBarSettingRepository: ProgressBarSettingRepository,
     private val clientSettingRepository: ClientSettingRepository,
     private val commandHistoryRepository: CommandHistoryRepository,
+    private val connectionRepository: ConnectionRepository,
     private val ioDispatcher: CoroutineDispatcher,
     private val reconnectAction: (suspend () -> Unit)? = null,
 ) : ViewModel(),
@@ -177,6 +179,17 @@ class GameViewModel(
                 null
             }
         }
+
+    // The connection's custom window title, or null to fall back to the character name. Reactive, so
+    // editing the connection while connected updates the title live.
+    val windowTitle: StateFlow<String?> =
+        observePerCharacter { characterId ->
+            connectionRepository.observeWindowTitle(characterId)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Lazily,
+            initialValue = null,
+        )
 
     val windowSettings =
         observePerCharacter { characterId ->

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModelFactory.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModelFactory.kt
@@ -7,6 +7,7 @@ import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.CharacterSettingsRepository
 import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
 import warlockfe.warlock3.core.prefs.repositories.CommandHistoryRepository
+import warlockfe.warlock3.core.prefs.repositories.ConnectionRepository
 import warlockfe.warlock3.core.prefs.repositories.MacroRepository
 import warlockfe.warlock3.core.prefs.repositories.PresetRepository
 import warlockfe.warlock3.core.prefs.repositories.ProgressBarSettingRepository
@@ -27,6 +28,7 @@ class GameViewModelFactory(
     private val progressBarSettingRepository: ProgressBarSettingRepository,
     private val clientSettingRepository: ClientSettingRepository,
     private val commandHistoryRepository: CommandHistoryRepository,
+    private val connectionRepository: ConnectionRepository,
     private val ioDispatcher: CoroutineDispatcher,
 ) {
     fun create(
@@ -48,6 +50,7 @@ class GameViewModelFactory(
             progressBarSettingRepository = progressBarSettingRepository,
             clientSettingRepository = clientSettingRepository,
             commandHistoryRepository = commandHistoryRepository,
+            connectionRepository = connectionRepository,
             ioDispatcher = ioDispatcher,
             reconnectAction = reconnect,
         )

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopConnectionSettingsDialog.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopConnectionSettingsDialog.kt
@@ -28,13 +28,16 @@ import warlockfe.warlock3.core.sge.ConnectionProxySettings
 @Composable
 fun DesktopConnectionSettingsDialog(
     name: String,
+    windowTitle: String?,
     proxySettings: ConnectionProxySettings,
     updateName: (String) -> Unit,
+    updateWindowTitle: (String?) -> Unit,
     updateProxySettings: (ConnectionProxySettings) -> Unit,
     closeDialog: () -> Unit,
 ) {
     var proxyEnabled by rememberSaveable(proxySettings) { mutableStateOf(proxySettings.enabled) }
     val nameState = rememberTextFieldState(name)
+    val windowTitleState = rememberTextFieldState(windowTitle ?: "")
     val proxyCommand = rememberTextFieldState(proxySettings.launchCommand ?: "")
     val proxyHost = rememberTextFieldState(proxySettings.host ?: "")
     val proxyPort = rememberTextFieldState(proxySettings.port ?: "")
@@ -52,6 +55,13 @@ fun DesktopConnectionSettingsDialog(
         ) {
             Text("Name")
             WarlockTextField(state = nameState, modifier = Modifier.fillMaxWidth())
+
+            Text("Window title")
+            WarlockTextField(
+                state = windowTitleState,
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = "Leave blank to use the character name",
+            )
 
             Text(
                 "In the following settings, \"{host}\" and \"{port}\" are replaced by the values for the game server. " +
@@ -96,6 +106,11 @@ fun DesktopConnectionSettingsDialog(
                             val newName = nameState.text.toString().trim()
                             if (newName.isNotEmpty() && newName != name) {
                                 updateName(newName)
+                            }
+                            val trimmedTitle = windowTitleState.text.toString().trim()
+                            val newWindowTitle = trimmedTitle.ifBlank { null }
+                            if (newWindowTitle != windowTitle) {
+                                updateWindowTitle(newWindowTitle)
                             }
                             updateProxySettings(
                                 ConnectionProxySettings(

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopDashboardView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopDashboardView.kt
@@ -571,8 +571,10 @@ private fun DashboardDialogs(
     ui.editConnection?.let { connection ->
         DesktopConnectionSettingsDialog(
             name = connection.name,
+            windowTitle = connection.windowTitle,
             proxySettings = connection.proxySettings,
             updateName = { viewModel.renameConnection(connection.id, it) },
+            updateWindowTitle = { viewModel.updateWindowTitle(connection.id, it) },
             updateProxySettings = { viewModel.updateProxySettings(connection.id, it) },
             closeDialog = { ui.editConnection = null },
         )

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/ConnectionSettingsDialog.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/ConnectionSettingsDialog.kt
@@ -27,13 +27,16 @@ import warlockfe.warlock3.core.sge.ConnectionProxySettings
 @Composable
 fun ConnectionSettingsDialog(
     name: String,
+    windowTitle: String?,
     proxySettings: ConnectionProxySettings,
     updateName: (String) -> Unit,
+    updateWindowTitle: (String?) -> Unit,
     updateProxySettings: (ConnectionProxySettings) -> Unit,
     closeDialog: () -> Unit,
 ) {
     var proxyEnabled by rememberSaveable(proxySettings) { mutableStateOf(proxySettings.enabled) }
     val nameState = rememberTextFieldState(name)
+    val windowTitleState = rememberTextFieldState(windowTitle ?: "")
     val proxyCommand = rememberTextFieldState(proxySettings.launchCommand ?: "")
     val proxyHost = rememberTextFieldState(proxySettings.host ?: "")
     val proxyPort = rememberTextFieldState(proxySettings.port ?: "")
@@ -47,6 +50,11 @@ fun ConnectionSettingsDialog(
                         val newName = nameState.text.toString().trim()
                         if (newName.isNotEmpty() && newName != name) {
                             updateName(newName)
+                        }
+                        val trimmedTitle = windowTitleState.text.toString().trim()
+                        val newWindowTitle = trimmedTitle.ifBlank { null }
+                        if (newWindowTitle != windowTitle) {
+                            updateWindowTitle(newWindowTitle)
                         }
                         updateProxySettings(
                             ConnectionProxySettings(
@@ -71,6 +79,16 @@ fun ConnectionSettingsDialog(
                     state = nameState,
                     label = {
                         Text("Name")
+                    },
+                    lineLimits = TextFieldLineLimits.SingleLine,
+                )
+                TextField(
+                    state = windowTitleState,
+                    label = {
+                        Text("Window title")
+                    },
+                    placeholder = {
+                        Text("Leave blank to use the character name")
                     },
                     lineLimits = TextFieldLineLimits.SingleLine,
                 )

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardView.kt
@@ -149,9 +149,13 @@ fun ConnectionList(
     if (editingConnection != null) {
         ConnectionSettingsDialog(
             name = editingConnection.name,
+            windowTitle = editingConnection.windowTitle,
             proxySettings = editingConnection.proxySettings,
             updateName = {
                 viewModel.renameConnection(editingConnection.id, it)
+            },
+            updateWindowTitle = {
+                viewModel.updateWindowTitle(editingConnection.id, it)
             },
             updateProxySettings = {
                 viewModel.updateProxySettings(editingConnection.id, it)

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigMappers.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigMappers.kt
@@ -239,6 +239,7 @@ internal fun ConnectionConfig.toStoredConnection(password: String?): StoredConne
         password = password,
         character = character,
         code = gameCode,
+        windowTitle = windowTitle,
         proxySettings =
             ConnectionProxySettings(
                 enabled = proxyEnabled,

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
@@ -309,6 +309,8 @@ data class ConnectionConfig(
     val username: String = "",
     val gameCode: String = "",
     val character: String = "",
+    @TomlComment("When set, the game window shows \"Warlock - <this>\" instead of the character name.")
+    val windowTitle: String? = null,
     val proxyEnabled: Boolean = false,
     val proxyLaunchCommand: String? = null,
     val proxyHost: String? = null,

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ConnectionRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ConnectionRepository.kt
@@ -43,6 +43,30 @@ class ConnectionRepository(
         }
     }
 
+    suspend fun saveWindowTitle(
+        id: String,
+        windowTitle: String?,
+    ) {
+        store.mutateConnections { registry ->
+            registry.copy(
+                connections = registry.connections.map { if (it.id == id) it.copy(windowTitle = windowTitle) else it },
+            )
+        }
+    }
+
+    /**
+     * The custom window title for the connected character, or null if none is set (or it's blank).
+     * Matched by `game:character` rather than connection id, since that's how the runtime character id
+     * is formed (so it resolves for both direct play.net and MUD Mobile connections).
+     */
+    fun observeWindowTitle(characterId: String): Flow<String?> =
+        store.observeConnections().map { registry ->
+            registry.connections
+                .firstOrNull { "${it.gameCode}:${it.character}".lowercase() == characterId }
+                ?.windowTitle
+                ?.takeIf { it.isNotBlank() }
+        }
+
     suspend fun save(
         username: String,
         character: String,

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ConnectionSettingsRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ConnectionSettingsRepository.kt
@@ -26,15 +26,21 @@ class ConnectionSettingsRepository(
         proxySettings: ConnectionProxySettings,
     ) {
         store.mutateConnections { registry ->
-            val existing = registry.connections.firstOrNull { it.id == connectionId } ?: ConnectionConfig(id = connectionId)
-            val updated =
-                existing.copy(
+            fun ConnectionConfig.withProxy() =
+                copy(
                     proxyEnabled = proxySettings.enabled,
                     proxyLaunchCommand = proxySettings.launchCommand,
                     proxyHost = proxySettings.host,
                     proxyPort = proxySettings.port,
                 )
-            registry.copy(connections = registry.connections.filterNot { it.id == connectionId } + updated)
+            if (registry.connections.any { it.id == connectionId }) {
+                // Update in place so the connection keeps its position in the list.
+                registry.copy(
+                    connections = registry.connections.map { if (it.id == connectionId) it.withProxy() else it },
+                )
+            } else {
+                registry.copy(connections = registry.connections + ConnectionConfig(id = connectionId).withProxy())
+            }
         }
     }
 }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/sge/StoredConnection.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/sge/StoredConnection.kt
@@ -7,6 +7,8 @@ data class StoredConnection(
     val password: String?,
     val character: String,
     val code: String,
+    // When set, the game window title shows "Warlock - <windowTitle>" instead of the character name.
+    val windowTitle: String? = null,
     val proxySettings: ConnectionProxySettings,
     // When true, this connection is played through MUD Mobile's hosted Lich rather than directly
     // to play.net. [characterCode] is the EAccess character code (known for MUD Mobile profiles).

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -57,6 +57,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -656,7 +657,12 @@ private fun GameState.getTitle(): Flow<String> =
         }
 
         is GameScreen.ConnectedGameState -> {
-            screen.viewModel.character.map { it?.name ?: "Loading..." }
+            combine(
+                screen.viewModel.windowTitle,
+                screen.viewModel.character,
+            ) { windowTitle, character ->
+                windowTitle ?: character?.name ?: "Loading..."
+            }
         }
 
         is GameScreen.NewGameState -> {


### PR DESCRIPTION
## Summary
- Adds an optional **Window title** field to connections, editable in both the desktop (`DesktopConnectionSettingsDialog`) and mobile (`ConnectionSettingsDialog`) connection editor dialogs.
- When set to a non-blank value, the connected game window shows `Warlock - <window title>` instead of the character name.
- The value persists on the connection in `connections.toml` (`ConnectionConfig.windowTitle`) and flows through to the `StoredConnection` domain model.
- At runtime it's resolved by `ConnectionRepository.observeWindowTitle(characterId)`, matching on `game:character` (the same shape as the runtime character id) so it works for both direct play.net and MUD Mobile connections, and is applied reactively via `GameViewModel.windowTitle` so editing it while connected updates the title live.
- Also fixes `ConnectionSettingsRepository.saveProxySettings` reordering the connection to the bottom of the list on every edit (the dialog always calls it on OK); it now updates the entry in place, preserving list order.

## How it works
`Main.kt`'s `getTitle()` emits the window title when present, otherwise the character name; the existing `"Warlock - $subtitle"` prefix produces the final title.

## Testing
- `:desktopApp:compileKotlin` and `:compose:compileAndroidMain` compile (covers common/jvm/mobile source sets).
- `ktlintCheck` passes for `core`, `compose`, and `desktopApp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)