### PR TITLE
Let a CLI window size override the saved per-character size

### DIFF
--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -281,6 +281,9 @@ private class WarlockCommand : CliktCommand() {
                                 sgeSettings = sgeSettings,
                             )
                             LaunchedEffect(windowState, connectedCharacter?.id) {
+                                // A window size passed on the command line should win, so don't clobber it
+                                // with the saved per-character size when a character connects.
+                                if (width != null || height != null) return@LaunchedEffect
                                 val characterId = connectedCharacter?.id ?: return@LaunchedEffect
                                 val bounds =
                                     appContainer.characterSettingsRepository


### PR DESCRIPTION
## Summary
The desktop app already accepts `--width`/`--height` to set the initial window size, but the saved **per-character** window bounds were restored as soon as a character connected — overwriting the size given on the command line.

This skips restoring the per-character bounds on connect when a window size was passed on the CLI, so the CLI size wins for the session.

## Notes
- Only the *restore* on connect is skipped; saving still works, and per-character restore is unchanged when no CLI size is given.
- Because the saved bounds bundle size and position, passing a CLI size also skips restoring the per-character position (the `-x`/`-y` options remain for that).

## Testing
- `:desktopApp:compileKotlin` and `:core:compileKotlinJvm` compile.
- `ktlintCheck` passes for `desktopApp` and `core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)