### PR TITLE
Add desktop dev tooling: --exit-on-disconnect, run timing, skip update in dev

### DIFF
--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -101,6 +101,7 @@ import java.awt.Dimension
 import java.io.File
 import kotlin.system.exitProcess
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 private val version = System.getProperty("warlock.release.version")?.takeIf { it.isNotBlank() }
 
@@ -126,9 +127,14 @@ private class WarlockCommand : CliktCommand() {
     ).int()
     val positionX: Int? by option("-x", "--position-x", help = "Position to place the window on the X-axis").int()
     val positionY: Int? by option("-y", "--position-y", help = "Position to place the window on the Y-axis").int()
+    val exitOnDisconnect: Boolean by option(
+        "--exit-on-disconnect",
+        help = "Exit the client when the game connection disconnects",
+    ).flag()
 
     @OptIn(FlowPreview::class, ExperimentalFoundationApi::class)
     override fun run() {
+        val started = TimeSource.Monotonic.markNow()
         Logger.setLogWriters(platformLogWriter())
         ComposeFoundationFlags.isNewContextMenuEnabled = true
 
@@ -215,9 +221,13 @@ private class WarlockCommand : CliktCommand() {
                     }
                 }
 
-                LaunchedEffect(Unit) {
-                    withContext(Dispatchers.IO) {
-                        checkUpdate()
+                // Dev builds (no baked-in release version) have nothing to update to, so skip the
+                // network update check.
+                if (version != null) {
+                    LaunchedEffect(Unit) {
+                        withContext(Dispatchers.IO) {
+                            checkUpdate()
+                        }
                     }
                 }
 
@@ -246,6 +256,18 @@ private class WarlockCommand : CliktCommand() {
                     val connectedScreen = gameState.screen as? GameScreen.ConnectedGameState
                     val characterFlow = connectedScreen?.viewModel?.character ?: flowOf(null)
                     val connectedCharacter by characterFlow.collectAsState(null)
+                    if (exitOnDisconnect) {
+                        // Tear the app down as soon as the connection drops (e.g. an input file
+                        // replayed to EOF) instead of showing the reconnect banner.
+                        val disconnectedFlow = connectedScreen?.viewModel?.disconnected ?: flowOf(false)
+                        val disconnected by disconnectedFlow.collectAsState(false)
+                        LaunchedEffect(disconnected) {
+                            if (disconnected) {
+                                println("App ran for ${started.elapsedNow()}")
+                                exitApplication()
+                            }
+                        }
+                    }
                     JewelDecoratedWindow(
                         title = title,
                         state = windowState,


### PR DESCRIPTION
## Summary

Small desktop-only tooling additions, useful for replay benchmarking and development:

- **`--exit-on-disconnect`** — exits the client once the game connection drops (e.g. an `--input` file replayed to EOF) instead of showing the reconnect banner. Independent of how you connect.
- **Run timing** — prints `App ran for <duration>` when that exit fires, measured from the start of `run()` (excludes Gradle/compile), so a `--input <log> --exit-on-disconnect` run gives a repeatable wall-clock number per replay.
- **Skip auto-update in dev** — dev builds (no baked-in release version) skip the network update check, which has nothing to update to anyway; packaged releases are unaffected.

## Testing

- `:desktopApp:compileKotlin`, `:desktopApp:ktlintMainSourceSetCheck` pass.
- Ran `./gradlew run --args="--input <session.log> --exit-on-disconnect"`: replays the log, prints the duration, and exits cleanly (verified against a 389-line and a 21,619-line session log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
