### PR TITLE
Account/character settings, account-first SGE connect, and password fixes

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
@@ -120,10 +120,6 @@ class DashboardViewModel(
         viewModelScope.launch { warlockSettingsSync.resolveConflict(path, resolution) }
     }
 
-    fun dismissSyncMessage() {
-        warlockSettingsSync.clearMessage()
-    }
-
     /** Defer the pending conflicts ("Later"); they resurface on the next sync. */
     fun deferSyncConflicts() {
         warlockSettingsSync.clearConflicts()
@@ -132,10 +128,6 @@ class DashboardViewModel(
     private suspend fun reloadAccounts() {
         savedAccounts = accountRepository.getAll()
     }
-
-    /** The saved password for a play.net account, if Warlock has one. */
-    fun savedPasswordFor(username: String): String? =
-        savedAccounts.firstOrNull { it.username.equals(username, ignoreCase = true) }?.password
 
     /**
      * On the first dashboard shown this session, reconnect the last launched connection if the user
@@ -201,6 +193,23 @@ class DashboardViewModel(
         connectJob?.cancel()
         connectJob = null
         message = null
+    }
+
+    /**
+     * Save a freshly-entered password onto the connection's play.net account, then connect. Used when
+     * a saved connection has no stored password (the account's password was never saved or was
+     * cleared), so the doomed empty-password login is replaced by a prompt that also fixes the account.
+     */
+    fun updatePasswordAndConnect(
+        connection: StoredConnection,
+        password: String,
+    ) {
+        if (password.isEmpty()) return
+        viewModelScope.launch {
+            accountRepository.save(AccountEntity(connection.username, password))
+            reloadAccounts()
+            connect(connection.copy(password = password))
+        }
     }
 
     // --- MUD Mobile actions ---

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsPage.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsPage.kt
@@ -12,4 +12,6 @@ enum class SettingsPage(
     Aliases("Aliases"),
     Alterations("Alterations"),
     Actions("Actions"),
+    Accounts("Accounts"),
+    Characters("Characters"),
 }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeViewModel.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import warlockfe.warlock3.compose.model.GameScreen
@@ -57,14 +56,9 @@ class SgeViewModel(
     private var characterName: String? = null
     private var gameCode: String? = null
 
-    val lastAccount: Flow<AccountEntity?> =
-        flow {
-            emit(
-                clientSettingRepository.getLastUsername()?.let { username ->
-                    accountRepository.getByUsername(username)
-                },
-            )
-        }
+    // The saved accounts shown on the first step of the wizard, so the user can pick one (logging in
+    // with its saved password) instead of re-typing it. Re-queried live so a delete in settings shows.
+    val accounts: Flow<List<AccountEntity>> = accountRepository.observeAll()
 
     init {
         job =

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopDashboardView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopDashboardView.kt
@@ -383,8 +383,9 @@ private fun ConnectionRow(
     val stripeColor = if (connection.mudMobile) MudMobileAccent else JewelTheme.globalColors.borders.normal
 
     fun login() {
-        // MUD Mobile connections need a password; prompt only if we don't already have one.
-        if (connection.mudMobile && connection.password.isNullOrBlank()) {
+        // A connection logs in with its account's saved password; prompt to set one when it's
+        // missing (both MUD Mobile and play.net logins need it) instead of attempting a doomed login.
+        if (connection.password.isNullOrBlank()) {
             ui.passwordPrompt = connection
         } else {
             viewModel.connect(connection)
@@ -558,14 +559,31 @@ private fun DashboardDialogs(
     }
 
     ui.passwordPrompt?.let { connection ->
-        MudMobilePasswordDialog(
-            connection = connection,
-            onConnect = { password ->
-                viewModel.connectMudMobile(connection, password)
-                ui.passwordPrompt = null
-            },
-            onDismiss = { ui.passwordPrompt = null },
-        )
+        if (connection.mudMobile) {
+            ConnectionPasswordDialog(
+                connection = connection,
+                description = "Enter the play.net password for account \"${connection.username}\".",
+                note = "Your password stays on this machine; it is never sent to MUD Mobile.",
+                confirmText = "Play",
+                onConnect = { password ->
+                    viewModel.connectMudMobile(connection, password)
+                    ui.passwordPrompt = null
+                },
+                onDismiss = { ui.passwordPrompt = null },
+            )
+        } else {
+            ConnectionPasswordDialog(
+                connection = connection,
+                description = "No password is saved for account \"${connection.username}\". Enter it to log in.",
+                note = "Your password is saved on this machine for next time.",
+                confirmText = "Login",
+                onConnect = { password ->
+                    viewModel.updatePasswordAndConnect(connection, password)
+                    ui.passwordPrompt = null
+                },
+                onDismiss = { ui.passwordPrompt = null },
+            )
+        }
     }
 
     ui.editConnection?.let { connection ->
@@ -746,10 +764,13 @@ private fun MudMobileAddCharacterDialog(
 }
 
 @Composable
-private fun MudMobilePasswordDialog(
+private fun ConnectionPasswordDialog(
     connection: StoredConnection,
+    description: String,
+    confirmText: String,
     onConnect: (String) -> Unit,
     onDismiss: () -> Unit,
+    note: String? = null,
 ) {
     val passwordState = rememberTextFieldState(connection.password ?: "")
 
@@ -763,15 +784,21 @@ private fun MudMobilePasswordDialog(
             modifier = Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text("Enter the play.net password for account \"${connection.username}\".")
-            Text("Your password stays on this machine; it is never sent to MUD Mobile.")
+            Text(description)
+            if (note != null) {
+                Text(note)
+            }
             WarlockPasswordField(state = passwordState, modifier = Modifier.fillMaxWidth())
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 WarlockOutlinedButton(onClick = onDismiss, text = "Cancel")
-                WarlockButton(onClick = { onConnect(passwordState.text.toString()) }, text = "Play")
+                WarlockButton(
+                    onClick = { onConnect(passwordState.text.toString()) },
+                    text = confirmText,
+                    enabled = passwordState.text.isNotBlank(),
+                )
             }
         }
     }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopAccountsView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopAccountsView.kt
@@ -1,0 +1,141 @@
+package warlockfe.warlock3.compose.desktop.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Text
+import warlockfe.warlock3.compose.desktop.shim.WarlockButton
+import warlockfe.warlock3.compose.desktop.shim.WarlockDialog
+import warlockfe.warlock3.compose.desktop.shim.WarlockListItem
+import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
+import warlockfe.warlock3.compose.desktop.shim.WarlockPasswordField
+import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
+import warlockfe.warlock3.core.prefs.models.AccountEntity
+import warlockfe.warlock3.core.prefs.repositories.AccountRepository
+
+@Composable
+fun DesktopAccountsView(
+    accountRepository: AccountRepository,
+    modifier: Modifier = Modifier,
+) {
+    val accounts by accountRepository.observeAll().collectAsState(emptyList())
+    var editingPasswordFor by remember { mutableStateOf<AccountEntity?>(null) }
+    var deleting by remember { mutableStateOf<AccountEntity?>(null) }
+    val scope = rememberCoroutineScope()
+
+    Column(modifier.fillMaxSize()) {
+        Text("Accounts")
+        Spacer(Modifier.height(8.dp))
+        if (accounts.isEmpty()) {
+            Text(
+                text = "No saved accounts. Accounts are saved automatically when you log in.",
+                color = JewelTheme.globalColors.text.info,
+            )
+        }
+        WarlockScrollableColumn(modifier = Modifier.fillMaxWidth().weight(1f)) {
+            accounts.forEach { account ->
+                WarlockListItem(
+                    headline = {
+                        Column {
+                            Text(account.username)
+                            Text(
+                                text = if (account.password.isNullOrEmpty()) "No password saved" else "Password saved",
+                                color = JewelTheme.globalColors.text.info,
+                            )
+                        }
+                    },
+                    trailing = {
+                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                            WarlockOutlinedButton(
+                                onClick = { editingPasswordFor = account },
+                                text = "Set password",
+                            )
+                            WarlockOutlinedButton(
+                                onClick = { deleting = account },
+                                text = "Delete",
+                            )
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    editingPasswordFor?.let { account ->
+        DesktopSetPasswordDialog(
+            username = account.username,
+            savePassword = { password ->
+                scope.launch {
+                    accountRepository.save(account.copy(password = password))
+                    editingPasswordFor = null
+                }
+            },
+            onClose = { editingPasswordFor = null },
+        )
+    }
+
+    deleting?.let { account ->
+        DesktopConfirmationDialog(
+            title = "Delete account",
+            text = "Delete the saved account \"${account.username}\" and its password? Your characters are not affected.",
+            onDismiss = { deleting = null },
+            onConfirm = {
+                scope.launch {
+                    accountRepository.deleteByUsername(account.username)
+                    deleting = null
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun DesktopSetPasswordDialog(
+    username: String,
+    savePassword: (String) -> Unit,
+    onClose: () -> Unit,
+) {
+    val password = rememberTextFieldState()
+
+    WarlockDialog(
+        title = "Set password",
+        onCloseRequest = onClose,
+        width = 480.dp,
+        height = 220.dp,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Password for $username")
+            WarlockPasswordField(state = password, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier.weight(1f))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, androidx.compose.ui.Alignment.End),
+            ) {
+                WarlockOutlinedButton(onClick = onClose, text = "Cancel")
+                WarlockButton(
+                    onClick = { savePassword(password.text.toString()) },
+                    text = "OK",
+                )
+            }
+        }
+    }
+}

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopCharactersView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopCharactersView.kt
@@ -1,0 +1,81 @@
+package warlockfe.warlock3.compose.desktop.ui.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Text
+import warlockfe.warlock3.compose.desktop.shim.WarlockListItem
+import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
+import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
+import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.repositories.CharacterRepository
+
+@Composable
+fun DesktopCharactersView(
+    allCharacters: List<GameCharacter>,
+    characterRepository: CharacterRepository,
+    modifier: Modifier = Modifier,
+) {
+    var deleting by remember { mutableStateOf<GameCharacter?>(null) }
+    val scope = rememberCoroutineScope()
+
+    Column(modifier.fillMaxSize()) {
+        Text("Characters")
+        Spacer(Modifier.height(8.dp))
+        if (allCharacters.isEmpty()) {
+            Text(
+                text = "No saved characters. Characters are saved automatically when you log in.",
+                color = JewelTheme.globalColors.text.info,
+            )
+        }
+        WarlockScrollableColumn(modifier = Modifier.fillMaxWidth().weight(1f)) {
+            allCharacters.forEach { character ->
+                WarlockListItem(
+                    headline = {
+                        Column {
+                            Text(character.name)
+                            Text(
+                                text = character.gameCode,
+                                color = JewelTheme.globalColors.text.info,
+                            )
+                        }
+                    },
+                    trailing = {
+                        WarlockOutlinedButton(
+                            onClick = { deleting = character },
+                            text = "Delete",
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    deleting?.let { character ->
+        DesktopConfirmationDialog(
+            title = "Delete character",
+            text =
+                "Delete \"${character.name}\" (${character.gameCode}) and its saved settings reference? " +
+                    "This does not affect your play.net account.",
+            onDismiss = { deleting = null },
+            onConfirm = {
+                scope.launch {
+                    characterRepository.deleteCharacter(character.id)
+                    deleting = null
+                }
+            },
+        )
+    }
+}

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsContent.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import warlockfe.warlock3.compose.ui.settings.SettingsPage
 import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.repositories.AccountRepository
 import warlockfe.warlock3.core.prefs.repositories.ActionRepository
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.AlterationRepository
@@ -34,6 +35,7 @@ fun DesktopSettingsContent(
     actionRepository: ActionRepository,
     alterationRepository: AlterationRepository,
     clientSettingRepository: ClientSettingRepository,
+    accountRepository: AccountRepository,
 ) {
     val characters by characterRepository.observeAllCharacters().collectAsState(emptyList())
 
@@ -109,6 +111,19 @@ fun DesktopSettingsContent(
                 currentCharacter = currentCharacter,
                 allCharacters = characters,
                 actionRepository = actionRepository,
+            )
+        }
+
+        SettingsPage.Accounts -> {
+            DesktopAccountsView(
+                accountRepository = accountRepository,
+            )
+        }
+
+        SettingsPage.Characters -> {
+            DesktopCharactersView(
+                allCharacters = characters,
+                characterRepository = characterRepository,
             )
         }
     }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsDialog.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsDialog.kt
@@ -26,6 +26,7 @@ import org.jetbrains.jewel.ui.component.Divider
 import org.jetbrains.jewel.ui.component.Text
 import warlockfe.warlock3.compose.ui.settings.SettingsPage
 import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.repositories.AccountRepository
 import warlockfe.warlock3.core.prefs.repositories.ActionRepository
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.AlterationRepository
@@ -55,6 +56,7 @@ fun DesktopSettingsDialog(
     actionRepository: ActionRepository,
     scriptDirRepository: ScriptDirRepository,
     clientSettingRepository: ClientSettingRepository,
+    accountRepository: AccountRepository,
     closeDialog: () -> Unit,
 ) {
     DialogWindow(
@@ -108,6 +110,7 @@ fun DesktopSettingsDialog(
                         actionRepository = actionRepository,
                         alterationRepository = alterationRepository,
                         clientSettingRepository = clientSettingRepository,
+                        accountRepository = accountRepository,
                     )
                 }
             }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/sge/DesktopAccountsView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/sge/DesktopAccountsView.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.ui.component.Text
 import warlockfe.warlock3.compose.desktop.shim.WarlockButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
-import warlockfe.warlock3.compose.desktop.shim.WarlockSecureTextField
+import warlockfe.warlock3.compose.desktop.shim.WarlockPasswordField
 import warlockfe.warlock3.compose.desktop.shim.WarlockTextField
 import warlockfe.warlock3.core.prefs.models.AccountEntity
 
@@ -50,7 +50,7 @@ fun DesktopAccountsView(
                 Spacer(Modifier.height(8.dp))
                 Text("Password")
                 Spacer(Modifier.height(4.dp))
-                WarlockSecureTextField(
+                WarlockPasswordField(
                     modifier = Modifier.padding(8.dp).width(280.dp),
                     state = password,
                 )

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/sge/DesktopSgeAccountSelectorView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/sge/DesktopSgeAccountSelectorView.kt
@@ -1,0 +1,98 @@
+package warlockfe.warlock3.compose.desktop.ui.sge
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.ui.Orientation
+import org.jetbrains.jewel.ui.component.Divider
+import org.jetbrains.jewel.ui.component.Text
+import warlockfe.warlock3.compose.desktop.shim.WarlockButton
+import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
+import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
+import warlockfe.warlock3.core.prefs.models.AccountEntity
+
+/**
+ * The first step of the SGE connect wizard: a list of saved accounts to pick from (logging in with
+ * the stored password), plus an "Add account" option that opens the username/password form. Falls
+ * straight through to the form when there are no saved accounts yet.
+ */
+@Composable
+fun DesktopSgeAccountSelectorView(
+    accounts: List<AccountEntity>,
+    onAccountSelect: (AccountEntity) -> Unit,
+    onSaveAccount: (AccountEntity) -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Start on the entry form when there are no saved accounts so first-time users don't see an
+    // empty list. The username pre-fills the form when an account has no saved password.
+    var showForm by remember { mutableStateOf(accounts.isEmpty()) }
+    var prefillUsername by remember { mutableStateOf<String?>(null) }
+
+    if (showForm) {
+        DesktopAccountsView(
+            initialUsername = prefillUsername,
+            initialPassword = null,
+            onAccountSelect = onSaveAccount,
+            onCancel = {
+                if (accounts.isEmpty()) {
+                    onCancel()
+                } else {
+                    showForm = false
+                    prefillUsername = null
+                }
+            },
+            modifier = modifier,
+        )
+    } else {
+        Column(modifier = modifier.fillMaxSize()) {
+            WarlockScrollableColumn(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                accounts.forEachIndexed { index, account ->
+                    Text(
+                        text = account.username,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    if (account.password.isNullOrEmpty()) {
+                                        // No saved password; open the form to enter one.
+                                        prefillUsername = account.username
+                                        showForm = true
+                                    } else {
+                                        onAccountSelect(account)
+                                    }
+                                }.padding(horizontal = 12.dp, vertical = 12.dp),
+                    )
+                    if (index < accounts.size - 1) {
+                        Divider(orientation = Orientation.Horizontal, modifier = Modifier.fillMaxWidth())
+                    }
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+            ) {
+                WarlockOutlinedButton(onClick = onCancel, text = "Cancel")
+                WarlockButton(
+                    onClick = {
+                        prefillUsername = null
+                        showForm = true
+                    },
+                    text = "Add account",
+                )
+            }
+        }
+    }
+}

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/sge/DesktopSgeWizard.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/sge/DesktopSgeWizard.kt
@@ -12,6 +12,7 @@ import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.Text
 import warlockfe.warlock3.compose.ui.sge.SgeViewModel
 import warlockfe.warlock3.compose.ui.sge.SgeViewState
+import warlockfe.warlock3.core.prefs.models.AccountEntity
 
 @Suppress("ktlint:compose:vm-forwarding-check")
 @Composable
@@ -28,16 +29,20 @@ fun DesktopSgeWizard(
     ) {
         when (val currentState = viewModel.state.value) {
             SgeViewState.SgeAccountSelector -> {
-                val account by viewModel.lastAccount.collectAsState(null)
-                DesktopAccountsView(
-                    initialUsername = account?.username,
-                    initialPassword = account?.password,
-                    onAccountSelect = { newAccount ->
-                        viewModel.saveAccount(newAccount)
-                        viewModel.accountSelected(newAccount)
-                    },
-                    onCancel = onCancel,
-                )
+                val accounts: List<AccountEntity>? by viewModel.accounts.collectAsState(initial = null)
+                accounts?.let { loaded ->
+                    DesktopSgeAccountSelectorView(
+                        accounts = loaded,
+                        onAccountSelect = { account ->
+                            viewModel.accountSelected(account)
+                        },
+                        onSaveAccount = { account ->
+                            viewModel.saveAccount(account)
+                            viewModel.accountSelected(account)
+                        },
+                        onCancel = onCancel,
+                    )
+                } ?: DesktopSgeLoadingView("Loading accounts")
             }
 
             SgeViewState.SgeLoadingGameList -> {

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardView.kt
@@ -9,14 +9,18 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SecureTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -90,6 +94,7 @@ fun ConnectionList(
 ) {
     var showConnectionSettings: StoredConnection? by remember { mutableStateOf(null) }
     var showConnectionDelete: StoredConnection? by remember { mutableStateOf(null) }
+    var passwordPrompt: StoredConnection? by remember { mutableStateOf(null) }
     val connections by viewModel.connections.collectAsState(emptyList())
     ScrollableLazyColumn(
         modifier.semantics {
@@ -118,7 +123,13 @@ fun ConnectionList(
                 leadingContent = {
                     IconButton(
                         onClick = {
-                            viewModel.connect(connection)
+                            // Prompt to set the account password when none is saved, rather than
+                            // attempting a doomed empty-password login.
+                            if (connection.password.isNullOrBlank()) {
+                                passwordPrompt = connection
+                            } else {
+                                viewModel.connect(connection)
+                            }
                         },
                     ) {
                         Icon(painter = painterResource(Res.drawable.login), contentDescription = "Login")
@@ -174,4 +185,49 @@ fun ConnectionList(
             },
         )
     }
+    passwordPrompt?.let { connection ->
+        PasswordPromptDialog(
+            connection = connection,
+            onConnect = { password ->
+                viewModel.updatePasswordAndConnect(connection, password)
+                passwordPrompt = null
+            },
+            onDismiss = { passwordPrompt = null },
+        )
+    }
+}
+
+@Composable
+private fun PasswordPromptDialog(
+    connection: StoredConnection,
+    onConnect: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val passwordState = rememberTextFieldState(connection.password ?: "")
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Password required") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("No password is saved for account \"${connection.username}\". Enter it to log in.")
+                SecureTextField(
+                    state = passwordState,
+                    label = { Text("Password") },
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = passwordState.text.isNotBlank(),
+                onClick = { onConnect(passwordState.text.toString()) },
+            ) {
+                Text("Login")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
 }

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/AccountsView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/AccountsView.kt
@@ -1,0 +1,140 @@
+package warlockfe.warlock3.compose.ui.settings
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.painterResource
+import warlockfe.warlock3.compose.components.ScrollableColumn
+import warlockfe.warlock3.compose.generated.resources.Res
+import warlockfe.warlock3.compose.generated.resources.delete
+import warlockfe.warlock3.compose.generated.resources.edit
+import warlockfe.warlock3.core.prefs.models.AccountEntity
+import warlockfe.warlock3.core.prefs.repositories.AccountRepository
+
+@Composable
+fun AccountsView(
+    accountRepository: AccountRepository,
+    modifier: Modifier = Modifier,
+) {
+    val accounts by accountRepository.observeAll().collectAsState(emptyList())
+    var editingPasswordFor by remember { mutableStateOf<AccountEntity?>(null) }
+    var deleting by remember { mutableStateOf<AccountEntity?>(null) }
+    val coroutineScope = rememberCoroutineScope()
+
+    ScrollableColumn(modifier.fillMaxSize()) {
+        accounts.forEach { account ->
+            ListItem(
+                headlineContent = { Text(account.username) },
+                supportingContent = {
+                    Text(if (account.password.isNullOrEmpty()) "No password saved" else "Password saved")
+                },
+                trailingContent = {
+                    Row {
+                        IconButton(onClick = { editingPasswordFor = account }) {
+                            Icon(
+                                painter = painterResource(Res.drawable.edit),
+                                contentDescription = "Set password",
+                            )
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        IconButton(onClick = { deleting = account }) {
+                            Icon(
+                                painter = painterResource(Res.drawable.delete),
+                                contentDescription = "Delete",
+                            )
+                        }
+                    }
+                },
+            )
+        }
+    }
+
+    editingPasswordFor?.let { account ->
+        SetPasswordDialog(
+            username = account.username,
+            savePassword = { password ->
+                coroutineScope.launch {
+                    accountRepository.save(account.copy(password = password))
+                    editingPasswordFor = null
+                }
+            },
+            onClose = { editingPasswordFor = null },
+        )
+    }
+
+    deleting?.let { account ->
+        AlertDialog(
+            onDismissRequest = { deleting = null },
+            title = { Text("Delete account") },
+            text = { Text("Delete the saved account \"${account.username}\" and its password? Your characters are not affected.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        coroutineScope.launch {
+                            accountRepository.deleteByUsername(account.username)
+                            deleting = null
+                        }
+                    },
+                ) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleting = null }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun SetPasswordDialog(
+    username: String,
+    savePassword: (String) -> Unit,
+    onClose: () -> Unit,
+) {
+    val password = rememberTextFieldState()
+
+    AlertDialog(
+        onDismissRequest = onClose,
+        title = { Text("Set password") },
+        text = {
+            TextField(
+                state = password,
+                label = { Text("Password for $username") },
+                lineLimits = TextFieldLineLimits.SingleLine,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { savePassword(password.text.toString()) }) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onClose) {
+                Text("Cancel")
+            }
+        },
+    )
+}

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/CharactersView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/CharactersView.kt
@@ -1,0 +1,80 @@
+package warlockfe.warlock3.compose.ui.settings
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.painterResource
+import warlockfe.warlock3.compose.components.ScrollableColumn
+import warlockfe.warlock3.compose.generated.resources.Res
+import warlockfe.warlock3.compose.generated.resources.delete
+import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.repositories.CharacterRepository
+
+@Composable
+fun CharactersView(
+    allCharacters: List<GameCharacter>,
+    characterRepository: CharacterRepository,
+    modifier: Modifier = Modifier,
+) {
+    var deleting by remember { mutableStateOf<GameCharacter?>(null) }
+    val coroutineScope = rememberCoroutineScope()
+
+    ScrollableColumn(modifier.fillMaxSize()) {
+        allCharacters.forEach { character ->
+            ListItem(
+                headlineContent = { Text(character.name) },
+                supportingContent = { Text(character.gameCode) },
+                trailingContent = {
+                    IconButton(onClick = { deleting = character }) {
+                        Icon(
+                            painter = painterResource(Res.drawable.delete),
+                            contentDescription = "Delete",
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    deleting?.let { character ->
+        AlertDialog(
+            onDismissRequest = { deleting = null },
+            title = { Text("Delete character") },
+            text = {
+                Text(
+                    "Delete \"${character.name}\" (${character.gameCode}) and its saved settings reference? " +
+                        "This does not affect your play.net account.",
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        coroutineScope.launch {
+                            characterRepository.deleteCharacter(character.id)
+                            deleting = null
+                        }
+                    },
+                ) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleting = null }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsContent.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.repositories.AccountRepository
 import warlockfe.warlock3.core.prefs.repositories.ActionRepository
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.AlterationRepository
@@ -34,6 +35,7 @@ fun SettingsContent(
     actionRepository: ActionRepository,
     alterationRepository: AlterationRepository,
     clientSettingRepository: ClientSettingRepository,
+    accountRepository: AccountRepository,
     wraythImporter: WraythImporter,
 ) {
     val characters by characterRepository.observeAllCharacters().collectAsState(emptyList())
@@ -111,6 +113,19 @@ fun SettingsContent(
                 currentCharacter = currentCharacter,
                 allCharacters = characters,
                 actionRepository = actionRepository,
+            )
+        }
+
+        SettingsPage.Accounts -> {
+            AccountsView(
+                accountRepository = accountRepository,
+            )
+        }
+
+        SettingsPage.Characters -> {
+            CharactersView(
+                allCharacters = characters,
+                characterRepository = characterRepository,
             )
         }
     }

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsScreen.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsScreen.kt
@@ -92,6 +92,7 @@ fun SettingsScreen(
                     actionRepository = appContainer.actionRepository,
                     alterationRepository = appContainer.alterationRepository,
                     clientSettingRepository = appContainer.clientSettings,
+                    accountRepository = appContainer.accountRepository,
                     wraythImporter = appContainer.wraythImporter,
                 )
             }

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeAccountSelectorView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeAccountSelectorView.kt
@@ -1,0 +1,99 @@
+package warlockfe.warlock3.compose.ui.sge
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import warlockfe.warlock3.core.prefs.models.AccountEntity
+
+/**
+ * The first step of the SGE connect wizard: a list of saved accounts to pick from (logging in with
+ * the stored password), plus an "Add account" option that opens the username/password form. Falls
+ * straight through to the form when there are no saved accounts yet.
+ */
+@Composable
+fun SgeAccountSelectorView(
+    accounts: List<AccountEntity>,
+    onAccountSelect: (AccountEntity) -> Unit,
+    onSaveAccount: (AccountEntity) -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Start on the entry form when there are no saved accounts so first-time users don't see an
+    // empty list. The username pre-fills the form when an account has no saved password.
+    var showForm by remember { mutableStateOf(accounts.isEmpty()) }
+    var prefillUsername by remember { mutableStateOf<String?>(null) }
+
+    if (showForm) {
+        AccountsView(
+            initialUsername = prefillUsername,
+            initialPassword = null,
+            onAccountSelect = onSaveAccount,
+            onCancel = {
+                if (accounts.isEmpty()) {
+                    onCancel()
+                } else {
+                    showForm = false
+                    prefillUsername = null
+                }
+            },
+            modifier = modifier,
+        )
+    } else {
+        Column(modifier = modifier.fillMaxSize()) {
+            LazyColumn(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                itemsIndexed(accounts) { index, account ->
+                    ListItem(
+                        modifier =
+                            Modifier.clickable {
+                                if (account.password.isNullOrEmpty()) {
+                                    // No saved password; open the form to enter one.
+                                    prefillUsername = account.username
+                                    showForm = true
+                                } else {
+                                    onAccountSelect(account)
+                                }
+                            },
+                        headlineContent = { Text(account.username) },
+                    )
+                    if (index < accounts.size - 1) {
+                        HorizontalDivider()
+                    }
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, androidx.compose.ui.Alignment.End),
+            ) {
+                OutlinedButton(onClick = onCancel) {
+                    Text("Cancel")
+                }
+                Button(
+                    onClick = {
+                        prefillUsername = null
+                        showForm = true
+                    },
+                ) {
+                    Text("Add account")
+                }
+            }
+        }
+    }
+}

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeWizard.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeWizard.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import warlockfe.warlock3.core.prefs.models.AccountEntity
 
 @Composable
 fun SgeWizard(
@@ -20,16 +21,20 @@ fun SgeWizard(
         val state = viewModel.state
         when (val currentState = state.value) {
             SgeViewState.SgeAccountSelector -> {
-                val account by viewModel.lastAccount.collectAsState(null)
-                AccountsView(
-                    initialUsername = account?.username,
-                    initialPassword = account?.password,
-                    onAccountSelect = { newAccount ->
-                        viewModel.saveAccount(newAccount)
-                        viewModel.accountSelected(newAccount)
-                    },
-                    onCancel = onCancel,
-                )
+                val accounts: List<AccountEntity>? by viewModel.accounts.collectAsState(initial = null)
+                accounts?.let { loaded ->
+                    SgeAccountSelectorView(
+                        accounts = loaded,
+                        onAccountSelect = { account ->
+                            viewModel.accountSelected(account)
+                        },
+                        onSaveAccount = { account ->
+                            viewModel.saveAccount(account)
+                            viewModel.accountSelected(account)
+                        },
+                        onCancel = onCancel,
+                    )
+                } ?: SgeLoadingView("Loading accounts")
             }
 
             SgeViewState.SgeLoadingGameList -> {

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/WarlockSettingsSync.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/mudmobile/WarlockSettingsSync.kt
@@ -121,11 +121,6 @@ class WarlockSettingsSync(
         }
     }
 
-    /** Clear a finished/failed status message without touching pending conflicts. */
-    fun clearMessage() {
-        _state.value = _state.value.copy(message = null)
-    }
-
     /**
      * Defer all pending conflicts (the "Later" action): drops them from view without resolving. They
      * resurface on the next [sync] because the base hashes are unchanged.

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/dao/AccountDao.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/dao/AccountDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 import warlockfe.warlock3.core.prefs.models.AccountEntity
 
 @Dao
@@ -11,9 +12,15 @@ interface AccountDao {
     @Query("SELECT * FROM account")
     suspend fun getAll(): List<AccountEntity>
 
+    @Query("SELECT * FROM account")
+    fun observeAll(): Flow<List<AccountEntity>>
+
     @Query("SELECT * FROM account WHERE username = :username")
     suspend fun getByUsername(username: String): AccountEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun save(account: AccountEntity)
+
+    @Query("DELETE FROM account WHERE username = :username")
+    suspend fun delete(username: String)
 }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/AccountRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/AccountRepository.kt
@@ -1,6 +1,7 @@
 package warlockfe.warlock3.core.prefs.repositories
 
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import warlockfe.warlock3.core.prefs.dao.AccountDao
 import warlockfe.warlock3.core.prefs.models.AccountEntity
@@ -10,11 +11,19 @@ class AccountRepository(
 ) {
     suspend fun getAll(): List<AccountEntity> = accountDao.getAll()
 
+    fun observeAll(): Flow<List<AccountEntity>> = accountDao.observeAll()
+
     suspend fun getByUsername(username: String): AccountEntity? = accountDao.getByUsername(username)
 
     suspend fun save(account: AccountEntity) {
         withContext(NonCancellable) {
             accountDao.save(account)
+        }
+    }
+
+    suspend fun deleteByUsername(username: String) {
+        withContext(NonCancellable) {
+            accountDao.delete(username)
         }
     }
 }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ConnectionRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ConnectionRepository.kt
@@ -1,6 +1,7 @@
 package warlockfe.warlock3.core.prefs.repositories
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import warlockfe.warlock3.core.mudmobile.MudMobileCharacter
 import warlockfe.warlock3.core.prefs.config.ClientConfigStore
@@ -19,9 +20,13 @@ class ConnectionRepository(
     private val accountDao: AccountDao,
 ) {
     fun observeAllConnections(): Flow<List<StoredConnection>> =
-        store.observeConnections().map { registry ->
+        combine(store.observeConnections(), accountDao.observeAll()) { registry, accounts ->
+            // Re-resolve passwords whenever either the connection registry or the saved accounts
+            // change. A password edited in settings only touches the account table, so mapping over
+            // the registry flow alone would leave the cached connection on its old password.
+            val passwordsByUsername = accounts.associateBy({ it.username }, { it.password })
             registry.connections.map { connection ->
-                connection.toStoredConnection(accountDao.getByUsername(connection.username)?.password)
+                connection.toStoredConnection(passwordsByUsername[connection.username])
             }
         }
 

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/SettingsDialog.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/SettingsDialog.kt
@@ -3,6 +3,7 @@ package warlockfe.warlock3.app
 import androidx.compose.runtime.Composable
 import warlockfe.warlock3.compose.desktop.ui.settings.DesktopSettingsDialog
 import warlockfe.warlock3.core.client.GameCharacter
+import warlockfe.warlock3.core.prefs.repositories.AccountRepository
 import warlockfe.warlock3.core.prefs.repositories.ActionRepository
 import warlockfe.warlock3.core.prefs.repositories.AliasRepository
 import warlockfe.warlock3.core.prefs.repositories.AlterationRepository
@@ -31,6 +32,7 @@ fun SettingsDialog(
     actionRepository: ActionRepository,
     scriptDirRepository: ScriptDirRepository,
     clientSettingRepository: ClientSettingRepository,
+    accountRepository: AccountRepository,
     closeDialog: () -> Unit,
 ) {
     DesktopSettingsDialog(
@@ -47,6 +49,7 @@ fun SettingsDialog(
         actionRepository = actionRepository,
         scriptDirRepository = scriptDirRepository,
         clientSettingRepository = clientSettingRepository,
+        accountRepository = accountRepository,
         closeDialog = closeDialog,
     )
 }

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
@@ -213,6 +213,7 @@ fun DecoratedWindowScope.WarlockApp(
             scriptDirRepository = appContainer.scriptDirRepository,
             alterationRepository = appContainer.alterationRepository,
             clientSettingRepository = appContainer.clientSettings,
+            accountRepository = appContainer.accountRepository,
         )
     }
 }


### PR DESCRIPTION
## Summary

Adds account/character management to settings, reworks the SGE connect flow to start from a list of saved accounts, and fixes password handling for connections.

## Settings
- **Accounts page** — set password / delete a saved play.net account.
- **Characters page** — delete a saved character.
- Both pages on desktop and mobile. `AccountDao`/`AccountRepository` gain `observeAll()` and `delete`.

## Password reveal
- Every desktop password edit field now has a Show/Hide toggle. The SGE login wizard and the settings Set-password dialog switched to the existing `WarlockPasswordField` (already used by the dashboard).

## SGE connect flow
- The connect wizard now opens on a **list of saved accounts** — pick one to log in with its stored password — plus an **Add account** option that opens the username/password form. First run (no saved accounts) falls straight through to the form. Selecting an account with no saved password opens the form pre-filled to enter one. Applied to desktop and mobile.

## Empty-password handling
- Logging in to a connection whose account has **no saved password** now prompts for one and saves it to the account, instead of attempting a doomed login (desktop and mobile).
- **Bug fix:** a password edited after the connection list was built (e.g. via the new settings page) was ignored, because `observeAllConnections()` only re-resolved the password when `connections.toml` changed. It now `combine`s the connection registry with the accounts table, so password edits from any source are reflected and used on the next connect.

## Cleanup
- Removed unused `DashboardViewModel.dismissSyncMessage` and `savedPasswordFor`, and the now-orphaned `WarlockSettingsSync.clearMessage`.

## Notes
- Independent of #185 (window focus); branched from `master`.
- Auto-connect-on-startup still can't prompt mid-startup, so an empty-password auto-connect will fail rather than prompt (rare edge case, left as-is).

## Testing
- `:core`, `:compose` (JVM + Android), and `:desktopApp` compile; `ktlintCheck` passes on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)