### PR TITLE
Apply progress-bar color overrides to the vitals bar and mobile

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/LocalProgressBarColors.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/LocalProgressBarColors.kt
@@ -1,13 +1,13 @@
-package warlockfe.warlock3.compose.desktop.ui.window
+package warlockfe.warlock3.compose.ui.window
 
-import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.compositionLocalOf
 import warlockfe.warlock3.core.prefs.models.ProgressBarSettingEntity
 import warlockfe.warlock3.core.text.WarlockColor
 
 /**
  * Carries the current character's progress-bar color overrides (keyed by progress-bar id) and a
- * callback to persist new colors. Provided high in the desktop game view so the deeply-nested
- * dialog content can read/write per-id colors without threading callbacks through every layer.
+ * callback to persist new colors. Provided high in the game view so the deeply-nested dialog
+ * content can read/write per-id colors without threading callbacks through every layer.
  */
 data class ProgressBarColorState(
     val settings: Map<String, ProgressBarSettingEntity>,
@@ -20,6 +20,6 @@ data class ProgressBarColorState(
 )
 
 val LocalProgressBarColors =
-    staticCompositionLocalOf {
+    compositionLocalOf {
         ProgressBarColorState(settings = emptyMap()) { _, _, _, _ -> }
     }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameBottomBar.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameBottomBar.kt
@@ -84,6 +84,8 @@ fun DesktopGameBottomBar(
                         entryFocusRequester = entryFocusRequester,
                     )
                     val vitalBars by viewModel.vitalBars.objects.collectAsState()
+                    // Color overrides come from LocalProgressBarColors, provided by DesktopGameView
+                    // around both this control bar and the text windows.
                     DesktopDialogContent(
                         dataObjects = vitalBars,
                         modifier = Modifier.fillMaxWidth().height(16.dp),

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
@@ -45,12 +45,12 @@ import org.jetbrains.jewel.ui.component.Text
 import warlockfe.warlock3.compose.desktop.shim.WarlockAlertDialog
 import warlockfe.warlock3.compose.desktop.shim.WarlockButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
-import warlockfe.warlock3.compose.desktop.ui.window.LocalProgressBarColors
-import warlockfe.warlock3.compose.desktop.ui.window.ProgressBarColorState
 import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.generated.resources.circle
 import warlockfe.warlock3.compose.generated.resources.circle_filled
 import warlockfe.warlock3.compose.ui.game.GameViewModel
+import warlockfe.warlock3.compose.ui.window.LocalProgressBarColors
+import warlockfe.warlock3.compose.ui.window.ProgressBarColorState
 import warlockfe.warlock3.compose.util.SAFE_DEFAULT_STYLE
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.core.client.WarlockAction
@@ -128,65 +128,65 @@ fun DesktopGameView(
         val presets by viewModel.presets.collectAsState(emptyMap())
         val defaultStyle = presets["default"] ?: SAFE_DEFAULT_STYLE
         val openWindows by viewModel.openWindows.collectAsState(emptyList())
+        val progressBarSettings by viewModel.progressBarSettings.collectAsState()
 
-        Row(modifier = Modifier.weight(1f)) {
-            if (sideBarVisible) {
-                val windows by viewModel.windows.collectAsState()
-                val scope = rememberCoroutineScope()
-                val sidebarBackground =
-                    defaultStyle.backgroundColor.takeIf { it.isSpecified() }?.toColor()
-                        ?: gameChrome.panelAlt
-                val sidebarTextColor =
-                    defaultStyle.textColor.takeIf { it.isSpecified() }?.toColor()
-                        ?: gameChrome.textPrimary
-                WarlockScrollableColumn(
-                    modifier =
-                        Modifier
-                            .padding(2.dp)
-                            .fillMaxHeight()
-                            .width(240.dp)
-                            .background(
-                                color = sidebarBackground,
-                                shape = RoundedCornerShape(2.dp),
-                            ).border(
-                                width = Dp.Hairline,
-                                color = gameChrome.border,
-                                shape = RoundedCornerShape(2.dp),
-                            ),
-                    contentPadding = PaddingValues(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    windows.sortedBy { it.title }.forEach { window ->
-                        DesktopWindowListItem(
-                            color = sidebarTextColor,
-                            windowInfo = window,
-                            isOpen = openWindows.contains(window.name),
-                            onClick = { open ->
-                                scope.launch {
-                                    if (open) {
-                                        viewModel.openWindow(window.name)
-                                    } else {
-                                        viewModel.closeWindow(window.name)
+        CompositionLocalProvider(
+            LocalProgressBarColors provides
+                ProgressBarColorState(
+                    settings = progressBarSettings,
+                    saveColors = viewModel::saveProgressBarColors,
+                ),
+        ) {
+            Row(modifier = Modifier.weight(1f)) {
+                if (sideBarVisible) {
+                    val windows by viewModel.windows.collectAsState()
+                    val scope = rememberCoroutineScope()
+                    val sidebarBackground =
+                        defaultStyle.backgroundColor.takeIf { it.isSpecified() }?.toColor()
+                            ?: gameChrome.panelAlt
+                    val sidebarTextColor =
+                        defaultStyle.textColor.takeIf { it.isSpecified() }?.toColor()
+                            ?: gameChrome.textPrimary
+                    WarlockScrollableColumn(
+                        modifier =
+                            Modifier
+                                .padding(2.dp)
+                                .fillMaxHeight()
+                                .width(240.dp)
+                                .background(
+                                    color = sidebarBackground,
+                                    shape = RoundedCornerShape(2.dp),
+                                ).border(
+                                    width = Dp.Hairline,
+                                    color = gameChrome.border,
+                                    shape = RoundedCornerShape(2.dp),
+                                ),
+                        contentPadding = PaddingValues(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        windows.sortedBy { it.title }.forEach { window ->
+                            DesktopWindowListItem(
+                                color = sidebarTextColor,
+                                windowInfo = window,
+                                isOpen = openWindows.contains(window.name),
+                                onClick = { open ->
+                                    scope.launch {
+                                        if (open) {
+                                            viewModel.openWindow(window.name)
+                                        } else {
+                                            viewModel.closeWindow(window.name)
+                                        }
                                     }
-                                }
-                            },
-                            onClear = { viewModel.clearStream(window.name) },
-                        )
+                                },
+                                onClear = { viewModel.clearStream(window.name) },
+                            )
+                        }
                     }
                 }
-            }
-            val leftWindows by viewModel.leftWindowUiStates.collectAsState()
-            val rightWindows by viewModel.rightWindowUiStates.collectAsState()
-            val topWindows by viewModel.topWindowUiStates.collectAsState()
-            val bottomWindows by viewModel.bottomWindowUiStates.collectAsState()
-            val progressBarSettings by viewModel.progressBarSettings.collectAsState()
-            CompositionLocalProvider(
-                LocalProgressBarColors provides
-                    ProgressBarColorState(
-                        settings = progressBarSettings,
-                        saveColors = viewModel::saveProgressBarColors,
-                    ),
-            ) {
+                val leftWindows by viewModel.leftWindowUiStates.collectAsState()
+                val rightWindows by viewModel.rightWindowUiStates.collectAsState()
+                val topWindows by viewModel.topWindowUiStates.collectAsState()
+                val bottomWindows by viewModel.bottomWindowUiStates.collectAsState()
                 DesktopGameTextWindows(
                     modifier = Modifier.weight(1f).padding(2.dp),
                     leftWindowUiStates = leftWindows,
@@ -250,8 +250,8 @@ fun DesktopGameView(
                     clearStream = viewModel::clearStream,
                 )
             }
+            DesktopGameBottomBar(viewModel, entryFocusRequester)
         }
-        DesktopGameBottomBar(viewModel, entryFocusRequester)
     }
     val macroError by viewModel.macroError.collectAsState()
     if (macroError != null) {

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopDialogContent.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopDialogContent.kt
@@ -31,6 +31,7 @@ import warlockfe.warlock3.compose.ui.window.DialogButton
 import warlockfe.warlock3.compose.ui.window.DialogImage
 import warlockfe.warlock3.compose.ui.window.DialogObjectLayout
 import warlockfe.warlock3.compose.ui.window.DialogProgressBar
+import warlockfe.warlock3.compose.ui.window.LocalProgressBarColors
 import warlockfe.warlock3.compose.util.LocalSkin
 import warlockfe.warlock3.compose.util.getColorGroup
 import warlockfe.warlock3.compose.util.toColor

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -61,6 +62,8 @@ import warlockfe.warlock3.compose.ui.window.DialogContent
 import warlockfe.warlock3.compose.ui.window.DragDropState
 import warlockfe.warlock3.compose.ui.window.DragOverlay
 import warlockfe.warlock3.compose.ui.window.DropResult
+import warlockfe.warlock3.compose.ui.window.LocalProgressBarColors
+import warlockfe.warlock3.compose.ui.window.ProgressBarColorState
 import warlockfe.warlock3.compose.ui.window.WindowUiState
 import warlockfe.warlock3.compose.ui.window.WindowView
 import warlockfe.warlock3.compose.ui.window.WindowsAtLocation
@@ -128,35 +131,44 @@ fun GameView(
                         navigateToDashboard = navigateToDashboard,
                     )
                 }
-                when (layout) {
-                    MobileGameLayout.Phone -> {
-                        PhoneGameView(
-                            viewModel = viewModel,
-                            entryFocusRequester = entryFocusRequester,
-                            navigateToDashboard = navigateToDashboard,
-                            openSettings = openSettings,
-                            openDrawer = openDrawer,
-                            modifier = Modifier.weight(1f),
-                        )
-                    }
+                val progressBarSettings by viewModel.progressBarSettings.collectAsState()
+                CompositionLocalProvider(
+                    LocalProgressBarColors provides
+                        ProgressBarColorState(
+                            settings = progressBarSettings,
+                            saveColors = viewModel::saveProgressBarColors,
+                        ),
+                ) {
+                    when (layout) {
+                        MobileGameLayout.Phone -> {
+                            PhoneGameView(
+                                viewModel = viewModel,
+                                entryFocusRequester = entryFocusRequester,
+                                navigateToDashboard = navigateToDashboard,
+                                openSettings = openSettings,
+                                openDrawer = openDrawer,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
 
-                    MobileGameLayout.Tablet -> {
-                        TabletGameView(
-                            viewModel = viewModel,
-                            entryFocusRequester = entryFocusRequester,
-                            openSettings = openSettings,
-                            modifier = Modifier.weight(1f),
-                        )
-                    }
+                        MobileGameLayout.Tablet -> {
+                            TabletGameView(
+                                viewModel = viewModel,
+                                entryFocusRequester = entryFocusRequester,
+                                openSettings = openSettings,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
 
-                    MobileGameLayout.Large -> {
-                        LargeGameView(
-                            viewModel = viewModel,
-                            entryFocusRequester = entryFocusRequester,
-                            openSettings = openSettings,
-                            navigateToDashboard = navigateToDashboard,
-                            modifier = Modifier.weight(1f),
-                        )
+                        MobileGameLayout.Large -> {
+                            LargeGameView(
+                                viewModel = viewModel,
+                                entryFocusRequester = entryFocusRequester,
+                                openSettings = openSettings,
+                                navigateToDashboard = navigateToDashboard,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
                     }
                 }
             }

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogContent.kt
@@ -1,24 +1,34 @@
 package warlockfe.warlock3.compose.ui.window
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
+import warlockfe.warlock3.compose.components.ColorPickerDialog
 import warlockfe.warlock3.compose.model.SkinColor
 import warlockfe.warlock3.compose.model.SkinObject
 import warlockfe.warlock3.compose.util.LocalSkin
@@ -28,6 +38,7 @@ import warlockfe.warlock3.core.client.DataDistance
 import warlockfe.warlock3.core.client.DialogObject
 import warlockfe.warlock3.core.client.Percentage
 import warlockfe.warlock3.core.text.StyleDefinition
+import warlockfe.warlock3.core.text.WarlockColor
 import warlockfe.warlock3.core.util.getIgnoringCase
 import kotlin.io.encoding.Base64
 
@@ -48,7 +59,7 @@ fun DialogContent(
                 }
 
                 is DialogObject.ProgressBar -> {
-                    DialogProgressBar(
+                    ProgressBarWithColorMenu(
                         skinObject = skinObject,
                         data = data,
                     )
@@ -105,6 +116,108 @@ fun DialogContent(
                 }
             }
         }
+    }
+}
+
+private enum class ProgressBarColorTarget {
+    Bar,
+    Background,
+    Text,
+}
+
+/**
+ * A vital/progress bar that applies the current character's saved color overrides and, on long
+ * press, offers a menu to recolor (or reset) the bar/background/text - the touch equivalent of the
+ * desktop right-click color menu. Reads and persists through [LocalProgressBarColors].
+ */
+@Composable
+private fun ProgressBarWithColorMenu(
+    skinObject: SkinObject?,
+    data: DialogObject.ProgressBar,
+) {
+    val colorState = LocalProgressBarColors.current
+    val setting = colorState.settings[data.id]
+    val barColor = setting?.barColor ?: WarlockColor.Unspecified
+    val backgroundColor = setting?.backgroundColor ?: WarlockColor.Unspecified
+    val textColor = setting?.textColor ?: WarlockColor.Unspecified
+
+    var menuOpen by remember { mutableStateOf(false) }
+    var editingTarget by remember { mutableStateOf<ProgressBarColorTarget?>(null) }
+
+    Box {
+        DialogProgressBar(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .pointerInput(data.id) {
+                        detectTapGestures(onLongPress = { menuOpen = true })
+                    },
+            skinObject = skinObject,
+            data = data,
+            barColorOverride = barColor,
+            backgroundColorOverride = backgroundColor,
+            textColorOverride = textColor,
+        )
+        DropdownMenu(
+            expanded = menuOpen,
+            onDismissRequest = { menuOpen = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text("Change bar color") },
+                onClick = {
+                    menuOpen = false
+                    editingTarget = ProgressBarColorTarget.Bar
+                },
+            )
+            DropdownMenuItem(
+                text = { Text("Change background color") },
+                onClick = {
+                    menuOpen = false
+                    editingTarget = ProgressBarColorTarget.Background
+                },
+            )
+            DropdownMenuItem(
+                text = { Text("Change text color") },
+                onClick = {
+                    menuOpen = false
+                    editingTarget = ProgressBarColorTarget.Text
+                },
+            )
+            DropdownMenuItem(
+                text = { Text("Reset colors") },
+                onClick = {
+                    menuOpen = false
+                    colorState.saveColors(
+                        data.id,
+                        WarlockColor.Unspecified,
+                        WarlockColor.Unspecified,
+                        WarlockColor.Unspecified,
+                    )
+                },
+            )
+        }
+    }
+
+    editingTarget?.let { target ->
+        val current =
+            when (target) {
+                ProgressBarColorTarget.Bar -> barColor
+                ProgressBarColorTarget.Background -> backgroundColor
+                ProgressBarColorTarget.Text -> textColor
+            }
+        ColorPickerDialog(
+            initialColor = current.toColor().takeIf { it.isSpecified },
+            onCloseRequest = { editingTarget = null },
+            onColorSelect = { chosen ->
+                colorState.saveColors(
+                    data.id,
+                    if (target == ProgressBarColorTarget.Bar) chosen else barColor,
+                    if (target == ProgressBarColorTarget.Background) chosen else backgroundColor,
+                    if (target == ProgressBarColorTarget.Text) chosen else textColor,
+                )
+                editingTarget = null
+            },
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Makes the per-character progress-bar **color overrides** apply everywhere a progress bar is shown, on both platforms.

- Moves `LocalProgressBarColors` / `ProgressBarColorState` to `commonMain` so desktop and mobile share one composition local.
- **Desktop:** hoists the `LocalProgressBarColors` provider in `DesktopGameView` so it also wraps the vitals bar in the control bar. Previously the provider only covered the dockable text windows, so the vitals bars ignored saved overrides and their right-click "Change bar/background/text color" menu silently did nothing (it read the default empty state).
- **Mobile:** provides `LocalProgressBarColors` in `GameView` and applies the overrides in `DialogContent`, with a long-press menu + color picker — the touch equivalent of the desktop right-click color menu.

## Testing

- `:compose:compileKotlinJvm`, `:compose:compileAndroidMain`, `:compose:ktlintCheck` all pass.
- Manually verified on desktop: right-click a vitals bar → change a color → it applies and persists across a reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
