### PR TITLE
Text-stream buffer perf, suppress-prompts setting, and shared window-view scaffold

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -3,6 +3,9 @@ package warlockfe.warlock3.compose.ui.window
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.buildAnnotatedString
 import co.touchlab.kermit.Logger
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -45,6 +48,7 @@ class ComposeTextStream(
     private var markLinks: Boolean,
     private var showImages: Boolean,
     private var showTimestamps: Boolean,
+    private var suppressPrompts: Boolean,
     private val highlights: StateFlow<HighlightIndex>,
     private val names: StateFlow<List<ViewHighlight>>,
     private val alterations: StateFlow<List<CompiledAlteration>>,
@@ -53,9 +57,18 @@ class ComposeTextStream(
     private val workQueue: StreamWorkQueue,
     private val scope: CoroutineScope,
 ) : TextStream {
-    private val cacheLines = ArrayList<CachedLine?>(maxLines)
-    private val finishedLines = ArrayList<StreamLine>(maxLines)
+    // ArrayDeque so trimming the oldest line (removeAt(0)) once the buffer fills is O(1) rather than
+    // the O(n) front shift of an ArrayList.
+    private val cacheLines = ArrayDeque<CachedLine?>(maxLines)
+    private val finishedLines = ArrayDeque<StreamLine>(maxLines)
     val lines = MutableStateFlow<List<StreamLine>>(emptyList())
+
+    // The displayed lines are an append-only persistent list plus a logical start index. Once the
+    // buffer fills, evicting the oldest displayed line (which happens on every newline) is then an
+    // O(1) start bump rather than an O(n) front removal, while appends stay O(log n). The backing is
+    // compacted once the dropped prefix grows large, amortizing that to O(1) per line.
+    private var displayBacking: PersistentList<StreamLine> = persistentListOf()
+    private var displayStart: Int = 0
     private val components = mutableMapOf<String, StyledString>()
 
     private var nextSerialNumber = 0L
@@ -125,8 +138,9 @@ class ComposeTextStream(
                     isPrompt = isPrompt,
                 )
             cacheLines[cacheLines.lastIndex] = cachedLine
-            finishedLines[finishedLines.lastIndex] = cachedLineToStreamLine(cachedLine, serialNumber)
-            linesUpdated()
+            val newLine = cachedLineToStreamLine(cachedLine, serialNumber)
+            finishedLines[finishedLines.lastIndex] = newLine
+            replaceLineInView(serialNumber, newLine)
         }
     }
 
@@ -175,7 +189,7 @@ class ComposeTextStream(
         val line = cachedLineToStreamLine(cachedLine, serialNumber)
         finishedLines.add(line)
         line.text?.let { playSound(it.text) }
-        linesUpdated()
+        appendLineToView(line)
     }
 
     private fun addComponentLocations(
@@ -249,12 +263,109 @@ class ComposeTextStream(
     }
 
     private fun updateLine(lineNumber: Int) {
-        val cachedLine = cacheLines[lineNumber]
-        if (cachedLine != null) {
-            val serialNumber = finishedLines[lineNumber].serialNumber
-            finishedLines[lineNumber] = cachedLineToStreamLine(cachedLine, serialNumber)
-            linesUpdated()
+        val cachedLine = cacheLines[lineNumber] ?: return
+        val serialNumber = finishedLines[lineNumber].serialNumber
+        val newLine = cachedLineToStreamLine(cachedLine, serialNumber)
+        finishedLines[lineNumber] = newLine
+        replaceLineInView(serialNumber, newLine)
+    }
+
+    // Append a single line to the displayed list instead of rebuilding and re-filtering all of it.
+    private fun appendLineToView(line: StreamLine) {
+        var changed = false
+        // removeLines() evicted the oldest lines from the buffer; being the smallest serial numbers
+        // they sit at the front of the serial-ordered view (when shown). Advancing the logical start
+        // drops them in O(1) each instead of an O(n) front removal.
+        val oldestSerial = finishedLines.firstOrNull()?.serialNumber
+        if (oldestSerial != null) {
+            while (displayStart < displayBacking.size &&
+                displayBacking[displayStart].serialNumber < oldestSerial
+            ) {
+                displayStart++
+                changed = true
+            }
         }
+        if (linePassesFilter(line)) {
+            displayBacking = displayBacking.add(line)
+            changed = true
+        }
+        if (changed) {
+            compactBacking()
+            publishLines()
+        }
+    }
+
+    // Replace a single already-displayed line. Updates almost always target the most recent line, so
+    // check the tail before binary searching the live window; PersistentList.set shares structure,
+    // avoiding a full copy. A line's prompt flag is fixed, but its name-filter match can change, so
+    // handle it appearing/disappearing.
+    private fun replaceLineInView(
+        serialNumber: Long,
+        newLine: StreamLine,
+    ) {
+        val backingIndex =
+            if (displayBacking.lastOrNull()?.serialNumber == serialNumber) {
+                displayBacking.lastIndex
+            } else {
+                displayBacking.binarySearch(displayStart, displayBacking.size) {
+                    it.serialNumber.compareTo(serialNumber)
+                }
+            }
+        val shouldShow = linePassesFilter(newLine)
+        when {
+            backingIndex >= displayStart && shouldShow -> {
+                displayBacking = displayBacking.set(backingIndex, newLine)
+                publishLines()
+            }
+
+            backingIndex >= displayStart -> {
+                // Was visible, now filtered out.
+                displayBacking = displayBacking.removeAt(backingIndex)
+                publishLines()
+            }
+
+            shouldShow -> {
+                // Was filtered out, now visible: rebuild so it lands in serial order.
+                linesUpdated()
+            }
+
+            // else: filtered out before and after - nothing to update.
+        }
+    }
+
+    // Drop the evicted prefix once it is as large as the live portion. The rebuild is O(n) but runs
+    // about once per n evictions, so it amortizes to O(1) per newline while keeping the backing from
+    // growing without bound.
+    private fun compactBacking() {
+        if (displayStart > 0 && displayStart >= displayBacking.size - displayStart) {
+            displayBacking = displayBacking.subList(displayStart, displayBacking.size).toPersistentList()
+            displayStart = 0
+        }
+    }
+
+    private fun publishLines() {
+        lines.value = OffsetList(displayBacking, displayStart)
+    }
+
+    // An O(1), immutable view over [backing] starting at [start], so the displayed window can be
+    // published without copying while the backing still carries an evicted prefix.
+    //
+    // Equality is referential, not a List's usual content equality: publishLines() emits a fresh
+    // instance only when the displayed lines actually changed, so identity inequality already means
+    // "changed". That lets StateFlow's de-dup and Compose's snapshot state skip an O(n) content
+    // comparison on every update - which otherwise dominates same-window updates such as a streaming
+    // partial line or a component refresh.
+    private class OffsetList(
+        private val backing: List<StreamLine>,
+        private val start: Int,
+    ) : AbstractList<StreamLine>() {
+        override val size: Int get() = backing.size - start
+
+        override fun get(index: Int): StreamLine = backing[start + index]
+
+        override fun equals(other: Any?): Boolean = this === other
+
+        override fun hashCode(): Int = size
     }
 
     private fun cachedLineToStreamLine(
@@ -303,14 +414,25 @@ class ComposeTextStream(
         this.showImages = showImages
     }
 
-    private fun linesUpdated() {
-        lines.value =
-            if (nameFilter) {
-                finishedLines.filter { lineMatchesName(it) }
-            } else {
-                finishedLines.toList()
+    fun setSuppressPrompts(suppressPrompts: Boolean) {
+        if (this.suppressPrompts == suppressPrompts) return
+        this.suppressPrompts = suppressPrompts
+        scope.launch {
+            workQueue.submit {
+                mutex.withLock { linesUpdated() }
             }
+        }
     }
+
+    private fun linesUpdated() {
+        displayBacking = finishedLines.filter { linePassesFilter(it) }.toPersistentList()
+        displayStart = 0
+        publishLines()
+    }
+
+    private fun linePassesFilter(line: StreamLine): Boolean =
+        (!nameFilter || lineMatchesName(line)) &&
+            (!suppressPrompts || (line as? StreamTextLine)?.isPrompt != true)
 
     private fun lineMatchesName(line: StreamLine): Boolean {
         val text = (line as? StreamTextLine)?.text?.text ?: return false

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowRegistryImpl.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowRegistryImpl.kt
@@ -88,6 +88,19 @@ class WindowRegistryImpl(
                 initialValue = true,
             )
 
+    private val suppressPrompts =
+        settingRepository
+            .observeSuppressPrompts()
+            .onEach {
+                streams.load().values.forEach { stream ->
+                    stream.setSuppressPrompts(it)
+                }
+            }.stateIn(
+                scope = scope,
+                started = SharingStarted.Eagerly,
+                initialValue = false,
+            )
+
     private val characterId = MutableStateFlow("global")
 
     private val names: StateFlow<List<ViewHighlight>> =
@@ -203,6 +216,7 @@ class WindowRegistryImpl(
                 markLinks = markLinks.value,
                 showImages = showImages.value,
                 showTimestamps = false,
+                suppressPrompts = suppressPrompts.value,
                 workQueue = workQueue,
                 scope = scope,
             )

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
@@ -1,0 +1,419 @@
+package warlockfe.warlock3.compose.ui.window
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.contextmenu.modifier.appendTextContextMenuComponents
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onLayoutRectChanged
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import co.touchlab.kermit.Logger
+import coil3.compose.AsyncImagePainter
+import coil3.compose.LocalPlatformContext
+import coil3.compose.rememberAsyncImagePainter
+import coil3.request.ImageRequest
+import coil3.size.Size
+import warlockfe.warlock3.compose.util.ClearContextMenuItemKey
+import warlockfe.warlock3.compose.util.CloseContextMenuItemKey
+import warlockfe.warlock3.compose.util.SettingsContextMenuItemKey
+import warlockfe.warlock3.compose.util.addItem
+import warlockfe.warlock3.compose.util.createFontFamily
+import warlockfe.warlock3.compose.util.toColor
+import warlockfe.warlock3.core.client.WarlockAction
+import warlockfe.warlock3.core.client.WarlockMenuData
+import warlockfe.warlock3.core.macro.ScrollEvent
+import warlockfe.warlock3.core.text.StyleDefinition
+import warlockfe.warlock3.core.window.ClientBackgroundImage
+import warlockfe.warlock3.core.window.WindowLocation
+
+/**
+ * Platform-agnostic window view. Holds the structure shared by the desktop and mobile clients (the
+ * frame, header, stream/dialog dispatch, the text/image render loop, and keyboard scroll handling).
+ * The pieces that genuinely differ between toolkits (the surrounding surface, the header chrome, the
+ * scrollbar, the action context menu, the settings dialog, and dialog content) are supplied by the
+ * caller as slots so each platform can render them with its own component library.
+ */
+@Composable
+internal fun WindowViewScaffold(
+    uiState: WindowUiState,
+    location: WindowLocation,
+    defaultStyle: StyleDefinition,
+    isSelected: Boolean,
+    openWindows: List<String>,
+    menuData: WarlockMenuData?,
+    onActionClick: (WarlockAction) -> Int?,
+    onCloseClick: () -> Unit,
+    onSelect: () -> Unit,
+    clearStream: () -> Unit,
+    scrollEvents: List<ScrollEvent>,
+    handledScrollEvent: (ScrollEvent) -> Unit,
+    defaultFontSize: TextUnit,
+    surface: @Composable (modifier: Modifier, content: @Composable () -> Unit) -> Unit,
+    header: @Composable (title: String, onSettingsClick: () -> Unit) -> Unit,
+    listContainer: @Composable (scrollState: LazyListState, content: @Composable () -> Unit) -> Unit,
+    actionContextMenu: @Composable (offset: Offset?, menuData: WarlockMenuData, onDismiss: () -> Unit) -> Unit,
+    settingsDialog: @Composable (onCloseRequest: () -> Unit) -> Unit,
+    dialogContent: @Composable (data: DialogWindowData, style: StyleDefinition) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val window by uiState.windowInfo
+    var showWindowSettingsDialog by remember { mutableStateOf(false) }
+    val scrollState = rememberLazyListState()
+
+    val title = (window?.title ?: uiState.name) + (window?.subtitle ?: "")
+    var viewportHeight by remember { mutableIntStateOf(0) }
+
+    surface(
+        modifier
+            .padding(2.dp)
+            .onLayoutRectChanged { bounds ->
+                viewportHeight = bounds.height
+            }.onFocusChanged { focusState ->
+                if (focusState.hasFocus) {
+                    onSelect()
+                }
+            }.semantics {
+                paneTitle = title
+            },
+    ) {
+        Column {
+            header(title) { showWindowSettingsDialog = true }
+
+            when (val data = uiState.data) {
+                is StreamWindowData -> {
+                    WindowViewContent(
+                        modifier =
+                            Modifier.addTextContextMenuOptions(
+                                windowLocation = location,
+                                showSettingsDialog = { showWindowSettingsDialog = true },
+                                onClearClick = clearStream,
+                                onCloseClick = onCloseClick,
+                            ),
+                        stream = data.stream,
+                        scrollState = scrollState,
+                        style = uiState.style.mergeWith(defaultStyle),
+                        backgroundImage = window?.backgroundImage,
+                        openWindows = openWindows,
+                        menuData = menuData,
+                        onActionClick = onActionClick,
+                        defaultFontSize = defaultFontSize,
+                        listContainer = listContainer,
+                        actionContextMenu = actionContextMenu,
+                    )
+                }
+
+                is DialogWindowData -> {
+                    dialogContent(data, uiState.style.mergeWith(defaultStyle))
+                }
+
+                else -> {
+                    // Loading
+                }
+            }
+        }
+    }
+
+    if (showWindowSettingsDialog) {
+        settingsDialog { showWindowSettingsDialog = false }
+    }
+
+    val currentHandledScrollEvent by rememberUpdatedState(handledScrollEvent)
+    LaunchedEffect(scrollEvents) {
+        if (isSelected) {
+            val event = scrollEvents.firstOrNull()
+            if (event != null) {
+                when (event) {
+                    ScrollEvent.PAGE_UP -> {
+                        scrollState.scrollBy(-viewportHeight.toFloat())
+                    }
+
+                    ScrollEvent.PAGE_DOWN -> {
+                        scrollState.scrollBy(viewportHeight.toFloat())
+                    }
+
+                    ScrollEvent.LINE_UP -> {
+                        scrollState.scrollBy(-20f)
+                    }
+
+                    ScrollEvent.LINE_DOWN -> {
+                        scrollState.scrollBy(20f)
+                    }
+
+                    ScrollEvent.BUFFER_END -> {
+                        scrollState.scrollToItem(scrollState.layoutInfo.totalItemsCount - 1)
+                    }
+
+                    ScrollEvent.BUFFER_START -> {
+                        scrollState.scrollToItem(0)
+                    }
+                }
+                currentHandledScrollEvent(event)
+            }
+        }
+    }
+}
+
+@Composable
+private fun WindowViewContent(
+    stream: ComposeTextStream,
+    scrollState: LazyListState,
+    style: StyleDefinition,
+    backgroundImage: ClientBackgroundImage?,
+    openWindows: List<String>,
+    menuData: WarlockMenuData?,
+    onActionClick: (WarlockAction) -> Int?,
+    defaultFontSize: TextUnit,
+    listContainer: @Composable (scrollState: LazyListState, content: @Composable () -> Unit) -> Unit,
+    actionContextMenu: @Composable (offset: Offset?, menuData: WarlockMenuData, onDismiss: () -> Unit) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val backgroundColor = style.backgroundColor.toColor()
+    val textColor = style.textColor.toColor()
+    val fontFamily = style.fontFamily?.let { createFontFamily(it) }
+    val fontSize = style.fontSize?.sp ?: defaultFontSize
+    val fontWeight = style.fontWeight?.let { FontWeight(it) }
+
+    val lines = stream.lines.collectAsState(emptyList()).value
+
+    var clickOffset by remember { mutableStateOf<Offset?>(null) }
+    var openMenuId by remember { mutableStateOf<Int?>(null) }
+
+    val currentOnActionClick by rememberUpdatedState(onActionClick)
+    DisposableEffect(stream) {
+        stream.actionHandler = { action ->
+            Logger.d { "action clicked: $action" }
+            openMenuId = currentOnActionClick(action)
+        }
+        onDispose {
+            stream.actionHandler = null
+        }
+    }
+
+    SelectionContainer(modifier = modifier) {
+        BoxWithConstraints(
+            Modifier
+                .fillMaxSize()
+                .clipToBounds()
+                .background(backgroundColor),
+        ) {
+            backgroundImage?.takeIf { it.image.isNotBlank() }?.let { image ->
+                WindowBackgroundImage(
+                    backgroundImage = image,
+                    width = maxWidth,
+                    height = maxHeight,
+                    modifier = Modifier.align(image.backgroundAlignment()),
+                )
+            }
+            listContainer(scrollState) {
+                LazyColumn(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(vertical = 4.dp)
+                            .semantics {
+                                isTraversalGroup = true
+                                liveRegion = LiveRegionMode.Polite
+                            },
+                    state = scrollState,
+                ) {
+                    items(
+                        count = lines.size,
+                        key = { index -> lines[index].serialNumber },
+                    ) { index ->
+                        when (val line = lines[index]) {
+                            is StreamTextLine -> {
+                                if (line.text != null &&
+                                    line.isShowing(openWindows) &&
+                                    (!line.isPrompt || !lines.isPreviousPrompt(index, openWindows))
+                                ) {
+                                    var positionInParent by remember { mutableStateOf(Offset.Zero) }
+                                    Box(
+                                        modifier =
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .onGloballyPositioned {
+                                                    positionInParent = it.positionInParent()
+                                                }.background(
+                                                    line.entireLineStyle?.backgroundColor?.toColor()
+                                                        ?: Color.Unspecified,
+                                                ).padding(start = 4.dp, end = 8.dp),
+                                    ) {
+                                        BasicText(
+                                            modifier =
+                                                Modifier
+                                                    .pointerInput(Unit) {
+                                                        awaitPointerEventScope {
+                                                            while (true) {
+                                                                val event = awaitPointerEvent()
+                                                                if (event.type == PointerEventType.Press) {
+                                                                    Logger.d { "Click: $event" }
+                                                                    clickOffset =
+                                                                        event.changes
+                                                                            .firstOrNull()
+                                                                            ?.position
+                                                                            ?.let { it + positionInParent }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                            text = line.text,
+                                            style =
+                                                TextStyle(
+                                                    color = textColor,
+                                                    fontFamily = fontFamily,
+                                                    fontSize = fontSize,
+                                                    fontWeight = fontWeight,
+                                                ),
+                                        )
+                                    }
+                                }
+                            }
+
+                            is StreamImageLine -> {
+                                val defaultHeight = 80.dp
+                                Box(Modifier.height(defaultHeight).fillMaxWidth().zIndex(1f)) {
+                                    val painter =
+                                        rememberAsyncImagePainter(
+                                            ImageRequest
+                                                .Builder(LocalPlatformContext.current)
+                                                .data(line.url)
+                                                .size(Size.ORIGINAL)
+                                                .build(),
+                                        )
+                                    val painterState by painter.state.collectAsState()
+                                    when (val state = painterState) {
+                                        is AsyncImagePainter.State.Success -> {
+                                            val interactionSource = remember { MutableInteractionSource() }
+                                            val hovered by interactionSource.collectIsHoveredAsState()
+                                            Logger.d { "Hovered: $hovered" }
+                                            val height =
+                                                if (hovered) {
+                                                    with(LocalDensity.current) {
+                                                        max(
+                                                            state.result.image.height
+                                                                .toDp(),
+                                                            defaultHeight,
+                                                        )
+                                                    }
+                                                } else {
+                                                    defaultHeight
+                                                }
+                                            Image(
+                                                modifier =
+                                                    Modifier
+                                                        .hoverable(interactionSource)
+                                                        .wrapContentSize(unbounded = true, align = Alignment.TopStart)
+                                                        .animateContentSize()
+                                                        .height(height),
+                                                painter = painter,
+                                                contentDescription = null,
+                                            )
+                                        }
+
+                                        else -> {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (menuData != null && menuData.id == openMenuId) {
+        actionContextMenu(clickOffset, menuData) { openMenuId = null }
+    }
+
+    var sticky by remember { mutableStateOf(true) }
+    val lastSerial = lines.lastOrNull()?.serialNumber
+    LaunchedEffect(lastSerial) {
+        if (lastSerial != null && sticky) {
+            lines.lastIndex.takeIf { it > -1 }?.let { index ->
+                scrollState.scrollToItem(index)
+            }
+        }
+    }
+    LaunchedEffect(scrollState.lastScrolledBackward, scrollState.canScrollForward) {
+        // If the user scrolled back and they can scroll forward, stop being sticky
+        // if the window can't be scrolled forward, be sticky again
+        if (scrollState.lastScrolledBackward && scrollState.canScrollForward) {
+            sticky = false
+        } else if (!scrollState.canScrollForward) {
+            sticky = true
+        }
+    }
+}
+
+@Composable
+internal fun Modifier.addTextContextMenuOptions(
+    windowLocation: WindowLocation,
+    showSettingsDialog: () -> Unit,
+    onClearClick: () -> Unit,
+    onCloseClick: () -> Unit,
+): Modifier =
+    this.appendTextContextMenuComponents {
+        separator()
+        addItem(key = SettingsContextMenuItemKey, label = "Window settings ...") {
+            showSettingsDialog()
+            close()
+        }
+        addItem(key = ClearContextMenuItemKey, label = "Clear window") {
+            onClearClick()
+            close()
+        }
+        if (windowLocation != WindowLocation.MAIN) {
+            addItem(key = CloseContextMenuItemKey, label = "Hide window") {
+                onCloseClick()
+                close()
+            }
+        }
+    }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopGeneralSettingsView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopGeneralSettingsView.kt
@@ -144,6 +144,21 @@ fun DesktopGeneralSettingsView(
 
             Spacer(Modifier.height(16.dp))
 
+            val suppressPrompts by clientSettingRepository
+                .observeSuppressPrompts()
+                .collectAsState(initial = false)
+            WarlockCheckboxRow(
+                checked = suppressPrompts,
+                onCheckedChange = {
+                    scope.launch {
+                        clientSettingRepository.putSuppressPrompts(it)
+                    }
+                },
+                text = "Hide prompts",
+            )
+
+            Spacer(Modifier.height(16.dp))
+
             val autoConnectLastConnection by clientSettingRepository
                 .observeAutoConnectLastConnection()
                 .collectAsState(initial = false)

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowView.kt
@@ -1,64 +1,32 @@
 package warlockfe.warlock3.compose.desktop.ui.window
 
-import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.scrollBy
-import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.HoverInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.foundation.text.contextmenu.modifier.appendTextContextMenuComponents
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.onLayoutRectChanged
-import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.semantics.LiveRegionMode
-import androidx.compose.ui.semantics.isTraversalGroup
-import androidx.compose.ui.semantics.liveRegion
-import androidx.compose.ui.semantics.paneTitle
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -68,16 +36,8 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.PopupPositionProvider
-import androidx.compose.ui.zIndex
-import co.touchlab.kermit.Logger
-import coil3.compose.AsyncImagePainter
-import coil3.compose.LocalPlatformContext
-import coil3.compose.rememberAsyncImagePainter
-import coil3.request.ImageRequest
-import coil3.size.Size
 import kotlinx.coroutines.launch
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.PopupMenu
@@ -88,29 +48,15 @@ import org.jetbrains.jewel.ui.theme.menuStyle
 import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
 import warlockfe.warlock3.compose.desktop.ui.game.gameChrome
 import warlockfe.warlock3.compose.desktop.ui.settings.DesktopWindowSettingsDialog
-import warlockfe.warlock3.compose.ui.window.ComposeTextStream
-import warlockfe.warlock3.compose.ui.window.DialogWindowData
-import warlockfe.warlock3.compose.ui.window.StreamImageLine
-import warlockfe.warlock3.compose.ui.window.StreamTextLine
-import warlockfe.warlock3.compose.ui.window.StreamWindowData
-import warlockfe.warlock3.compose.ui.window.WindowBackgroundImage
 import warlockfe.warlock3.compose.ui.window.WindowHeader
 import warlockfe.warlock3.compose.ui.window.WindowUiState
-import warlockfe.warlock3.compose.ui.window.backgroundAlignment
-import warlockfe.warlock3.compose.ui.window.isPreviousPrompt
-import warlockfe.warlock3.compose.ui.window.isShowing
-import warlockfe.warlock3.compose.util.ClearContextMenuItemKey
-import warlockfe.warlock3.compose.util.CloseContextMenuItemKey
-import warlockfe.warlock3.compose.util.SettingsContextMenuItemKey
-import warlockfe.warlock3.compose.util.addItem
-import warlockfe.warlock3.compose.util.createFontFamily
+import warlockfe.warlock3.compose.ui.window.WindowViewScaffold
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.core.client.WarlockAction
 import warlockfe.warlock3.core.client.WarlockMenuData
 import warlockfe.warlock3.core.client.WarlockMenuItem
 import warlockfe.warlock3.core.macro.ScrollEvent
 import warlockfe.warlock3.core.text.StyleDefinition
-import warlockfe.warlock3.core.window.ClientBackgroundImage
 import warlockfe.warlock3.core.window.WindowLocation
 
 private val titleSmallStyle =
@@ -140,35 +86,40 @@ fun DesktopWindowView(
     clearStream: () -> Unit,
 ) {
     val window by uiState.windowInfo
-    var showWindowSettingsDialog by remember { mutableStateOf(false) }
-    val scrollState = rememberLazyListState()
-
-    val title = (window?.title ?: uiState.name) + (window?.subtitle ?: "")
-    var viewportHeight by remember { mutableIntStateOf(0) }
-    val frameShape = RoundedCornerShape(4.dp)
-    Box(
-        modifier =
-            modifier
-                .padding(2.dp)
-                // Clip so a body that paints its own background (dialog panels, user styles) does not
-                // overdraw the rounded corners.
-                .clip(frameShape)
-                .background(gameChrome.panel, frameShape)
-                .border(
-                    Dp.Hairline,
-                    if (isSelected) gameChrome.borderStrong else gameChrome.border,
-                    frameShape,
-                ).onLayoutRectChanged { bounds ->
-                    viewportHeight = bounds.height
-                }.onFocusChanged { focusState ->
-                    if (focusState.hasFocus) {
-                        onSelect()
-                    }
-                }.semantics {
-                    paneTitle = title
-                },
-    ) {
-        Column {
+    WindowViewScaffold(
+        uiState = uiState,
+        location = location,
+        defaultStyle = defaultStyle,
+        isSelected = isSelected,
+        openWindows = openWindows,
+        menuData = menuData,
+        onActionClick = onActionClick,
+        onCloseClick = onCloseClick,
+        onSelect = onSelect,
+        clearStream = clearStream,
+        scrollEvents = scrollEvents,
+        handledScrollEvent = handledScrollEvent,
+        modifier = modifier,
+        defaultFontSize = JewelTheme.defaultTextStyle.fontSize,
+        surface = { surfaceModifier, content ->
+            val frameShape = RoundedCornerShape(4.dp)
+            androidx.compose.foundation.layout.Box(
+                modifier =
+                    surfaceModifier
+                        // Clip so a body that paints its own background (dialog panels, user styles) does not
+                        // overdraw the rounded corners.
+                        .clip(frameShape)
+                        .background(gameChrome.panel, frameShape)
+                        .border(
+                            Dp.Hairline,
+                            if (isSelected) gameChrome.borderStrong else gameChrome.border,
+                            frameShape,
+                        ),
+            ) {
+                content()
+            }
+        },
+        header = { title, onSettingsClick ->
             WindowHeader(
                 modifier =
                     headerModifier
@@ -192,326 +143,51 @@ fun DesktopWindowView(
                 },
                 location = location,
                 isSelected = isSelected,
-                onSettingsClick = { showWindowSettingsDialog = true },
+                onSettingsClick = onSettingsClick,
                 onClearClick = clearStream,
                 onCloseClick = onCloseClick,
             )
-
-            when (val data = uiState.data) {
-                is StreamWindowData -> {
-                    DesktopWindowViewContent(
-                        modifier =
-                            Modifier.addTextContextMenuOptions(
-                                windowLocation = location,
-                                showSettingsDialog = { showWindowSettingsDialog = true },
-                                onClearClick = clearStream,
-                                onCloseClick = onCloseClick,
-                            ),
-                        stream = data.stream,
-                        scrollState = scrollState,
-                        style = uiState.style.mergeWith(defaultStyle),
-                        backgroundImage = window?.backgroundImage,
-                        openWindows = openWindows,
-                        menuData = menuData,
-                        onActionClick = onActionClick,
-                    )
-                }
-
-                is DialogWindowData -> {
-                    WarlockScrollableColumn(
-                        Modifier
-                            .fillMaxSize()
-                            .background(
-                                uiState.style
-                                    .mergeWith(defaultStyle)
-                                    .backgroundColor
-                                    .toColor(),
-                            ),
-                    ) {
-                        val dataObjects by data.dialogData.objects.collectAsState()
-                        DesktopDialogContent(
-                            dataObjects = dataObjects,
-                            modifier = Modifier.padding(8.dp),
-                            executeCommand = { command ->
-                                onActionClick(WarlockAction.SendCommand(command))
-                            },
-                            style = uiState.style.mergeWith(defaultStyle),
-                        )
-                    }
-                }
-
-                else -> {
-                    // Loading
-                }
-            }
-        }
-    }
-
-    if (showWindowSettingsDialog) {
-        DesktopWindowSettingsDialog(
-            onCloseRequest = { showWindowSettingsDialog = false },
-            style = uiState.style,
-            defaultStyle = defaultStyle,
-            saveStyle = saveStyle,
-            nameFilterOption = window?.nameFilterOption ?: false,
-            nameFilter = uiState.nameFilter,
-            saveNameFilter = saveNameFilter,
-        )
-    }
-
-    val currentHandledScrollEvent by rememberUpdatedState(handledScrollEvent)
-    LaunchedEffect(scrollEvents) {
-        if (isSelected) {
-            val event = scrollEvents.firstOrNull()
-            if (event != null) {
-                when (event) {
-                    ScrollEvent.PAGE_UP -> {
-                        scrollState.scrollBy(-viewportHeight.toFloat())
-                    }
-
-                    ScrollEvent.PAGE_DOWN -> {
-                        scrollState.scrollBy(viewportHeight.toFloat())
-                    }
-
-                    ScrollEvent.LINE_UP -> {
-                        scrollState.scrollBy(-20f)
-                    }
-
-                    ScrollEvent.LINE_DOWN -> {
-                        scrollState.scrollBy(20f)
-                    }
-
-                    ScrollEvent.BUFFER_END -> {
-                        scrollState.scrollToItem(scrollState.layoutInfo.totalItemsCount - 1)
-                    }
-
-                    ScrollEvent.BUFFER_START -> {
-                        scrollState.scrollToItem(0)
-                    }
-                }
-                currentHandledScrollEvent(event)
-            }
-        }
-    }
-}
-
-@Composable
-private fun Modifier.addTextContextMenuOptions(
-    windowLocation: WindowLocation,
-    showSettingsDialog: () -> Unit,
-    onClearClick: () -> Unit,
-    onCloseClick: () -> Unit,
-): Modifier =
-    this.appendTextContextMenuComponents {
-        separator()
-        addItem(key = SettingsContextMenuItemKey, label = "Window settings ...") {
-            showSettingsDialog()
-            close()
-        }
-        addItem(key = ClearContextMenuItemKey, label = "Clear window") {
-            onClearClick()
-            close()
-        }
-        if (windowLocation != WindowLocation.MAIN) {
-            addItem(key = CloseContextMenuItemKey, label = "Hide window") {
-                onCloseClick()
-                close()
-            }
-        }
-    }
-
-@Composable
-private fun DesktopWindowViewContent(
-    stream: ComposeTextStream,
-    scrollState: LazyListState,
-    style: StyleDefinition,
-    backgroundImage: ClientBackgroundImage?,
-    openWindows: List<String>,
-    menuData: WarlockMenuData?,
-    onActionClick: (WarlockAction) -> Int?,
-    modifier: Modifier = Modifier,
-) {
-    val backgroundColor = style.backgroundColor.toColor()
-    val textColor = style.textColor.toColor()
-    val fontFamily = style.fontFamily?.let { createFontFamily(it) }
-    val fontSize = style.fontSize?.sp ?: JewelTheme.defaultTextStyle.fontSize
-    val fontWeight = style.fontWeight?.let { FontWeight(it) }
-
-    val lines = stream.lines.collectAsState(emptyList()).value
-
-    var clickOffset by remember { mutableStateOf<Offset?>(null) }
-    var openMenuId by remember { mutableStateOf<Int?>(null) }
-
-    val currentOnActionClick by rememberUpdatedState(onActionClick)
-    DisposableEffect(stream) {
-        stream.actionHandler = { action ->
-            Logger.d { "action clicked: $action" }
-            openMenuId = currentOnActionClick(action)
-        }
-        onDispose {
-            stream.actionHandler = null
-        }
-    }
-
-    SelectionContainer(modifier = modifier) {
-        BoxWithConstraints(
-            Modifier
-                .fillMaxSize()
-                .clipToBounds()
-                .background(backgroundColor),
-        ) {
-            backgroundImage?.takeIf { it.image.isNotBlank() }?.let { image ->
-                WindowBackgroundImage(
-                    backgroundImage = image,
-                    width = maxWidth,
-                    height = maxHeight,
-                    modifier = Modifier.align(image.backgroundAlignment()),
-                )
-            }
+        },
+        listContainer = { scrollState, content ->
             VerticallyScrollableContainer(
                 scrollState = scrollState,
                 modifier = Modifier.fillMaxSize(),
             ) {
-                LazyColumn(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(vertical = 4.dp)
-                            .semantics {
-                                isTraversalGroup = true
-                                liveRegion = LiveRegionMode.Polite
-                            },
-                    state = scrollState,
-                ) {
-                    items(
-                        count = lines.size,
-                        key = { index -> lines[index].serialNumber },
-                    ) { index ->
-                        when (val line = lines[index]) {
-                            is StreamTextLine -> {
-                                if (line.text != null &&
-                                    line.isShowing(openWindows) &&
-                                    (!line.isPrompt || !lines.isPreviousPrompt(index, openWindows))
-                                ) {
-                                    var positionInParent by remember { mutableStateOf(Offset.Zero) }
-                                    Box(
-                                        modifier =
-                                            Modifier
-                                                .fillMaxWidth()
-                                                .onGloballyPositioned {
-                                                    positionInParent = it.positionInParent()
-                                                }.background(
-                                                    line.entireLineStyle?.backgroundColor?.toColor()
-                                                        ?: Color.Unspecified,
-                                                ).padding(start = 4.dp, end = 8.dp),
-                                    ) {
-                                        BasicText(
-                                            modifier =
-                                                Modifier
-                                                    .pointerInput(Unit) {
-                                                        awaitPointerEventScope {
-                                                            while (true) {
-                                                                val event = awaitPointerEvent()
-                                                                if (event.type == PointerEventType.Press) {
-                                                                    Logger.d { "Click: $event" }
-                                                                    clickOffset =
-                                                                        event.changes
-                                                                            .firstOrNull()
-                                                                            ?.position
-                                                                            ?.let { it + positionInParent }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                            text = line.text,
-                                            style =
-                                                TextStyle(
-                                                    color = textColor,
-                                                    fontFamily = fontFamily,
-                                                    fontSize = fontSize,
-                                                    fontWeight = fontWeight,
-                                                ),
-                                        )
-                                    }
-                                }
-                            }
-
-                            is StreamImageLine -> {
-                                val defaultHeight = 80.dp
-                                Box(Modifier.height(defaultHeight).fillMaxWidth().zIndex(1f)) {
-                                    val painter =
-                                        rememberAsyncImagePainter(
-                                            ImageRequest
-                                                .Builder(LocalPlatformContext.current)
-                                                .data(line.url)
-                                                .size(Size.ORIGINAL)
-                                                .build(),
-                                        )
-                                    val painterState by painter.state.collectAsState()
-                                    when (val state = painterState) {
-                                        is AsyncImagePainter.State.Success -> {
-                                            val interactionSource = remember { MutableInteractionSource() }
-                                            val hovered by interactionSource.collectIsHoveredAsState()
-                                            Logger.d { "Hovered: $hovered" }
-                                            val height =
-                                                if (hovered) {
-                                                    with(LocalDensity.current) {
-                                                        max(
-                                                            state.result.image.height
-                                                                .toDp(),
-                                                            defaultHeight,
-                                                        )
-                                                    }
-                                                } else {
-                                                    defaultHeight
-                                                }
-                                            Image(
-                                                modifier =
-                                                    Modifier
-                                                        .hoverable(interactionSource)
-                                                        .wrapContentSize(unbounded = true, align = Alignment.TopStart)
-                                                        .animateContentSize()
-                                                        .height(height),
-                                                painter = painter,
-                                                contentDescription = null,
-                                            )
-                                        }
-
-                                        else -> {}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                content()
             }
-        }
-    }
-
-    if (menuData != null && menuData.id == openMenuId) {
-        ActionContextMenu(
-            offset = clickOffset,
-            menuData = menuData,
-            onDismiss = { openMenuId = null },
-        )
-    }
-
-    var sticky by remember { mutableStateOf(true) }
-    val lastSerial = lines.lastOrNull()?.serialNumber
-    LaunchedEffect(lastSerial) {
-        if (lastSerial != null && sticky) {
-            lines.lastIndex.takeIf { it > -1 }?.let { index ->
-                scrollState.scrollToItem(index)
+        },
+        actionContextMenu = { offset, menu, onDismiss ->
+            ActionContextMenu(offset = offset, menuData = menu, onDismiss = onDismiss)
+        },
+        settingsDialog = { onCloseRequest ->
+            DesktopWindowSettingsDialog(
+                onCloseRequest = onCloseRequest,
+                style = uiState.style,
+                defaultStyle = defaultStyle,
+                saveStyle = saveStyle,
+                nameFilterOption = window?.nameFilterOption ?: false,
+                nameFilter = uiState.nameFilter,
+                saveNameFilter = saveNameFilter,
+            )
+        },
+        dialogContent = { data, style ->
+            WarlockScrollableColumn(
+                Modifier
+                    .fillMaxSize()
+                    .background(style.backgroundColor.toColor()),
+            ) {
+                val dataObjects by data.dialogData.objects.collectAsState()
+                DesktopDialogContent(
+                    dataObjects = dataObjects,
+                    modifier = Modifier.padding(8.dp),
+                    executeCommand = { command ->
+                        onActionClick(WarlockAction.SendCommand(command))
+                    },
+                    style = style,
+                )
             }
-        }
-    }
-    LaunchedEffect(scrollState.lastScrolledBackward, scrollState.canScrollForward) {
-        if (scrollState.lastScrolledBackward && scrollState.canScrollForward) {
-            sticky = false
-        } else if (!scrollState.canScrollForward) {
-            sticky = true
-        }
-    }
+        },
+    )
 }
 
 private class OffsetPositionProvider(

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/GeneralSettingsView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/GeneralSettingsView.kt
@@ -204,6 +204,17 @@ fun GeneralSettingsView(
 
             Spacer(Modifier.height(16.dp))
 
+            val suppressPrompts by clientSettingRepository
+                .observeSuppressPrompts()
+                .collectAsState(initial = false)
+            SwitchRow(
+                checked = suppressPrompts,
+                onCheckedChange = { scope.launch { clientSettingRepository.putSuppressPrompts(it) } },
+                text = "Hide prompts",
+            )
+
+            Spacer(Modifier.height(16.dp))
+
             val autoConnectLastConnection by clientSettingRepository
                 .observeAutoConnectLastConnection()
                 .collectAsState(initial = false)

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowView.kt
@@ -1,28 +1,12 @@
 package warlockfe.warlock3.compose.ui.window
 
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.scrollBy
-import androidx.compose.foundation.hoverable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.foundation.text.contextmenu.modifier.appendTextContextMenuComponents
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -31,48 +15,21 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.onLayoutRectChanged
-import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.semantics.LiveRegionMode
-import androidx.compose.ui.semantics.isTraversalGroup
-import androidx.compose.ui.semantics.liveRegion
-import androidx.compose.ui.semantics.paneTitle
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.max
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.zIndex
 import co.touchlab.kermit.Logger
-import coil3.compose.AsyncImagePainter
-import coil3.compose.LocalPlatformContext
-import coil3.compose.rememberAsyncImagePainter
-import coil3.request.ImageRequest
-import coil3.size.Size
 import io.github.oikvpqya.compose.fastscroller.VerticalScrollbar
 import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
 import kotlinx.coroutines.launch
@@ -82,17 +39,11 @@ import warlockfe.warlock3.compose.components.defaultScrollbarStyle
 import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.generated.resources.arrow_right
 import warlockfe.warlock3.compose.ui.settings.WindowSettingsDialog
-import warlockfe.warlock3.compose.util.ClearContextMenuItemKey
-import warlockfe.warlock3.compose.util.CloseContextMenuItemKey
-import warlockfe.warlock3.compose.util.SettingsContextMenuItemKey
-import warlockfe.warlock3.compose.util.addItem
-import warlockfe.warlock3.compose.util.createFontFamily
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.core.client.WarlockAction
 import warlockfe.warlock3.core.client.WarlockMenuData
 import warlockfe.warlock3.core.macro.ScrollEvent
 import warlockfe.warlock3.core.text.StyleDefinition
-import warlockfe.warlock3.core.window.ClientBackgroundImage
 import warlockfe.warlock3.core.window.WindowLocation
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -116,27 +67,31 @@ fun WindowView(
     clearStream: () -> Unit,
 ) {
     val window by uiState.windowInfo
-    var showWindowSettingsDialog by remember { mutableStateOf(false) }
-    val scrollState = rememberLazyListState()
-
-    val title = (window?.title ?: uiState.name) + (window?.subtitle ?: "")
-    var viewportHeight by remember { mutableIntStateOf(0) }
-    Surface(
-        modifier
-            .padding(2.dp)
-            .onLayoutRectChanged { bounds ->
-                viewportHeight = bounds.height
-            }.onFocusChanged { focusState ->
-                if (focusState.hasFocus) {
-                    onSelect()
-                }
-            }.semantics {
-                paneTitle = title
-            },
-        shape = MaterialTheme.shapes.extraSmall,
-        border = BorderStroke(Dp.Hairline, MaterialTheme.colorScheme.outline),
-    ) {
-        Column {
+    WindowViewScaffold(
+        uiState = uiState,
+        location = location,
+        defaultStyle = defaultStyle,
+        isSelected = isSelected,
+        openWindows = openWindows,
+        menuData = menuData,
+        onActionClick = onActionClick,
+        onCloseClick = onCloseClick,
+        onSelect = onSelect,
+        clearStream = clearStream,
+        scrollEvents = scrollEvents,
+        handledScrollEvent = handledScrollEvent,
+        modifier = modifier,
+        defaultFontSize = MaterialTheme.typography.bodyMedium.fontSize,
+        surface = { surfaceModifier, content ->
+            Surface(
+                surfaceModifier,
+                shape = MaterialTheme.shapes.extraSmall,
+                border = BorderStroke(Dp.Hairline, MaterialTheme.colorScheme.outline),
+            ) {
+                content()
+            }
+        },
+        header = { title, onSettingsClick ->
             WindowHeader(
                 modifier =
                     headerModifier
@@ -158,332 +113,56 @@ fun WindowView(
                 },
                 location = location,
                 isSelected = isSelected,
-                onSettingsClick = { showWindowSettingsDialog = true },
+                onSettingsClick = onSettingsClick,
                 onClearClick = clearStream,
                 onCloseClick = onCloseClick,
             )
-
-            when (val data = uiState.data) {
-                is StreamWindowData -> {
-                    WindowViewContent(
-                        modifier =
-                            Modifier.addTextContextMenuOptions(
-                                windowLocation = location,
-                                showSettingsDialog = { showWindowSettingsDialog = true },
-                                onClearClick = clearStream,
-                                onCloseClick = onCloseClick,
-                            ),
-                        stream = data.stream,
-                        scrollState = scrollState,
-                        style = uiState.style.mergeWith(defaultStyle),
-                        backgroundImage = window?.backgroundImage,
-                        openWindows = openWindows,
-                        menuData = menuData,
-                        onActionClick = onActionClick,
-                    )
-                }
-
-                is DialogWindowData -> {
-                    ScrollableColumn(
+        },
+        listContainer = { scrollState, content ->
+            Box(Modifier.fillMaxSize()) {
+                content()
+                VerticalScrollbar(
+                    adapter = rememberScrollbarAdapter(scrollState),
+                    style = defaultScrollbarStyle(),
+                    modifier =
                         Modifier
-                            .fillMaxSize()
-                            .background(
-                                uiState.style
-                                    .mergeWith(defaultStyle)
-                                    .backgroundColor
-                                    .toColor(),
-                            ),
-                    ) {
-                        val dataObjects by data.dialogData.objects.collectAsState()
-                        DialogContent(
-                            dataObjects = dataObjects,
-                            modifier = Modifier.padding(8.dp),
-                            executeCommand = { command ->
-                                onActionClick(WarlockAction.SendCommand(command))
-                            },
-                            style = uiState.style.mergeWith(defaultStyle),
-                        )
-                    }
-                }
-
-                else -> {
-                    // Loading
-                }
-            }
-        }
-    }
-
-    if (showWindowSettingsDialog) {
-        WindowSettingsDialog(
-            onCloseRequest = { showWindowSettingsDialog = false },
-            style = uiState.style,
-            defaultStyle = defaultStyle,
-            saveStyle = saveStyle,
-            nameFilterOption = window?.nameFilterOption ?: false,
-            nameFilter = uiState.nameFilter,
-            saveNameFilter = saveNameFilter,
-        )
-    }
-
-    val currentHandledScrollEvent by rememberUpdatedState(handledScrollEvent)
-    LaunchedEffect(scrollEvents) {
-        if (isSelected) {
-            val event = scrollEvents.firstOrNull()
-            if (event != null) {
-                when (event) {
-                    ScrollEvent.PAGE_UP -> {
-                        scrollState.scrollBy(-viewportHeight.toFloat())
-                    }
-
-                    ScrollEvent.PAGE_DOWN -> {
-                        scrollState.scrollBy(viewportHeight.toFloat())
-                    }
-
-                    ScrollEvent.LINE_UP -> {
-                        scrollState.scrollBy(-20f)
-                    }
-
-                    ScrollEvent.LINE_DOWN -> {
-                        scrollState.scrollBy(20f)
-                    }
-
-                    ScrollEvent.BUFFER_END -> {
-                        scrollState.scrollToItem(scrollState.layoutInfo.totalItemsCount - 1)
-                    }
-
-                    ScrollEvent.BUFFER_START -> {
-                        scrollState.scrollToItem(0)
-                    }
-                }
-                currentHandledScrollEvent(event)
-            }
-        }
-    }
-}
-
-@Composable
-private fun Modifier.addTextContextMenuOptions(
-    windowLocation: WindowLocation,
-    showSettingsDialog: () -> Unit,
-    onClearClick: () -> Unit,
-    onCloseClick: () -> Unit,
-): Modifier =
-    this.appendTextContextMenuComponents {
-        separator()
-        addItem(key = SettingsContextMenuItemKey, label = "Window settings ...") {
-            showSettingsDialog()
-            close()
-        }
-        addItem(key = ClearContextMenuItemKey, label = "Clear window") {
-            onClearClick()
-            close()
-        }
-        if (windowLocation != WindowLocation.MAIN) {
-            addItem(key = CloseContextMenuItemKey, label = "Hide window") {
-                onCloseClick()
-                close()
-            }
-        }
-    }
-
-@Composable
-private fun WindowViewContent(
-    stream: ComposeTextStream,
-    scrollState: LazyListState,
-    style: StyleDefinition,
-    backgroundImage: ClientBackgroundImage?,
-    openWindows: List<String>,
-    menuData: WarlockMenuData?,
-    onActionClick: (WarlockAction) -> Int?,
-    modifier: Modifier = Modifier,
-) {
-    val backgroundColor = style.backgroundColor.toColor()
-    val textColor = style.textColor.toColor()
-    val fontFamily = style.fontFamily?.let { createFontFamily(it) }
-    val fontSize = style.fontSize?.sp ?: MaterialTheme.typography.bodyMedium.fontSize
-    val fontWeight = style.fontWeight?.let { FontWeight(it) }
-
-    val lines = stream.lines.collectAsState(emptyList()).value
-
-    var clickOffset by remember { mutableStateOf<Offset?>(null) }
-    var openMenuId by remember { mutableStateOf<Int?>(null) }
-
-    val currentOnActionClick by rememberUpdatedState(onActionClick)
-    DisposableEffect(stream) {
-        stream.actionHandler = { action ->
-            Logger.d { "action clicked: $action" }
-            openMenuId = currentOnActionClick(action)
-        }
-        onDispose {
-            stream.actionHandler = null
-        }
-    }
-
-    SelectionContainer(modifier = modifier) {
-        BoxWithConstraints(
-            Modifier
-                .fillMaxSize()
-                .clipToBounds()
-                .background(backgroundColor),
-        ) {
-            backgroundImage?.takeIf { it.image.isNotBlank() }?.let { image ->
-                WindowBackgroundImage(
-                    backgroundImage = image,
-                    width = maxWidth,
-                    height = maxHeight,
-                    modifier = Modifier.align(image.backgroundAlignment()),
+                            .align(Alignment.CenterEnd)
+                            .fillMaxHeight(),
                 )
             }
-            LazyColumn(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(vertical = 4.dp)
-                        .semantics {
-                            isTraversalGroup = true
-                            liveRegion = LiveRegionMode.Polite
-                        },
-                state = scrollState,
-            ) {
-                items(
-                    count = lines.size,
-                    key = { index -> lines[index].serialNumber },
-                ) { index ->
-                    when (val line = lines[index]) {
-                        is StreamTextLine -> {
-                            if (line.text != null &&
-                                line.isShowing(openWindows) &&
-                                (!line.isPrompt || !lines.isPreviousPrompt(index, openWindows))
-                            ) {
-                                var positionInParent by remember { mutableStateOf(Offset.Zero) }
-                                Box(
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .onGloballyPositioned {
-                                                positionInParent = it.positionInParent()
-                                            }.background(
-                                                line.entireLineStyle?.backgroundColor?.toColor()
-                                                    ?: Color.Unspecified,
-                                                // end = scrollbar width
-                                            ).padding(start = 4.dp, end = 8.dp),
-                                ) {
-                                    BasicText(
-                                        modifier =
-                                            Modifier
-                                                .pointerInput(Unit) {
-                                                    awaitPointerEventScope {
-                                                        while (true) {
-                                                            val event = awaitPointerEvent()
-                                                            if (event.type == PointerEventType.Press) {
-                                                                Logger.d { "Click: $event" }
-                                                                clickOffset =
-                                                                    event.changes
-                                                                        .firstOrNull()
-                                                                        ?.position
-                                                                        ?.let { it + positionInParent }
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                        text = line.text,
-                                        style =
-                                            TextStyle(
-                                                color = textColor,
-                                                fontFamily = fontFamily,
-                                                fontSize = fontSize,
-                                                fontWeight = fontWeight,
-                                            ),
-                                    )
-                                }
-                            }
-                        }
-
-                        is StreamImageLine -> {
-                            val defaultHeight = 80.dp
-                            Box(Modifier.height(defaultHeight).fillMaxWidth().zIndex(1f)) {
-                                val painter =
-                                    rememberAsyncImagePainter(
-                                        ImageRequest
-                                            .Builder(LocalPlatformContext.current)
-                                            .data(line.url)
-                                            .size(Size.ORIGINAL)
-                                            .build(),
-                                    )
-                                val painterState by painter.state.collectAsState()
-                                when (val state = painterState) {
-                                    is AsyncImagePainter.State.Success -> {
-                                        val interactionSource = remember { MutableInteractionSource() }
-                                        val hovered by interactionSource.collectIsHoveredAsState()
-                                        Logger.d { "Hovered: $hovered" }
-                                        val height =
-                                            if (hovered) {
-                                                with(LocalDensity.current) {
-                                                    max(
-                                                        state.result.image.height
-                                                            .toDp(),
-                                                        defaultHeight,
-                                                    )
-                                                }
-                                            } else {
-                                                defaultHeight
-                                            }
-                                        Image(
-                                            modifier =
-                                                Modifier
-                                                    .hoverable(interactionSource)
-                                                    .wrapContentSize(unbounded = true, align = Alignment.TopStart)
-                                                    .animateContentSize()
-                                                    .height(height),
-                                            painter = painter,
-                                            contentDescription = null,
-                                        )
-                                    }
-
-                                    else -> {}
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            VerticalScrollbar(
-                adapter = rememberScrollbarAdapter(scrollState),
-                style = defaultScrollbarStyle(),
-                modifier =
-                    Modifier
-                        .align(Alignment.CenterEnd)
-                        .fillMaxHeight(),
+        },
+        actionContextMenu = { offset, menu, onDismiss ->
+            ActionContextMenu(offset = offset, menuData = menu, onDismiss = onDismiss)
+        },
+        settingsDialog = { onCloseRequest ->
+            WindowSettingsDialog(
+                onCloseRequest = onCloseRequest,
+                style = uiState.style,
+                defaultStyle = defaultStyle,
+                saveStyle = saveStyle,
+                nameFilterOption = window?.nameFilterOption ?: false,
+                nameFilter = uiState.nameFilter,
+                saveNameFilter = saveNameFilter,
             )
-        }
-    }
-
-    if (menuData != null && menuData.id == openMenuId) {
-        ActionContextMenu(
-            offset = clickOffset,
-            menuData = menuData,
-            onDismiss = { openMenuId = null },
-        )
-    }
-
-    var sticky by remember { mutableStateOf(true) }
-    val lastSerial = lines.lastOrNull()?.serialNumber
-    LaunchedEffect(lastSerial) {
-        if (lastSerial != null && sticky) {
-            lines.lastIndex.takeIf { it > -1 }?.let { index ->
-                scrollState.scrollToItem(index)
+        },
+        dialogContent = { data, style ->
+            ScrollableColumn(
+                Modifier
+                    .fillMaxSize()
+                    .background(style.backgroundColor.toColor()),
+            ) {
+                val dataObjects by data.dialogData.objects.collectAsState()
+                DialogContent(
+                    dataObjects = dataObjects,
+                    modifier = Modifier.padding(8.dp),
+                    executeCommand = { command ->
+                        onActionClick(WarlockAction.SendCommand(command))
+                    },
+                    style = style,
+                )
             }
-        }
-    }
-    LaunchedEffect(scrollState.lastScrolledBackward, scrollState.canScrollForward) {
-        // If the user scrolled back and they can scroll forward, stop being sticky
-        // if the window can't be scrolled forward, be sticky again
-        if (scrollState.lastScrolledBackward && scrollState.canScrollForward) {
-            sticky = false
-        } else if (!scrollState.canScrollForward) {
-            sticky = true
-        }
-    }
+        },
+    )
 }
 
 @Composable

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
@@ -271,6 +271,8 @@ data class ClientConfig(
     val scrollback: Int? = null,
     val markLinks: Boolean = true,
     val showImages: Boolean = true,
+    @TomlComment("When true, prompt lines are hidden from the game windows.")
+    val suppressPrompts: Boolean = false,
     val logPath: String? = null,
     val logType: String? = null,
     val logTimestamps: Boolean = true,

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ClientSettingRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ClientSettingRepository.kt
@@ -128,6 +128,8 @@ class ClientSettingRepository(
 
     fun observeShowImages(): Flow<Boolean> = clientConfigStore.observeClient().map { it.showImages }
 
+    fun observeSuppressPrompts(): Flow<Boolean> = clientConfigStore.observeClient().map { it.suppressPrompts }
+
     suspend fun putLoggingPath(value: String) {
         clientConfigStore.mutateClient { it.copy(logPath = value) }
     }
@@ -170,6 +172,10 @@ class ClientSettingRepository(
 
     suspend fun putShowImages(value: Boolean) {
         clientConfigStore.mutateClient { it.copy(showImages = value) }
+    }
+
+    suspend fun putSuppressPrompts(value: Boolean) {
+        clientConfigStore.mutateClient { it.copy(suppressPrompts = value) }
     }
 
     // --- SQLite helpers ---


### PR DESCRIPTION
> **Draft / bundled.** This carries three loosely-related changes that are entangled across the same files (`ComposeTextStream.kt` especially), so they couldn't be cleanly separated into individual PRs. It also overlaps open #180 (`perf/stream-render-efficiency`) in the stream-rendering area — opening as a draft so it can be reconciled with #180 and the WIP pieces finished before it's considered for merge.

## What's here

**1. ComposeTextStream buffer performance**
Updates the displayed-line list incrementally instead of rebuilding and re-filtering the whole buffer on every line:
- `ArrayDeque` line buffers — trimming the oldest line at capacity is O(1), not an O(n) array shift.
- Displayed view = an append-only persistent list + a logical start index, so evicting the oldest displayed line (every newline once the buffer fills) is an O(1) start bump with amortized compaction; appends are O(log n).
- Identity-equals `OffsetList` snapshot so the `StateFlow`/Compose-state dedup comparison is O(1) instead of an O(n) content scan.
- Result: per-newline work at capacity goes from ~2-3× O(n) to O(log n).

**2. Suppress-prompts setting**
A client setting that filters prompt lines out of the displayed stream, with desktop and mobile settings toggles (`ConfigSchema`, `ClientSettingRepository`, `WindowRegistryImpl`, the two `GeneralSettingsView`s).

**3. Shared `WindowViewScaffold`**
Extracts the window frame / header / stream-render loop / scroll handling shared by desktop and mobile into one `commonMain` scaffold, with the toolkit-specific pieces (surface, header, scrollbar, context menu, settings dialog, dialog content) supplied as slots. Desktop/mobile `WindowView` become thin wrappers.

## Testing

- `:compose:compileKotlinJvm`, `:compose:compileAndroidMain`, `:compose:ktlintCheck`, `:core:ktlintCheck` pass.
- The desktop app builds and replays real session logs end-to-end (389-line and 21,619-line) with no errors; against `v3.1.0-beta.7`, replaying the 21,619-line log trends ~15% faster (noisy macro benchmark).

## Notes

- No unit tests cover `ComposeTextStream`, so the buffer rewrite rests on reasoning + the replay runs above.
- `OffsetList` intentionally uses referential equality (documented on the class) — safe only because the sole consumer reads/indexes it and never compares two snapshots by content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
