### PR TITLE
Draw progress-bar text filled, not stroked

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogProgressBar.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogProgressBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.takeOrElse
@@ -113,6 +114,7 @@ fun DialogProgressBar(
                 textLayoutResult = measuredText,
                 color = textColor,
                 topLeft = topLeft,
+                drawStyle = Fill,
             )
         }
     }


### PR DESCRIPTION
## Summary

The progress-bar label had regressed to rendering with a **stroke** draw style (outlined/hollow text). This passes `drawStyle = Fill` to the `drawText` call in `DialogProgressBar`, so the text draws solid again.

One-line fix (plus the `Fill` import).

## Testing
- `:compose` (JVM + Android) compiles; `ktlintCheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)