### PR TITLE
Move disconnect/reconnect actions into the window chrome

### DIFF
--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/DesktopMainScreen.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/DesktopMainScreen.kt
@@ -47,10 +47,11 @@ fun DesktopMainScreen(
         wizardContent = { viewModel, onCancel ->
             DesktopSgeWizard(viewModel = viewModel, onCancel = onCancel)
         },
-        gameContent = { viewModel, navigateToDashboard ->
+        gameContent = { viewModel, _ ->
+            // Dashboard navigation lives in the desktop title bar (see TitleBarView), so the game
+            // view no longer needs the navigate-to-dashboard callback.
             DesktopGameView(
                 viewModel = viewModel,
-                navigateToDashboard = navigateToDashboard,
                 sideBarVisible = sideBarVisible,
             )
         },

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
@@ -62,11 +62,9 @@ import warlockfe.warlock3.core.window.WindowInfo
 @Composable
 fun DesktopGameView(
     viewModel: GameViewModel,
-    navigateToDashboard: () -> Unit,
     sideBarVisible: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val disconnected by viewModel.disconnected.collectAsState()
     val entryFocusRequester = remember { FocusRequester() }
     var ignoreNextUnknownKeyEvent by remember { mutableStateOf(false) }
 
@@ -95,34 +93,6 @@ fun DesktopGameView(
                     }
                 },
     ) {
-        if (disconnected) {
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 8.dp,
-                            color = Color(red = 0xff, green = 0xcc, blue = 0),
-                        ).padding(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                Text("You have been disconnected from the server")
-                Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                    if (viewModel.canReconnect) {
-                        WarlockButton(
-                            onClick = viewModel::reconnect,
-                            text = "Reconnect",
-                        )
-                    }
-                    WarlockButton(
-                        onClick = navigateToDashboard,
-                        text = "Go to dashboard",
-                    )
-                }
-            }
-        }
-
         val mainWindow = viewModel.mainWindowUiState.collectAsState()
         val menuData: WarlockMenuData? by viewModel.menuData.collectAsState()
         val presets by viewModel.presets.collectAsState(emptyMap())

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameTopBar.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameTopBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -35,6 +36,9 @@ fun GameTopBar(
     onSettings: () -> Unit,
     onDashboard: () -> Unit,
     modifier: Modifier = Modifier,
+    disconnected: Boolean = false,
+    canReconnect: Boolean = false,
+    onReconnect: () -> Unit = {},
 ) {
     var menuOpen by remember { mutableStateOf(false) }
     TopAppBar(
@@ -64,6 +68,13 @@ fun GameTopBar(
             }
         },
         actions = {
+            // Surface reconnect in the bar when disconnected (the old disconnected banner is gone);
+            // "Go to dashboard" remains in the overflow menu below.
+            if (disconnected && canReconnect) {
+                FilledTonalButton(onClick = onReconnect) {
+                    Text("Reconnect")
+                }
+            }
             Box {
                 IconButton(onClick = { menuOpen = true }) {
                     Icon(painter = painterResource(Res.drawable.more_vert), contentDescription = "More")

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
@@ -1,22 +1,15 @@
 package warlockfe.warlock3.compose.ui.game
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledTonalButton
@@ -32,12 +25,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isAltPressed
 import androidx.compose.ui.input.key.isCtrlPressed
@@ -45,16 +36,11 @@ import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import warlockfe.warlock3.compose.components.CompassButtonColors
 import warlockfe.warlock3.compose.components.CompassButtons
-import warlockfe.warlock3.compose.components.ScrollableColumn
 import warlockfe.warlock3.compose.generated.resources.Res
-import warlockfe.warlock3.compose.generated.resources.circle
-import warlockfe.warlock3.compose.generated.resources.circle_filled
 import warlockfe.warlock3.compose.generated.resources.settings_filled
 import warlockfe.warlock3.compose.generated.resources.space_dashboard
 import warlockfe.warlock3.compose.generated.resources.space_dashboard_filled
@@ -76,8 +62,6 @@ import warlockfe.warlock3.core.client.WarlockAction
 import warlockfe.warlock3.core.client.WarlockMenuData
 import warlockfe.warlock3.core.macro.ScrollEvent
 import warlockfe.warlock3.core.text.StyleDefinition
-import warlockfe.warlock3.core.text.isSpecified
-import warlockfe.warlock3.core.window.WindowInfo
 import warlockfe.warlock3.core.window.WindowLocation
 
 /**
@@ -95,7 +79,6 @@ fun GameView(
     openDrawer: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val disconnected by viewModel.disconnected.collectAsState()
     val entryFocusRequester = remember { FocusRequester() }
     // On JVM, KeyDown is followed by an Unknown/KEY_TYPED event
     var ignoreNextUnknownKeyEvent by remember { mutableStateOf(false) }
@@ -124,13 +107,6 @@ fun GameView(
         BoxWithConstraints {
             val layout = WindowWidthSizeClass.fromWidth(maxWidth).gameLayout()
             Column(Modifier.fillMaxSize()) {
-                if (disconnected) {
-                    DisconnectedBanner(
-                        canReconnect = viewModel.canReconnect,
-                        onReconnect = viewModel::reconnect,
-                        navigateToDashboard = navigateToDashboard,
-                    )
-                }
                 val progressBarSettings by viewModel.progressBarSettings.collectAsState()
                 CompositionLocalProvider(
                     LocalProgressBarColors provides
@@ -156,6 +132,7 @@ fun GameView(
                                 viewModel = viewModel,
                                 entryFocusRequester = entryFocusRequester,
                                 openSettings = openSettings,
+                                navigateToDashboard = navigateToDashboard,
                                 modifier = Modifier.weight(1f),
                             )
                         }
@@ -184,34 +161,6 @@ fun GameView(
                 },
                 text = { Text(macroError!!) },
             )
-        }
-    }
-}
-
-@Composable
-private fun DisconnectedBanner(
-    canReconnect: Boolean,
-    onReconnect: () -> Unit,
-    navigateToDashboard: () -> Unit,
-) {
-    Column(
-        Modifier
-            .fillMaxWidth()
-            .border(width = 8.dp, color = Color(red = 0xff, green = 0xcc, blue = 0))
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Text("You have been disconnected from the server")
-        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-            if (canReconnect) {
-                FilledTonalButton(onClick = onReconnect) {
-                    Text("Reconnect")
-                }
-            }
-            FilledTonalButton(onClick = navigateToDashboard) {
-                Text("Go to dashboard")
-            }
         }
     }
 }
@@ -389,6 +338,10 @@ fun GameBottomBar(
     openSettings: (() -> Unit)? = null,
     windowListVisible: Boolean = false,
     onToggleWindowList: (() -> Unit)? = null,
+    disconnected: Boolean = false,
+    canReconnect: Boolean = false,
+    onReconnect: (() -> Unit)? = null,
+    onDashboard: (() -> Unit)? = null,
 ) {
     val presets by viewModel.presets.collectAsState(emptyMap())
     val style = presets["default"] ?: SAFE_DEFAULT_STYLE
@@ -407,6 +360,17 @@ fun GameBottomBar(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
+                // Disconnect actions for layouts without a top bar (tablet): the old banner is gone.
+                if (disconnected && (onDashboard != null || (canReconnect && onReconnect != null))) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        if (canReconnect && onReconnect != null) {
+                            FilledTonalButton(onClick = onReconnect) { Text("Reconnect") }
+                        }
+                        if (onDashboard != null) {
+                            FilledTonalButton(onClick = onDashboard) { Text("Dashboard") }
+                        }
+                    }
+                }
                 val actionBar by viewModel.actionBar.collectAsState()
                 if (actionBar.toolbar.isNotEmpty()) {
                     Row(

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/LargeGameTopBar.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/LargeGameTopBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -48,6 +49,8 @@ fun LargeGameTopBar(
     title: String,
     subtitle: String?,
     connected: Boolean,
+    canReconnect: Boolean,
+    onReconnect: () -> Unit,
     onMenu: () -> Unit,
     onSettings: () -> Unit,
     onDashboard: () -> Unit,
@@ -81,7 +84,14 @@ fun LargeGameTopBar(
             }
         },
         actions = {
-            ConnectionPill(connected = connected)
+            // When disconnected with a reconnect available, the status indicator becomes an action.
+            if (!connected && canReconnect) {
+                FilledTonalButton(onClick = onReconnect) {
+                    Text("Reconnect")
+                }
+            } else {
+                ConnectionPill(connected = connected)
+            }
             Spacer(Modifier.width(4.dp))
             IconButton(onClick = onSettings) {
                 Icon(painter = painterResource(Res.drawable.settings_filled), contentDescription = "Settings")

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/LargeGameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/LargeGameView.kt
@@ -73,6 +73,8 @@ fun LargeGameView(
                         ?.takeIf { it.isNotBlank() },
                 ).joinToString(separator = " - ").ifBlank { null },
             connected = !disconnected,
+            canReconnect = viewModel.canReconnect,
+            onReconnect = viewModel::reconnect,
             onMenu = { windowListVisible = !windowListVisible },
             onSettings = openSettings,
             onDashboard = navigateToDashboard,

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/PhoneGameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/PhoneGameView.kt
@@ -50,6 +50,7 @@ fun PhoneGameView(
     val openWindows by viewModel.openWindows.collectAsState(emptyList())
     val menuData by viewModel.menuData.collectAsState()
     val selectedWindow by viewModel.selectedWindow.collectAsState()
+    val disconnected by viewModel.disconnected.collectAsState()
     var movementOpen by remember { mutableStateOf(false) }
     var selectedTab by rememberSaveable { mutableStateOf("main") }
     val currentTab = if (windows.any { it.name == selectedTab }) selectedTab else "main"
@@ -61,6 +62,9 @@ fun PhoneGameView(
             onMenu = openDrawer,
             onSettings = openSettings,
             onDashboard = navigateToDashboard,
+            disconnected = disconnected,
+            canReconnect = viewModel.canReconnect,
+            onReconnect = viewModel::reconnect,
         )
         GameStatusCard(
             viewModel = viewModel,

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/TabletGameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/TabletGameView.kt
@@ -43,11 +43,13 @@ fun TabletGameView(
     viewModel: GameViewModel,
     entryFocusRequester: FocusRequester,
     openSettings: () -> Unit,
+    navigateToDashboard: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val location by viewModel.observeTabletWindowLocation().collectAsState(WindowLocation.RIGHT)
     val windows by viewModel.windows.collectAsState()
     val hasSecondary = windows.any { it.name != "main" }
+    val disconnected by viewModel.disconnected.collectAsState()
 
     Column(modifier) {
         Box(modifier = Modifier.weight(1f)) {
@@ -113,6 +115,10 @@ fun TabletGameView(
             viewModel = viewModel,
             entryFocusRequester = entryFocusRequester,
             openSettings = openSettings,
+            disconnected = disconnected,
+            canReconnect = viewModel.canReconnect,
+            onReconnect = viewModel::reconnect,
+            onDashboard = navigateToDashboard,
         )
     }
 }

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/TitleBarView.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/TitleBarView.kt
@@ -4,12 +4,14 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -52,6 +54,10 @@ internal fun DecoratedWindowScope.TitleBarView(
     sideBarVisible: Boolean,
     showSideBar: (Boolean) -> Unit,
     isConnected: Boolean,
+    disconnected: Boolean,
+    canReconnect: Boolean,
+    reconnect: () -> Unit,
+    goToDashboard: () -> Unit,
     openNewWindow: () -> Unit,
     showSettingsDialog: () -> Unit,
     disconnect: () -> Unit,
@@ -158,7 +164,7 @@ internal fun DecoratedWindowScope.TitleBarView(
                                 AppMenuItem("Import wrayth settings...", onClick = importWraythSettings),
                                 AppMenuItem("Settings...", onClick = showSettingsDialog),
                                 null,
-                                AppMenuItem("Disconnect", enabled = isConnected, onClick = disconnect),
+                                AppMenuItem("Disconnect", enabled = isConnected && !disconnected, onClick = disconnect),
                             ),
                     ),
                     AppMenu(
@@ -214,6 +220,59 @@ internal fun DecoratedWindowScope.TitleBarView(
             modifier = Modifier.align(Alignment.CenterHorizontally),
             text = title,
         )
+        if (isConnected) {
+            Row(
+                modifier = Modifier.align(Alignment.End).padding(end = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                when {
+                    !disconnected -> TitleBarPill(text = "Connected", dotColor = ConnectedColor)
+
+                    // Disconnected: the status indicator becomes a reconnect action when possible.
+                    canReconnect -> TitleBarPill(text = "Reconnect", onClick = reconnect)
+
+                    else -> TitleBarPill(text = "Disconnected", dotColor = DisconnectedColor)
+                }
+                if (disconnected) {
+                    TitleBarPill(text = "Dashboard", onClick = goToDashboard)
+                }
+            }
+        }
+    }
+}
+
+private val ConnectedColor = Color(0xFF86D6A0)
+private val DisconnectedColor = Color(0xFFE5484D)
+
+/**
+ * A compact title-bar pill matching the "Windows" toggle: a hairline-outlined rounded row that draws
+ * within the title-bar bounds (so the bar height is unchanged). Shows an optional status [dotColor]
+ * and becomes clickable when [onClick] is supplied.
+ */
+@Composable
+private fun TitleBarPill(
+    text: String,
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    dotColor: Color? = null,
+) {
+    val shape = RoundedCornerShape(5.dp)
+    val contentColor = LocalContentColor.current
+    Row(
+        modifier =
+            modifier
+                .clip(shape)
+                .border(Dp.Hairline, contentColor.copy(alpha = 0.5f), shape)
+                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+                .padding(horizontal = 10.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (dotColor != null) {
+            Box(modifier = Modifier.size(8.dp).clip(CircleShape).background(dotColor))
+            Spacer(Modifier.width(6.dp))
+        }
+        Text(text)
     }
 }
 

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
@@ -12,6 +12,7 @@ import io.github.kdroidfilter.nucleus.window.DecoratedWindowScope
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import io.github.vinceglb.filekit.utils.toKotlinxIoPath
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import warlockfe.warlock3.compose.AppContainer
 import warlockfe.warlock3.compose.desktop.shim.WarlockAlertDialog
@@ -74,11 +75,26 @@ fun DecoratedWindowScope.WarlockApp(
                 }
             }
         }
+    val gameViewModel = (gameState.screen as? GameScreen.ConnectedGameState)?.viewModel
+    val disconnectedFlow = remember(gameViewModel) { gameViewModel?.disconnected ?: MutableStateFlow(false) }
+    val disconnected by disconnectedFlow.collectAsState()
     TitleBarView(
         title = title,
         sideBarVisible = sideBarVisible,
         showSideBar = { sideBarVisible = it },
         isConnected = gameState.screen is GameScreen.ConnectedGameState,
+        disconnected = disconnected,
+        canReconnect = gameViewModel?.canReconnect == true,
+        reconnect = { (gameState.screen as? GameScreen.ConnectedGameState)?.viewModel?.reconnect() },
+        goToDashboard = {
+            val screen = gameState.screen
+            if (screen is GameScreen.ConnectedGameState) {
+                scope.launch {
+                    screen.viewModel.close()
+                    gameState.setScreen(GameScreen.Dashboard)
+                }
+            }
+        },
         openNewWindow = openNewWindow,
         showSettingsDialog = { showSettings = true },
         disconnect = {


### PR DESCRIPTION
## Summary

Replaces the full-width "You have been disconnected" banner with reconnect/dashboard affordances built into each platform's existing chrome, so the disconnect state is handled in the title/top bar instead of a banner pushing the game down.

## Mobile (game screen)
- Removed the `DisconnectedBanner` from `GameView`.
- **Phone** top bar: a **Reconnect** button appears when disconnected and reconnect is possible; "Go to dashboard" stays in the overflow menu.
- **Large** top bar: the connection pill becomes a **Reconnect** button when disconnected and reconnect is possible (otherwise the Connected/Disconnected pill); dashboard stays in the overflow.
- **Tablet** (no top bar): shows **Reconnect + Dashboard** in its bottom bar when disconnected, via opt-in `GameBottomBar` params, so it isn't stranded.

## Desktop
- **File → Disconnect** is now disabled when already disconnected (`isConnected && !disconnected`).
- Removed the `DisconnectedBanner` from `DesktopGameView` (and the now-unused navigate-to-dashboard plumbing).
- **Title bar**: shows a connection status pill while in a game; when disconnected it becomes a **Reconnect** button (when reconnect is possible) with a **Dashboard** button alongside.

## Notes
- "Reconnect" only appears when the session actually supports it (`GameViewModel.canReconnect`); otherwise a "Disconnected" indicator is shown.
- Independent of #187 (MUD Mobile mobile / dashboard); branched from `master` and touches only game-screen + title-bar/file-menu files.

## Testing
- `:compose` (JVM + Android), `:desktopApp` compile; `ktlintCheck` passes on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)