### PR TITLE
Game screen: show all active indicators (skin-positioned) + mobile button compass

### DIFF
--- a/compose/skin/skin.json
+++ b/compose/skin/skin.json
@@ -281,19 +281,21 @@
     }
   },
   "indicator": {
+    "width": 24,
+    "height": 24,
     "children": {
       "kneeling": { "image": { "name": "kneeling" } },
       "prone": { "image": { "name": "prone" } },
       "sitting": { "image": { "name": "sitting" } },
       "standing": { "image": { "name": "standing" } },
-      "poisoned": { "image": { "name": "poisoned" } },
-      "diseased": { "image": { "name": "diseased" } },
+      "poisoned": { "image": { "name": "poisoned" }, "top": 13, "left": 0, "width": 11, "height": 11 },
+      "diseased": { "image": { "name": "diseased" }, "top": 13, "left": 13, "width": 11, "height": 11 },
       "joined": { "image": { "name": "joined" } },
       "bleeding": { "image": { "name": "local_hospital" } },
-      "dead": { "image": { "name": "death" } },
+      "dead": { "image": { "name": "death" }, "top": 0, "left": 13, "width": 11, "height": 11 },
       "invisible": { "image": { "name": "invisible" } },
-      "hidden": { "image": { "name": "hidden" } },
-      "webbed": { "image": { "name": "webbed" } },
+      "hidden": { "image": { "name": "hidden" }, "top": 0, "left": 13, "width": 11, "height": 11 },
+      "webbed": { "image": { "name": "webbed" }, "top": 13, "left": 13, "width": 11, "height": 11 },
       "stunned": { "image": { "name": "stunned" } }
     }
   }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/components/CompassButtons.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/components/CompassButtons.kt
@@ -1,0 +1,185 @@
+package warlockfe.warlock3.compose.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.painterResource
+import warlockfe.warlock3.compose.generated.resources.Res
+import warlockfe.warlock3.compose.generated.resources.arrow_right_alt
+import warlockfe.warlock3.compose.generated.resources.logout
+import warlockfe.warlock3.core.compass.Direction
+
+/** Colors for [CompassButtons]: a "lit" available direction versus a dim unavailable one. */
+data class CompassButtonColors(
+    val litBackground: Color,
+    val litBorder: Color,
+    val litIcon: Color,
+    val background: Color,
+    val border: Color,
+    val icon: Color,
+)
+
+/**
+ * A grid of tappable direction buttons: the eight compass points around a central "out", with up and
+ * down in their own column. Available [directions] are lit and clickable; unavailable ones are dim.
+ * Clicking a lit direction invokes [onClick] with that [Direction].
+ */
+@Composable
+fun CompassButtons(
+    height: Dp,
+    directions: Set<Direction>,
+    onClick: (Direction) -> Unit,
+    colors: CompassButtonColors,
+    modifier: Modifier = Modifier,
+) {
+    val available = remember(directions) { directions.map { it.value.lowercase() }.toSet() }
+    val gap = 3.dp
+    // Icon sizes as a fixed fraction of the cell height: the rotated direction arrows and the
+    // central "out" glyph.
+    val arrowIconSize = height / 4
+    val outIconSize = height / 5
+
+    Row(modifier, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+        // 3x3 grid of the eight compass points around a central "out".
+        Column(
+            modifier = Modifier.size(height),
+            verticalArrangement = Arrangement.spacedBy(gap),
+        ) {
+            // Each direction is the arrow_right_alt icon (pointing east) rotated clockwise from 0deg.
+            // "out" has no arrow - it renders the logout icon instead, see below - hence the null.
+            val rows: List<List<Pair<String, Float?>>> =
+                listOf(
+                    listOf("nw" to 225f, "n" to 270f, "ne" to 315f),
+                    listOf("w" to 180f, "out" to null, "e" to 0f),
+                    listOf("sw" to 135f, "s" to 90f, "se" to 45f),
+                )
+            rows.forEach { row ->
+                Row(
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    horizontalArrangement = Arrangement.spacedBy(gap),
+                ) {
+                    row.forEach { (value, rotation) ->
+                        CompassCell(
+                            modifier = Modifier.fillMaxHeight().weight(1f),
+                            lit = available.contains(value),
+                            colors = colors,
+                            onClick = { onClick(Direction(value)) },
+                        ) { contentColor ->
+                            if (rotation == null) {
+                                // "Out" of the room reads as a door with an arrow leaving it
+                                // (Material Symbols "logout").
+                                Image(
+                                    modifier = Modifier.size(outIconSize),
+                                    painter = painterResource(Res.drawable.logout),
+                                    colorFilter = ColorFilter.tint(contentColor),
+                                    contentDescription = "out",
+                                )
+                            } else {
+                                DirectionArrow(
+                                    rotationDegrees = rotation,
+                                    size = arrowIconSize,
+                                    color = contentColor,
+                                    contentDescription = value,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Up / down sit in their own column, as in the design.
+        Column(
+            modifier = Modifier.height(height).width(height * 0.36f),
+            verticalArrangement = Arrangement.spacedBy(gap),
+        ) {
+            CompassCell(
+                modifier = Modifier.fillMaxWidth().weight(1f),
+                lit = available.contains("up"),
+                colors = colors,
+                onClick = { onClick(Direction("up")) },
+            ) { contentColor ->
+                DirectionArrow(
+                    rotationDegrees = 270f,
+                    size = arrowIconSize,
+                    color = contentColor,
+                    contentDescription = "up",
+                )
+            }
+            CompassCell(
+                modifier = Modifier.fillMaxWidth().weight(1f),
+                lit = available.contains("down"),
+                colors = colors,
+                onClick = { onClick(Direction("down")) },
+            ) { contentColor ->
+                DirectionArrow(
+                    rotationDegrees = 90f,
+                    size = arrowIconSize,
+                    color = contentColor,
+                    contentDescription = "down",
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CompassCell(
+    lit: Boolean,
+    colors: CompassButtonColors,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable (contentColor: Color) -> Unit,
+) {
+    val shape = RoundedCornerShape(4.dp)
+    Box(
+        modifier =
+            modifier
+                .clip(shape)
+                .background(if (lit) colors.litBackground else colors.background)
+                .border(
+                    width = Dp.Hairline,
+                    color = if (lit) colors.litBorder else colors.border,
+                    shape = shape,
+                ).then(if (lit) Modifier.clickable(onClick = onClick) else Modifier),
+        contentAlignment = Alignment.Center,
+    ) {
+        content(if (lit) colors.litIcon else colors.icon)
+    }
+}
+
+/** A compass direction arrow: the east-pointing [arrow_right_alt] rotated [rotationDegrees] clockwise. */
+@Composable
+private fun DirectionArrow(
+    rotationDegrees: Float,
+    size: Dp,
+    color: Color,
+    contentDescription: String,
+) {
+    Image(
+        modifier = Modifier.size(size).rotate(rotationDegrees),
+        painter = painterResource(Res.drawable.arrow_right_alt),
+        colorFilter = ColorFilter.tint(color),
+        contentDescription = contentDescription,
+    )
+}

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/IndicatorImages.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/IndicatorImages.kt
@@ -1,0 +1,48 @@
+package warlockfe.warlock3.compose.util
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.DrawableResource
+import warlockfe.warlock3.compose.generated.resources.Res
+import warlockfe.warlock3.compose.generated.resources.allDrawableResources
+import warlockfe.warlock3.compose.model.SkinObject
+import warlockfe.warlock3.core.util.getIgnoringCase
+
+/** The skin's "indicator" entry for a status (its image + optional position), or null. */
+fun Map<String, SkinObject>.indicatorEntry(status: String): SkinObject? = getIgnoringCase("indicator")?.children?.getIgnoringCase(status)
+
+/** The reference box size the indicator offsets are authored against (the skin's panel size; 24 by default). */
+fun Map<String, SkinObject>.indicatorReference(): Int {
+    val panel = getIgnoringCase("indicator")
+    return panel?.width ?: panel?.height ?: 24
+}
+
+/** The drawable a skin "indicator" entry points at via its image `name`, or null. */
+fun SkinObject?.indicatorDrawable(): DrawableResource? = this?.image?.name?.let { Res.allDrawableResources[it] }
+
+/** Convenience: the drawable for a status, resolved through the skin's "indicator" section. */
+fun Map<String, SkinObject>.indicatorDrawable(status: String): DrawableResource? = indicatorEntry(status).indicatorDrawable()
+
+/**
+ * Places one status icon inside its indicator box. Skin offsets ([SkinObject.top]/[left][SkinObject.left]/
+ * [width][SkinObject.width]/[height][SkinObject.height]) are authored against a [reference]-unit box
+ * and scaled to the actual [boxSize], so several active statuses can sit side by side. An entry with
+ * no offsets fills the box (the single-status case).
+ */
+fun indicatorIconModifier(
+    entry: SkinObject,
+    boxSize: Dp,
+    reference: Int,
+): Modifier {
+    val positioned = entry.top != null || entry.left != null || entry.width != null || entry.height != null
+    if (!positioned) return Modifier.fillMaxSize().padding(boxSize / 6f)
+    val scale = boxSize / reference.dp
+    return Modifier
+        .offset(x = ((entry.left ?: 0) * scale).dp, y = ((entry.top ?: 0) * scale).dp)
+        .size(width = ((entry.width ?: reference) * scale).dp, height = ((entry.height ?: reference) * scale).dp)
+}

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopCompass.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopCompass.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.jewel.ui.component.Text
+import warlockfe.warlock3.compose.components.CompassButtonColors
+import warlockfe.warlock3.compose.components.CompassButtons
 import warlockfe.warlock3.compose.components.CompassView
 import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.generated.resources.arrow_right_alt
@@ -78,10 +80,20 @@ fun DesktopCompass(
     ) {
         when (style) {
             CompassStyle.BUTTONS -> {
+                val chrome = gameChrome
                 CompassButtons(
                     height = height,
                     directions = directions,
                     onClick = onClick,
+                    colors =
+                        CompassButtonColors(
+                            litBackground = chrome.litBackground,
+                            litBorder = chrome.litBorder,
+                            litIcon = chrome.litIcon,
+                            background = chrome.panelAlt,
+                            border = chrome.border,
+                            icon = chrome.compassDarkIcon,
+                        ),
                 )
             }
 
@@ -184,139 +196,4 @@ private fun CompassStyleMenuItem(
         Spacer(Modifier.width(10.dp))
         Text(text = label, color = gameChrome.textPrimary)
     }
-}
-
-@Composable
-private fun CompassButtons(
-    height: Dp,
-    directions: Set<Direction>,
-    onClick: (Direction) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val available = remember(directions) { directions.map { it.value.lowercase() }.toSet() }
-    val gap = 3.dp
-    // Icon sizes as a fixed fraction of the cell height: the rotated direction arrows and the
-    // central "out" glyph.
-    val arrowIconSize = height / 4
-    val outIconSize = height / 5
-
-    Row(modifier, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
-        // 3x3 grid of the eight compass points around a central "out".
-        Column(
-            modifier = Modifier.size(height),
-            verticalArrangement = Arrangement.spacedBy(gap),
-        ) {
-            // Each direction is the arrow_right_alt icon (pointing east) rotated clockwise from 0deg.
-            // "out" has no arrow - it renders the logout icon instead, see below - hence the null.
-            val rows: List<List<Pair<String, Float?>>> =
-                listOf(
-                    listOf("nw" to 225f, "n" to 270f, "ne" to 315f),
-                    listOf("w" to 180f, "out" to null, "e" to 0f),
-                    listOf("sw" to 135f, "s" to 90f, "se" to 45f),
-                )
-            rows.forEach { row ->
-                Row(
-                    modifier = Modifier.fillMaxWidth().weight(1f),
-                    horizontalArrangement = Arrangement.spacedBy(gap),
-                ) {
-                    row.forEach { (value, rotation) ->
-                        CompassCell(
-                            modifier = Modifier.fillMaxHeight().weight(1f),
-                            lit = available.contains(value),
-                            onClick = { onClick(Direction(value)) },
-                        ) { contentColor ->
-                            if (rotation == null) {
-                                // "Out" of the room reads as a door with an arrow leaving it
-                                // (Material Symbols "logout").
-                                Image(
-                                    modifier = Modifier.size(outIconSize),
-                                    painter = painterResource(Res.drawable.logout),
-                                    colorFilter = ColorFilter.tint(contentColor),
-                                    contentDescription = "out",
-                                )
-                            } else {
-                                DirectionArrow(
-                                    rotationDegrees = rotation,
-                                    size = arrowIconSize,
-                                    color = contentColor,
-                                    contentDescription = value,
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        // Up / down sit in their own column, as in the design.
-        Column(
-            modifier = Modifier.height(height).width(height * 0.36f),
-            verticalArrangement = Arrangement.spacedBy(gap),
-        ) {
-            CompassCell(
-                modifier = Modifier.fillMaxWidth().weight(1f),
-                lit = available.contains("up"),
-                onClick = { onClick(Direction("up")) },
-            ) { contentColor ->
-                DirectionArrow(
-                    rotationDegrees = 270f,
-                    size = arrowIconSize,
-                    color = contentColor,
-                    contentDescription = "up",
-                )
-            }
-            CompassCell(
-                modifier = Modifier.fillMaxWidth().weight(1f),
-                lit = available.contains("down"),
-                onClick = { onClick(Direction("down")) },
-            ) { contentColor ->
-                DirectionArrow(
-                    rotationDegrees = 90f,
-                    size = arrowIconSize,
-                    color = contentColor,
-                    contentDescription = "down",
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun CompassCell(
-    lit: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable (contentColor: Color) -> Unit,
-) {
-    val shape = RoundedCornerShape(4.dp)
-    Box(
-        modifier =
-            modifier
-                .clip(shape)
-                .background(
-                    if (lit) gameChrome.litBackground else gameChrome.panelAlt,
-                ).border(
-                    width = Dp.Hairline,
-                    color = if (lit) gameChrome.litBorder else gameChrome.border,
-                    shape = shape,
-                ).then(if (lit) Modifier.clickable(onClick = onClick) else Modifier),
-        contentAlignment = Alignment.Center,
-    ) {
-        content(if (lit) gameChrome.litIcon else gameChrome.compassDarkIcon)
-    }
-}
-
-/** A compass direction arrow: the east-pointing [arrow_right_alt] rotated [rotationDegrees] clockwise. */
-@Composable
-private fun DirectionArrow(
-    rotationDegrees: Float,
-    size: Dp,
-    color: Color,
-    contentDescription: String,
-) {
-    Image(
-        modifier = Modifier.size(size).rotate(rotationDegrees),
-        painter = painterResource(Res.drawable.arrow_right_alt),
-        colorFilter = ColorFilter.tint(color),
-        contentDescription = contentDescription,
-    )
 }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopIndicatorView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopIndicatorView.kt
@@ -6,29 +6,28 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
-import warlockfe.warlock3.compose.generated.resources.Res
-import warlockfe.warlock3.compose.generated.resources.allDrawableResources
-import warlockfe.warlock3.compose.model.SkinObject
 import warlockfe.warlock3.compose.util.LocalSkin
-import warlockfe.warlock3.core.util.getIgnoringCase
+import warlockfe.warlock3.compose.util.indicatorDrawable
+import warlockfe.warlock3.compose.util.indicatorEntry
+import warlockfe.warlock3.compose.util.indicatorIconModifier
+import warlockfe.warlock3.compose.util.indicatorReference
 
 /**
- * The five grouped status slots on the right of the control bar. Each group shows at most one active
- * status; an active slot is tinted with an accent (amber for posture/concealment, red for health),
- * an inactive slot is an empty bordered box.
+ * The five grouped status slots on the right of the control bar. Every active status in a slot is
+ * drawn at its skin-defined position, so co-active statuses (e.g. a posture plus poisoned) are all
+ * visible at once; a status with no skin offset fills the box (the single-status case). The slot's
+ * highest-priority active status colors the box (amber for posture/concealment, red for health) and
+ * each icon keeps its own accent tint; an inactive slot is an empty bordered box.
  */
 @Composable
 fun DesktopIndicatorView(
@@ -36,11 +35,9 @@ fun DesktopIndicatorView(
     indicators: Set<String>,
     modifier: Modifier = Modifier,
 ) {
-    // Grouping and priority stay in code; the image used for each status is looked up from the skin's
-    // "indicator" section (status name -> SkinImage referencing a drawable). Posture and affliction
-    // share the first slot and only the first matching status in a group is shown, so affliction is
-    // listed before posture: a posture (usually "standing") is almost always present and would
-    // otherwise permanently mask the more important poisoned/diseased warning.
+    // Grouping and priority stay in code; the per-status image and position come from the skin's
+    // "indicator" section. Affliction is listed before posture so the box takes the danger color (and
+    // poisoned/diseased are never dropped) even though a posture is almost always present too.
     val groups: List<List<String>> =
         listOf(
             listOf("poisoned", "diseased", "kneeling", "prone", "sitting", "standing"),
@@ -51,41 +48,38 @@ fun DesktopIndicatorView(
         )
 
     val chrome = gameChrome
-    val indicatorImages = LocalSkin.current.getIgnoringCase("indicator")?.children
+    val skin = LocalSkin.current
+    val reference = skin.indicatorReference()
     val shape = RoundedCornerShape(5.dp)
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         groups.forEach { group ->
-            val activeKey = group.firstOrNull { indicators.contains(it) }
-            val accent = activeKey?.let { indicatorAccent(it, chrome) } ?: inactiveAccent(chrome)
+            val active = group.filter { indicators.contains(it) }
+            val accent = active.firstOrNull()?.let { indicatorAccent(it, chrome) } ?: inactiveAccent(chrome)
             Box(
                 modifier =
                     Modifier
                         .size(indicatorSize)
+                        .clip(shape)
                         .background(accent.background, shape)
-                        .border(width = Dp.Hairline, color = accent.border, shape = shape)
-                        .padding(indicatorSize / 6f),
-                contentAlignment = Alignment.Center,
+                        .border(width = Dp.Hairline, color = accent.border, shape = shape),
             ) {
-                val drawable = activeKey?.let { indicatorImages?.indicatorDrawable(it) }
-                if (activeKey != null && drawable != null) {
+                active.forEach { status ->
+                    val entry = skin.indicatorEntry(status) ?: return@forEach
+                    val drawable = entry.indicatorDrawable() ?: return@forEach
                     Image(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = indicatorIconModifier(entry, indicatorSize, reference),
                         painter = painterResource(drawable),
-                        colorFilter = accent.iconTint?.let { ColorFilter.tint(it) },
-                        contentDescription = activeKey,
+                        colorFilter = indicatorAccent(status, chrome).iconTint?.let { ColorFilter.tint(it) },
+                        contentDescription = status,
                     )
                 }
             }
         }
     }
 }
-
-/** Resolves a status key to its drawable via the skin's "indicator" section (the image `name`). */
-private fun Map<String, SkinObject>.indicatorDrawable(status: String): DrawableResource? =
-    getIgnoringCase(status)?.image?.name?.let { Res.allDrawableResources[it] }
 
 private data class IndicatorAccent(
     val border: Color,

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/ConnectionSettingsDialog.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/ConnectionSettingsDialog.kt
@@ -51,7 +51,10 @@ fun ConnectionSettingsDialog(
                         updateProxySettings(
                             ConnectionProxySettings(
                                 enabled = proxyEnabled,
-                                launchCommand = proxyCommand.text.toString().ifBlank { null },
+                                launchCommand =
+                                    proxyCommand.text
+                                        .toString()
+                                        .ifBlank { null },
                                 host = proxyHost.text.toString().ifBlank { null },
                                 port = proxyPort.text.toString().ifBlank { null },
                             ),

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/ConditionChips.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/ConditionChips.kt
@@ -18,49 +18,23 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
-import warlockfe.warlock3.compose.generated.resources.Res
-import warlockfe.warlock3.compose.generated.resources.death
-import warlockfe.warlock3.compose.generated.resources.diseased
-import warlockfe.warlock3.compose.generated.resources.hidden
-import warlockfe.warlock3.compose.generated.resources.invisible
-import warlockfe.warlock3.compose.generated.resources.joined
-import warlockfe.warlock3.compose.generated.resources.kneeling
-import warlockfe.warlock3.compose.generated.resources.local_hospital
-import warlockfe.warlock3.compose.generated.resources.poisoned
-import warlockfe.warlock3.compose.generated.resources.prone
-import warlockfe.warlock3.compose.generated.resources.sitting
-import warlockfe.warlock3.compose.generated.resources.standing
-import warlockfe.warlock3.compose.generated.resources.stunned
-import warlockfe.warlock3.compose.generated.resources.webbed
+import warlockfe.warlock3.compose.util.LocalSkin
+import warlockfe.warlock3.compose.util.indicatorDrawable
 
-private enum class ConditionSeverity { Posture, Danger, Warn, Info }
+// Enum order is the chip display order (chips are grouped by severity, calm to dangerous).
+private enum class ConditionSeverity { Posture, Info, Warn, Danger }
 
-private data class ConditionInfo(
-    val label: String,
-    val icon: DrawableResource,
-    val severity: ConditionSeverity,
-)
-
-// Known status indicators -> chip label, icon (reusing the existing indicator drawables) and a
-// tonal severity. Iteration order here is the chip display order.
-private val conditionInfo: Map<String, ConditionInfo> =
-    mapOf(
-        "standing" to ConditionInfo("standing", Res.drawable.standing, ConditionSeverity.Posture),
-        "kneeling" to ConditionInfo("kneeling", Res.drawable.kneeling, ConditionSeverity.Posture),
-        "prone" to ConditionInfo("prone", Res.drawable.prone, ConditionSeverity.Posture),
-        "sitting" to ConditionInfo("sitting", Res.drawable.sitting, ConditionSeverity.Posture),
-        "joined" to ConditionInfo("joined", Res.drawable.joined, ConditionSeverity.Info),
-        "hidden" to ConditionInfo("hidden", Res.drawable.hidden, ConditionSeverity.Info),
-        "invisible" to ConditionInfo("invisible", Res.drawable.invisible, ConditionSeverity.Info),
-        "webbed" to ConditionInfo("webbed", Res.drawable.webbed, ConditionSeverity.Warn),
-        "stunned" to ConditionInfo("stunned", Res.drawable.stunned, ConditionSeverity.Warn),
-        "poisoned" to ConditionInfo("poisoned", Res.drawable.poisoned, ConditionSeverity.Danger),
-        "diseased" to ConditionInfo("diseased", Res.drawable.diseased, ConditionSeverity.Danger),
-        "bleeding" to ConditionInfo("bleeding", Res.drawable.local_hospital, ConditionSeverity.Danger),
-        "dead" to ConditionInfo("dead", Res.drawable.death, ConditionSeverity.Danger),
-    )
+// Maps a known status indicator to its chip severity (tone); unknown indicators get no chip. The
+// chip label is the status name and the icon comes from the skin's "indicator" section.
+private fun conditionSeverity(status: String): ConditionSeverity? =
+    when (status) {
+        "standing", "kneeling", "prone", "sitting" -> ConditionSeverity.Posture
+        "joined", "hidden", "invisible" -> ConditionSeverity.Info
+        "webbed", "stunned" -> ConditionSeverity.Warn
+        "poisoned", "diseased", "bleeding", "dead" -> ConditionSeverity.Danger
+        else -> null
+    }
 
 /**
  * The active status indicators rendered as M3 tonal chips (icon + label), used by the phone status
@@ -72,20 +46,27 @@ fun ConditionChips(
     indicators: Set<String>,
     modifier: Modifier = Modifier,
 ) {
-    val active = conditionInfo.filterKeys { indicators.contains(it) }.values.toList()
+    val active =
+        indicators
+            .mapNotNull { status -> conditionSeverity(status)?.let { status to it } }
+            .sortedBy { it.second.ordinal }
     if (active.isEmpty()) return
     FlowRow(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        active.forEach { info -> ConditionChip(info) }
+        active.forEach { (status, severity) -> ConditionChip(status, severity) }
     }
 }
 
 @Composable
-private fun ConditionChip(info: ConditionInfo) {
-    val (container, content) = severityColors(info.severity)
+private fun ConditionChip(
+    status: String,
+    severity: ConditionSeverity,
+) {
+    val (container, content) = severityColors(severity)
+    val icon = LocalSkin.current.indicatorDrawable(status)
     Row(
         modifier =
             Modifier
@@ -96,13 +77,15 @@ private fun ConditionChip(info: ConditionInfo) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(5.dp),
     ) {
-        Icon(
-            modifier = Modifier.size(16.dp),
-            painter = painterResource(info.icon),
-            contentDescription = null,
-            tint = content,
-        )
-        Text(text = info.label, color = content, style = MaterialTheme.typography.labelMedium)
+        if (icon != null) {
+            Icon(
+                modifier = Modifier.size(16.dp),
+                painter = painterResource(icon),
+                contentDescription = null,
+                tint = content,
+            )
+        }
+        Text(text = status, color = content, style = MaterialTheme.typography.labelMedium)
     }
 }
 

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
@@ -48,7 +48,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
-import warlockfe.warlock3.compose.components.CompassView
+import warlockfe.warlock3.compose.components.CompassButtonColors
+import warlockfe.warlock3.compose.components.CompassButtons
 import warlockfe.warlock3.compose.components.ScrollableColumn
 import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.generated.resources.circle
@@ -462,12 +463,21 @@ fun GameBottomBar(
                 defaultColor = textColor,
                 indicators = indicators,
             )
-            CompassView(
+            CompassButtons(
                 height = 88.dp,
                 directions = viewModel.compassState.collectAsState().value,
                 onClick = { direction ->
                     viewModel.sendCommand(direction.value)
                 },
+                colors =
+                    CompassButtonColors(
+                        litBackground = MaterialTheme.colorScheme.secondaryContainer,
+                        litBorder = MaterialTheme.colorScheme.primary,
+                        litIcon = MaterialTheme.colorScheme.onSecondaryContainer,
+                        background = MaterialTheme.colorScheme.surfaceVariant,
+                        border = MaterialTheme.colorScheme.outlineVariant,
+                        icon = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f),
+                    ),
             )
         }
     }

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/IndicatorView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/IndicatorView.kt
@@ -5,33 +5,24 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.painterResource
-import warlockfe.warlock3.compose.generated.resources.Res
-import warlockfe.warlock3.compose.generated.resources.death
-import warlockfe.warlock3.compose.generated.resources.diseased
-import warlockfe.warlock3.compose.generated.resources.hidden
-import warlockfe.warlock3.compose.generated.resources.invisible
-import warlockfe.warlock3.compose.generated.resources.joined
-import warlockfe.warlock3.compose.generated.resources.kneeling
-import warlockfe.warlock3.compose.generated.resources.local_hospital
-import warlockfe.warlock3.compose.generated.resources.poisoned
-import warlockfe.warlock3.compose.generated.resources.prone
-import warlockfe.warlock3.compose.generated.resources.sitting
-import warlockfe.warlock3.compose.generated.resources.standing
-import warlockfe.warlock3.compose.generated.resources.stunned
-import warlockfe.warlock3.compose.generated.resources.webbed
+import warlockfe.warlock3.compose.model.SkinImage
+import warlockfe.warlock3.compose.model.SkinObject
+import warlockfe.warlock3.compose.util.LocalSkin
+import warlockfe.warlock3.compose.util.indicatorDrawable
+import warlockfe.warlock3.compose.util.indicatorEntry
+import warlockfe.warlock3.compose.util.indicatorIconModifier
+import warlockfe.warlock3.compose.util.indicatorReference
 
 @Composable
 fun IndicatorView(
@@ -41,149 +32,72 @@ fun IndicatorView(
     defaultColor: Color,
     modifier: Modifier = Modifier,
 ) {
-    val statusKeysList: Array<Map<String, @Composable (Modifier) -> Unit>> =
-        arrayOf(
-            mapOf(
-                "kneeling" to {
-                    Icon(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.kneeling),
-                        contentDescription = "kneeling",
-                        tint = defaultColor,
-                    )
-                },
-                "prone" to {
-                    Icon(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.prone),
-                        contentDescription = "prone",
-                        tint = defaultColor,
-                    )
-                },
-                "sitting" to {
-                    Icon(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.sitting),
-                        contentDescription = "sitting",
-                        tint = defaultColor,
-                    )
-                },
-                "standing" to {
-                    Icon(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.standing),
-                        contentDescription = "standing",
-                        tint = defaultColor,
-                    )
-                },
-                "poisoned" to {
-                    Image(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.poisoned),
-                        contentDescription = "poisoned",
-                    )
-                },
-                "diseased" to {
-                    Image(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.diseased),
-                        contentDescription = "diseased",
-                    )
-                },
-            ),
-            mapOf(
-                "joined" to {
-                    Icon(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.joined),
-                        contentDescription = "joined",
-                        tint = defaultColor,
-                    )
-                },
-            ),
-            mapOf(
-                "bleeding" to {
-                    Icon(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.local_hospital),
-                        contentDescription = "bleeding",
-                        tint = Color.Red,
-                    )
-                },
-                "dead" to {
-                    Icon(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.death),
-                        contentDescription = "dead",
-                        tint = defaultColor,
-                    )
-                },
-            ),
-            mapOf(
-                "invisible" to {
-                    Icon(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.invisible),
-                        contentDescription = "invisible",
-                        tint = defaultColor,
-                    )
-                },
-                "hidden" to {
-                    Image(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.hidden),
-                        contentDescription = "hidden",
-                    )
-                },
-                "webbed" to {
-                    Icon(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.webbed),
-                        contentDescription = "standing",
-                        tint = defaultColor,
-                    )
-                },
-            ),
-            mapOf(
-                "stunned" to {
-                    Icon(
-                        modifier = it,
-                        painter = painterResource(Res.drawable.stunned),
-                        contentDescription = "stunned",
-                        tint = defaultColor,
-                    )
-                },
-            ),
+    // Grouping stays in code; each status's image and position come from the skin's "indicator"
+    // section, so every active status in a slot is drawn at its own spot (a status with no offset
+    // fills the box).
+    val groups: List<List<String>> =
+        listOf(
+            listOf("kneeling", "prone", "sitting", "standing", "poisoned", "diseased"),
+            listOf("joined"),
+            listOf("bleeding", "dead"),
+            listOf("invisible", "hidden", "webbed"),
+            listOf("stunned"),
         )
+    val skin = LocalSkin.current
+    val reference = skin.indicatorReference()
 
     Row(modifier = modifier.background(backgroundColor)) {
-        statusKeysList.forEach { statusKeys ->
+        groups.forEach { group ->
             Box(
                 modifier =
                     Modifier
                         .size(indicatorSize)
-                        .border(width = Dp.Hairline, color = MaterialTheme.colorScheme.outline)
-                        .padding(indicatorSize / 7.5f),
-                contentAlignment = Alignment.Center,
+                        .border(width = Dp.Hairline, color = MaterialTheme.colorScheme.outline),
             ) {
-                statusKeys.filter { indicators.contains(it.key) }.forEach { it.value(Modifier.fillMaxSize()) }
+                group.filter { indicators.contains(it) }.forEach { status ->
+                    val entry = skin.indicatorEntry(status) ?: return@forEach
+                    val drawable = entry.indicatorDrawable() ?: return@forEach
+                    val tint = indicatorTint(status, defaultColor)
+                    Image(
+                        modifier = indicatorIconModifier(entry, indicatorSize, reference),
+                        painter = painterResource(drawable),
+                        colorFilter = tint?.let { ColorFilter.tint(it) },
+                        contentDescription = status,
+                    )
+                }
             }
         }
     }
 }
 
+// Full-color status assets stay untinted; bleeding is red; everything else takes the default color.
+private fun indicatorTint(
+    status: String,
+    defaultColor: Color,
+): Color? =
+    when (status) {
+        "poisoned", "diseased", "hidden" -> null
+        "bleeding" -> Color.Red
+        else -> defaultColor
+    }
+
 @Preview
 @Composable
 private fun IndicatorPreview() {
-    IndicatorView(
-        indicatorSize = 60.dp,
-        indicators =
-            setOf(
-                "standing",
-                "stunned",
-                "webbed",
-            ),
-        backgroundColor = Color.DarkGray,
-        defaultColor = Color.LightGray,
-    )
+    val previewStatuses = listOf("standing", "stunned", "webbed")
+    val skin =
+        mapOf(
+            "indicator" to
+                SkinObject(
+                    children = previewStatuses.associateWith { SkinObject(image = SkinImage(name = it)) },
+                ),
+        )
+    CompositionLocalProvider(LocalSkin provides skin) {
+        IndicatorView(
+            indicatorSize = 60.dp,
+            indicators = previewStatuses.toSet(),
+            backgroundColor = Color.DarkGray,
+            defaultColor = Color.LightGray,
+        )
+    }
 }


### PR DESCRIPTION
Builds on the merged game-screen work (#169, #172) and the recent skin moves (#173, #174). Three related changes:

## 1. Show all active indicators (desktop + mobile grid)
Each status slot previously showed only one active status, so co-active statuses in a group (e.g. a posture *and* poisoned) were hidden. Now every active status in a slot is drawn at its own **skin-defined offset**, so they're all visible at once; a status with no offset fills the box (the single-status case, unchanged).
- Offsets live in the default skin's `indicator` section. `SkinObject` already carries `top`/`left`/`width`/`height`, so no model change — they're authored against a 24-unit box and scaled to the responsive box size.
- Each slot is colored by its highest-priority active status; each icon keeps its own accent tint.

## 2. Mobile parity for skin-driven indicators
- Shared lookup/placement helpers (`indicatorEntry` / `indicatorDrawable` / `indicatorIconModifier` in `IndicatorImages.kt`), used by the desktop grid and the mobile `IndicatorView` grid (which also fixes its prior icon overlap).
- `ConditionChips` simplified from a 13-entry `Map<String, ConditionInfo>` to a `status -> severity` function (the chip label was always the status string; the icon comes from the skin).

## 3. Mobile button compass
Mobile rendered the skin compass *rose*; it now uses the **button** compass like desktop. The desktop button grid is extracted into a shared commonMain `CompassButtons` parameterized by `CompassButtonColors`; desktop's `BUTTONS` style delegates to it (`gameChrome` colors), and mobile `GameView` uses it with Material colors (always buttons).

## Also
- A one-line wrap of a pre-existing `chain-method-continuation` nit in `ConnectionSettingsDialog.kt` so ktlint is fully green.

## Verification
- `:compose:compileKotlinJvm` and `:compose:compileAndroidMain` compile; `:compose:ktlintCheck` clean; skin tests (`SkinJsonTest`/`SkinZipLoaderTest`) pass.
- No code-level fallback for skins that omit the new skin keys (per project preference: a bad/old skin is updated or the user switches back to the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)