### PR TITLE
Select a window on any press, not just clicking its text

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -110,6 +111,7 @@ internal fun WindowViewScaffold(
 
     val title = (window?.title ?: uiState.name) + (window?.subtitle ?: "")
     var viewportHeight by remember { mutableIntStateOf(0) }
+    val currentOnSelect by rememberUpdatedState(onSelect)
 
     surface(
         modifier
@@ -119,6 +121,19 @@ internal fun WindowViewScaffold(
             }.onFocusChanged { focusState ->
                 if (focusState.hasFocus) {
                     onSelect()
+                }
+            }.pointerInput(Unit) {
+                // Select this window on any press inside it, not only when the text grabs focus
+                // (via the selection container) and bubbles up to onFocusChanged. Observe in the
+                // Initial pass without consuming so text selection, links, and header buttons still
+                // receive the event.
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                        if (event.type == PointerEventType.Press) {
+                            currentOnSelect()
+                        }
+                    }
                 }
             }.semantics {
                 paneTitle = title


### PR DESCRIPTION
## Summary

Clicking anywhere in a `WindowView` now selects/focuses that window, not only when you click on its text.

## Why

The window surface already selected itself via `onFocusChanged { if (hasFocus) onSelect() }`. That only fires when something focusable inside the window grabs focus, which happens when you click text (the `SelectionContainer`) but not when you click empty space, where nothing focusable exists. So clicking a blank area of a window left it unselected.

## Fix

Added a `pointerInput` on the shared `WindowViewScaffold` surface that calls `onSelect()` on any press:

- Observes in `PointerEventPass.Initial` so the surface sees the press before its children, firing even when a child (header button, action link, text) later consumes the event.
- Does not consume the event, so text selection, links, and header buttons keep working.
- Uses `rememberUpdatedState` so the `pointerInput(Unit)` handler always calls the latest `onSelect`.

The existing `onFocusChanged` path is left in place (idempotent), so clicking text still selects too. The change lives in `commonMain`, so it applies to both desktop and mobile.

## Testing

- `./gradlew :compose:compileKotlinJvm` - clean
- `./gradlew :compose:ktlintCommonMainSourceSetCheck` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)