### PR TITLE
Add auto-connect-with-last-connection option

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/model/GameState.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/model/GameState.kt
@@ -11,6 +11,11 @@ class GameState {
     var screen by mutableStateOf<GameScreen>(GameScreen.Dashboard)
         private set
 
+    // Guards the once-per-window "auto-connect last connection on startup" attempt. Set true once the
+    // attempt has been consumed (or pre-set true for windows that should never auto-connect, e.g. a
+    // window already connected via the command line, or a manually opened additional window).
+    var autoConnectAttempted: Boolean = false
+
     suspend fun setScreen(screen: GameScreen) {
         withContext(Dispatchers.Main.immediate) {
             this@GameState.screen = screen

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
@@ -102,6 +102,7 @@ class DashboardViewModel(
                 warlockSettingsSync.sync()
             }
         }
+        maybeAutoConnectLastConnection()
     }
 
     // --- Settings sync ---
@@ -136,6 +137,23 @@ class DashboardViewModel(
     fun savedPasswordFor(username: String): String? =
         savedAccounts.firstOrNull { it.username.equals(username, ignoreCase = true) }?.password
 
+    /**
+     * On the first dashboard shown this session, reconnect the last launched connection if the user
+     * enabled auto-connect and that connection still exists. Guarded by
+     * [GameState.autoConnectAttempted] so it fires at most once per window (not again when returning
+     * to the dashboard after a disconnect).
+     */
+    private fun maybeAutoConnectLastConnection() {
+        if (gameState.autoConnectAttempted) return
+        gameState.autoConnectAttempted = true
+        viewModelScope.launch {
+            if (!clientSettingRepository.getAutoConnectLastConnection()) return@launch
+            val lastConnectionId = clientSettingRepository.getLastConnectionId() ?: return@launch
+            val connection = connectionRepository.getById(lastConnectionId) ?: return@launch
+            connect(connection)
+        }
+    }
+
     fun connect(connection: StoredConnection) {
         // MUD Mobile connections route through the hosted-Lich flow instead of a direct play.net login.
         if (connection.mudMobile) {
@@ -148,6 +166,8 @@ class DashboardViewModel(
         connectJob =
             viewModelScope.launch {
                 try {
+                    // Remember this as the last launched connection (for auto-connect-on-startup).
+                    clientSettingRepository.putLastConnectionId(connection.id)
                     message = "Connecting..."
                     val sgeClient = sgeClientFactory.create()
                     val result = sgeClient.autoConnect(sgeSettings, connection)
@@ -324,6 +344,8 @@ class DashboardViewModel(
         connectJob =
             viewModelScope.launch {
                 try {
+                    // Remember this as the last launched connection (for auto-connect-on-startup).
+                    clientSettingRepository.putLastConnectionId(connection.id)
                     val token = clientSettingRepository.getMudMobileToken()
                     if (token == null) {
                         mudMobileMessage = "Connect your MUD Mobile account first."

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopGeneralSettingsView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopGeneralSettingsView.kt
@@ -144,6 +144,21 @@ fun DesktopGeneralSettingsView(
 
             Spacer(Modifier.height(16.dp))
 
+            val autoConnectLastConnection by clientSettingRepository
+                .observeAutoConnectLastConnection()
+                .collectAsState(initial = false)
+            WarlockCheckboxRow(
+                checked = autoConnectLastConnection,
+                onCheckedChange = {
+                    scope.launch {
+                        clientSettingRepository.putAutoConnectLastConnection(it)
+                    }
+                },
+                text = "Reconnect the last connection on startup",
+            )
+
+            Spacer(Modifier.height(16.dp))
+
             if (currentCharacterId != "global") {
                 val maxTypeAheadState = rememberTextFieldState(DEFAULT_MAX_TYPE_AHEAD.toString())
                 var maxTypeAheadError by remember { mutableStateOf<String?>(null) }

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/GeneralSettingsView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/GeneralSettingsView.kt
@@ -204,6 +204,17 @@ fun GeneralSettingsView(
 
             Spacer(Modifier.height(16.dp))
 
+            val autoConnectLastConnection by clientSettingRepository
+                .observeAutoConnectLastConnection()
+                .collectAsState(initial = false)
+            SwitchRow(
+                checked = autoConnectLastConnection,
+                onCheckedChange = { scope.launch { clientSettingRepository.putAutoConnectLastConnection(it) } },
+                text = "Reconnect the last connection on startup",
+            )
+
+            Spacer(Modifier.height(16.dp))
+
             if (currentCharacterId != "global") {
                 val maxTypeAheadState = rememberTextFieldState(DEFAULT_MAX_TYPE_AHEAD.toString())
                 var maxTypeAheadError by remember { mutableStateOf<String?>(null) }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
@@ -282,6 +282,8 @@ data class ClientConfig(
     val historySize: Int? = null,
     @TomlComment("MUD Mobile device token (wlk_...). Treat like a password; it can start billable sessions.")
     val mudMobileToken: String? = null,
+    @TomlComment("When true, the last launched connection is reconnected automatically on startup.")
+    val autoConnectLastConnection: Boolean = false,
 )
 
 /**

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ClientSettingRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ClientSettingRepository.kt
@@ -37,6 +37,13 @@ class ClientSettingRepository(
 
     suspend fun getLastUsername(): String? = get("lastUsername")
 
+    /** The id of the most recently launched connection, used for auto-connect-on-startup. */
+    suspend fun getLastConnectionId(): String? = get("lastConnectionId")
+
+    suspend fun putLastConnectionId(value: String?) {
+        put("lastConnectionId", value)
+    }
+
     suspend fun putWidth(value: Int) {
         putInt("width", value)
     }
@@ -100,6 +107,14 @@ class ClientSettingRepository(
     fun observeHistorySize(): Flow<Int> = clientConfigStore.observeClient().map { it.historySize ?: DEFAULT_HISTORY_SIZE }
 
     fun observeMarkLinks(): Flow<Boolean> = clientConfigStore.observeClient().map { it.markLinks }
+
+    fun observeAutoConnectLastConnection(): Flow<Boolean> = clientConfigStore.observeClient().map { it.autoConnectLastConnection }
+
+    fun getAutoConnectLastConnection(): Boolean = clientConfigStore.currentClient().autoConnectLastConnection
+
+    suspend fun putAutoConnectLastConnection(value: Boolean) {
+        clientConfigStore.mutateClient { it.copy(autoConnectLastConnection = value) }
+    }
 
     // --- MUD Mobile device token ---
 

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ConnectionRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ConnectionRepository.kt
@@ -116,6 +116,11 @@ class ConnectionRepository(
         val connection = store.currentConnections().connections.firstOrNull { it.name == name } ?: return null
         return connection.toStoredConnection(accountDao.getByUsername(connection.username)?.password)
     }
+
+    suspend fun getById(id: String): StoredConnection? {
+        val connection = store.currentConnections().connections.firstOrNull { it.id == id } ?: return null
+        return connection.toStoredConnection(accountDao.getByUsername(connection.username)?.password)
+    }
 }
 
 private fun MudMobileCharacter.toMudMobileConfig(): ConnectionConfig =

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -273,7 +273,8 @@ private class WarlockCommand : CliktCommand() {
                                 appContainer = appContainer,
                                 gameState = gameState,
                                 openNewWindow = {
-                                    games.add(GameState())
+                                    // A manually opened window shows the dashboard; never auto-connect into it.
+                                    games.add(GameState().apply { autoConnectAttempted = true })
                                 },
                                 showUpdateDialog = { showUpdateDialog = true },
                                 sgeSettings = sgeSettings,
@@ -434,6 +435,8 @@ private class WarlockCommand : CliktCommand() {
     ): GameState =
         GameState().apply {
             if (credentials != null || stdin || inputFile != null) {
+                // Already connecting on startup; don't also auto-connect the last connection.
+                autoConnectAttempted = true
                 val windowRegistry = appContainer.windowRegistryFactory.create()
                 // TODO: move this somewhere we can control it
                 runBlocking {
@@ -470,6 +473,8 @@ private class WarlockCommand : CliktCommand() {
                     }
                 }
             } else if (autoConnectName != null) {
+                // Connecting to a named connection from the CLI; skip last-connection auto-connect.
+                autoConnectAttempted = true
                 runBlocking {
                     val connection = appContainer.connectionRepository.getByName(autoConnectName!!)
                     if (connection == null) {


### PR DESCRIPTION
## Summary
Adds a client option to automatically reconnect the last-launched connection when the app starts.

- New **Reconnect the last connection on startup** toggle on the General settings page (desktop Jewel + mobile M3), persisted in `client.toml` as `ClientConfig.autoConnectLastConnection`.
- Whenever a connection is launched (direct play.net or MUD Mobile), its id is recorded as the last connection (`lastConnectionId`, in client settings).
- On the first dashboard shown after launch, if the option is enabled and the saved connection still exists (`ConnectionRepository.getById`, null if deleted), it is launched automatically via the existing `DashboardViewModel.connect()` flow — so proxy and MUD Mobile connections work and the normal connecting UI is shown.

## Once-per-launch guard
The auto-connect is guarded by a new `GameState.autoConnectAttempted` flag so it fires **at most once per window**, not again when returning to the dashboard after a disconnect (the dashboard nav entry recreates its view model, but the `GameState` instance persists). On desktop it's pre-set to suppress auto-connect for startups that are already connecting (stdin / input file / credentials / the CLI `-c` connection) and for manually opened additional windows. Mobile holds a single retained `GameState`, so it auto-connects once on launch.

## Testing
- `:desktopApp:compileKotlin` and `:compose:compileAndroidMain` compile (common/jvm/mobile source sets).
- `ktlintCheck` passes for `core`, `compose`, and `desktopApp`.

Note: this is a separate PR from the per-connection window-title change (#176); the two are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)