### PR TITLE
Avoid UI stall during rapid game-text floods (e.g. ;go2)

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.buildAnnotatedString
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
@@ -53,8 +55,8 @@ class ComposeTextStream(
     private val workQueue: StreamWorkQueue,
     private val scope: CoroutineScope,
 ) : TextStream {
-    private val cacheLines = ArrayList<CachedLine?>(maxLines)
-    private val finishedLines = ArrayList<StreamLine>(maxLines)
+    private val cacheLines = ArrayDeque<CachedLine?>(maxLines)
+    private val finishedLines = ArrayDeque<StreamLine>(maxLines)
     val lines = MutableStateFlow<List<StreamLine>>(emptyList())
     private val components = mutableMapOf<String, StyledString>()
 
@@ -74,7 +76,20 @@ class ComposeTextStream(
 
     val mutex = Mutex()
 
+    // Coalesces buffer mutations into at most one snapshot publish per burst. During a flood (e.g.
+    // ;go2) lines arrive back-to-back; without this, each line republished an O(n) copy of the whole
+    // scrollback, so the work-queue coroutine fell behind and the UI froze until the burst finished
+    // ("dumped all at once"). A CONFLATED channel collapses pending publishes into a single one.
+    private val publishSignal = Channel<Unit>(Channel.CONFLATED)
+
     init {
+        // Drain coalesced publish requests: a burst of appends yields a handful of snapshots instead
+        // of one per line.
+        scope.launch(Dispatchers.Default) {
+            for (signal in publishSignal) {
+                mutex.withLock { publishSnapshot() }
+            }
+        }
         // Re-filter displayed lines whenever the names list changes
         names
             .onEach {
@@ -204,8 +219,8 @@ class ComposeTextStream(
 
     private fun removeLines() {
         while (maxLines > 0 && finishedLines.size >= maxLines) {
-            finishedLines.removeAt(0)
-            cacheLines.removeAt(0)
+            finishedLines.removeFirst()
+            cacheLines.removeFirst()
             removedLines++
             // Intentionally leak components here. They don't exist in the main window,
             // and no other windows get long enough
@@ -303,7 +318,13 @@ class ComposeTextStream(
         this.showImages = showImages
     }
 
+    // Request a publish. Coalesced via [publishSignal]; the snapshot itself runs in [publishSnapshot].
     private fun linesUpdated() {
+        publishSignal.trySend(Unit)
+    }
+
+    // Snapshots the buffer into [lines]. Runs on the publish coroutine, once per coalesced burst.
+    private fun publishSnapshot() {
         lines.value =
             if (nameFilter) {
                 finishedLines.filter { lineMatchesName(it) }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/StyledString.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/StyledString.kt
@@ -1,18 +1,21 @@
 package warlockfe.warlock3.core.text
 
-import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 
 data class StyledString(
-    val substrings: ImmutableList<StyledStringLeaf> = persistentListOf(),
+    val substrings: PersistentList<StyledStringLeaf> = persistentListOf(),
 ) {
     constructor(text: String, styles: List<WarlockStyle> = emptyList()) :
         this(persistentListOf<StyledStringSubstring>(StyledStringSubstring(text, styles)))
 
     constructor(text: String, style: WarlockStyle) : this(text, listOf(style))
 
-    operator fun plus(string: StyledString): StyledString = StyledString((substrings + string.substrings).toPersistentList())
+    // addAll on a persistent list appends in O(elements added) with structural sharing, so folding
+    // many fragments into one line (e.g. a room description) is O(total) rather than the O(n²) of
+    // repeated (a + b) whole-list copies.
+    operator fun plus(string: StyledString): StyledString = copy(substrings = substrings.addAll(string.substrings))
 
     fun applyStyle(style: WarlockStyle): StyledString = copy(substrings = substrings.map { it.applyStyle(style) }.toPersistentList())
 


### PR DESCRIPTION
> **Note from human:** I noticed some slowness that made it nearly unplayable, so Claude and I made some fixes.

## Problem

Running a Lich `;go2` flood (rapid room descriptions) on a **single** character froze the UI and then dumped the whole travel log at once, and typing a command could lag for seconds. The cost was per-line work in the stream buffer that scales with the scrollback size, so it showed up even with one window open.

## Changes (two commits)

**`ComposeTextStream`: coalesce publishes + O(1) eviction**
- Every appended line republished a full O(n) `toList()` copy of the scrollback to the `lines` `StateFlow`, and once the buffer hit `maxLines` it evicted the head with `ArrayList.removeAt(0)` — another O(n) shift. Under a flood, the single work-queue coroutine couldn't keep up, so the conflated `StateFlow` dropped every intermediate value and the UI only repainted after the burst finished.
- `finishedLines`/`cacheLines` are now `ArrayDeque` (O(1) head eviction), and snapshots are coalesced: line ops `trySend` to a `CONFLATED` channel and a single collector publishes one snapshot per *burst* instead of per *line*.

**`StyledString`: O(k) line assembly**
- `plus` folded fragments with `(a + b).toPersistentList()`, copying the whole accumulator each time — O(k²) for a fragment-heavy room line. `substrings` is narrowed to `PersistentList` and appended with `addAll` (structural sharing), making line assembly O(k).

## Behavior

Rendered output, line ordering, name-filter, and component-update logic are unchanged — only the per-line cost (now O(1) amortized) and the publish cadence. The `StateFlow` already conflated intermediate emissions, so nothing visible is lost.

## Testing

- `:core:jvmTest` and `:wrayth:jvmTest` pass; `:compose` compiles clean (no new warnings).
- Verified by hand: flooded a character with a long `;go2` — text now streams in incrementally and typing stays responsive during travel, instead of freezing and dumping the log at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
