### PR TITLE
StyledString: O(k) line assembly via persistent addAll

### DIFF
--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/StyledString.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/StyledString.kt
@@ -1,18 +1,21 @@
 package warlockfe.warlock3.core.text
 
-import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 
 data class StyledString(
-    val substrings: ImmutableList<StyledStringLeaf> = persistentListOf(),
+    val substrings: PersistentList<StyledStringLeaf> = persistentListOf(),
 ) {
     constructor(text: String, styles: List<WarlockStyle> = emptyList()) :
         this(persistentListOf<StyledStringSubstring>(StyledStringSubstring(text, styles)))
 
     constructor(text: String, style: WarlockStyle) : this(text, listOf(style))
 
-    operator fun plus(string: StyledString): StyledString = StyledString((substrings + string.substrings).toPersistentList())
+    // addAll on a persistent list appends in O(elements added) with structural sharing, so folding
+    // many fragments into one line (e.g. a room description) is O(total) rather than the O(n²) of
+    // repeated (a + b) whole-list copies.
+    operator fun plus(string: StyledString): StyledString = copy(substrings = substrings.addAll(string.substrings))
 
     fun applyStyle(style: WarlockStyle): StyledString = copy(substrings = substrings.map { it.applyStyle(style) }.toPersistentList())
 


### PR DESCRIPTION
## Summary

Salvages the `StyledString` line-assembly fix from #180 onto current `master`.

`StyledString.plus` previously folded fragments with `(substrings + other).toPersistentList()`, copying the whole accumulator on each `+` — O(k²) for a fragment-heavy line (e.g. a room description). This narrows `substrings` to `PersistentList` and appends with `addAll` (structural sharing), making line assembly **O(k)**.

## Context

This is a clean cherry-pick of the `StyledString` commit from **#180** (credit: @jasonjaclyn2017). #180's other commit (the `ComposeTextStream` ArrayDeque + coalesced-publish change) was **superseded by #183**, which reworked the same buffer/publish path and is now in `master` — so #180 went conflicting. This PR carries forward the remaining, still-valuable piece that #183 did not touch, so it isn't lost. #180 is being closed in favor of this.

## Testing

- `:core:jvmTest` passes; `:core` / `:wrayth` / `:compose` compile clean; `:core:ktlintCheck` passes.
- The `substrings` type change (`ImmutableList` → `PersistentList`, a subtype) compiles across all consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
