### PR TITLE
Address stream-buffer review findings from #183

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -185,13 +185,13 @@ class ComposeTextStream(
         showWhenClosed: String?,
         isPrompt: Boolean,
     ) {
-        removeLines()
         val serialNumber = nextSerialNumber++
         addComponentLocations(text, serialNumber)
         val cachedLine = styledStringToCachedLine(text, ignoreWhenBlank, showWhenClosed, isPrompt)
         cacheLines.add(cachedLine)
         val line = cachedLineToStreamLine(cachedLine, serialNumber)
         finishedLines.add(line)
+        removeLines()
         line.text?.let { playSound(it.text) }
         appendLineToView(line)
     }
@@ -220,8 +220,10 @@ class ComposeTextStream(
             isPrompt = isPrompt,
         )
 
+    // Trim the buffer down to the cap. Callers append first, then trim, so this evicts the oldest
+    // lines until at most maxLines remain (maxLines <= 0 means unbounded).
     private fun removeLines() {
-        while (maxLines > 0 && finishedLines.size >= maxLines) {
+        while (maxLines > 0 && finishedLines.size > maxLines) {
             finishedLines.removeAt(0)
             cacheLines.removeAt(0)
             removedLines++
@@ -236,7 +238,6 @@ class ComposeTextStream(
                 // Images must be on their own line
                 partialLine = null
                 if (!showImages) return@withLock
-                removeLines()
                 cacheLines.add(null)
                 val line =
                     StreamImageLine(
@@ -244,6 +245,7 @@ class ComposeTextStream(
                         serialNumber = nextSerialNumber++,
                     )
                 finishedLines.add(line)
+                removeLines()
                 appendLineToView(line)
             }
         }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -61,7 +61,11 @@ class ComposeTextStream(
     // the O(n) front shift of an ArrayList.
     private val cacheLines = ArrayDeque<CachedLine?>(maxLines)
     private val finishedLines = ArrayDeque<StreamLine>(maxLines)
-    val lines = MutableStateFlow<List<StreamLine>>(emptyList())
+
+    // Seeded with an (empty) OffsetList rather than emptyList() so every value this flow ever holds
+    // shares OffsetList's referential equality. emptyList() compares by content, which would make the
+    // first published OffsetList equal to it (both empty) and let StateFlow swallow that emission.
+    val lines = MutableStateFlow<List<StreamLine>>(OffsetList(persistentListOf(), 0))
 
     // The displayed lines are an append-only persistent list plus a logical start index. Once the
     // buffer fills, evicting the oldest displayed line (which happens on every newline) is then an
@@ -140,7 +144,7 @@ class ComposeTextStream(
             cacheLines[cacheLines.lastIndex] = cachedLine
             val newLine = cachedLineToStreamLine(cachedLine, serialNumber)
             finishedLines[finishedLines.lastIndex] = newLine
-            replaceLineInView(serialNumber, newLine)
+            applyViewChange(replaceLineInView(serialNumber, newLine))
         }
     }
 
@@ -232,14 +236,15 @@ class ComposeTextStream(
                 // Images must be on their own line
                 partialLine = null
                 if (!showImages) return@withLock
+                removeLines()
                 cacheLines.add(null)
-                finishedLines.add(
+                val line =
                     StreamImageLine(
                         url = url,
                         serialNumber = nextSerialNumber++,
-                    ),
-                )
-                linesUpdated()
+                    )
+                finishedLines.add(line)
+                appendLineToView(line)
             }
         }
     }
@@ -251,23 +256,28 @@ class ComposeTextStream(
         workQueue.submit {
             mutex.withLock {
                 components[name] = value
+                // A component can appear on many lines; re-render them all, then publish once instead
+                // of emitting a fresh snapshot per affected line.
+                var change = ViewChange.NONE
                 componentLocations[name]?.forEach { serialNumber ->
                     val lineNumber = (serialNumber - removedLines).toInt()
                     // If the component has scrolled back past the buffer, ignore it
                     if (lineNumber >= 0) {
-                        updateLine(lineNumber)
+                        change = change.coalesce(updateLine(lineNumber))
                     }
                 }
+                applyViewChange(change)
             }
         }
     }
 
-    private fun updateLine(lineNumber: Int) {
-        val cachedLine = cacheLines[lineNumber] ?: return
+    // Re-render a single buffered line in place and stage (without publishing) the resulting change.
+    private fun updateLine(lineNumber: Int): ViewChange {
+        val cachedLine = cacheLines[lineNumber] ?: return ViewChange.NONE
         val serialNumber = finishedLines[lineNumber].serialNumber
         val newLine = cachedLineToStreamLine(cachedLine, serialNumber)
         finishedLines[lineNumber] = newLine
-        replaceLineInView(serialNumber, newLine)
+        return replaceLineInView(serialNumber, newLine)
     }
 
     // Append a single line to the displayed list instead of rebuilding and re-filtering all of it.
@@ -295,42 +305,84 @@ class ComposeTextStream(
         }
     }
 
-    // Replace a single already-displayed line. Updates almost always target the most recent line, so
-    // check the tail before binary searching the live window; PersistentList.set shares structure,
-    // avoiding a full copy. A line's prompt flag is fixed, but its name-filter match can change, so
-    // handle it appearing/disappearing.
+    // Replace a single already-displayed line, returning the view change to apply (the caller
+    // publishes, so a batch of replacements can emit one snapshot). Updates almost always target the
+    // most recent line, so check the tail before binary searching the live window; PersistentList.set
+    // shares structure, avoiding a full copy. A line's prompt flag is fixed, but its name-filter match
+    // can change, so handle it appearing/disappearing.
     private fun replaceLineInView(
         serialNumber: Long,
         newLine: StreamLine,
-    ) {
+    ): ViewChange {
+        val lastSerial = displayBacking.lastOrNull()?.serialNumber
         val backingIndex =
-            if (displayBacking.lastOrNull()?.serialNumber == serialNumber) {
-                displayBacking.lastIndex
-            } else {
-                displayBacking.binarySearch(displayStart, displayBacking.size) {
-                    it.serialNumber.compareTo(serialNumber)
+            when {
+                lastSerial == serialNumber -> {
+                    displayBacking.lastIndex
+                }
+
+                // A serial newer than the last displayed line cannot be in the live window (e.g. a
+                // suppressed/filtered partial line being streamed), so skip the binary search.
+                lastSerial == null || serialNumber > lastSerial -> {
+                    -1
+                }
+
+                else -> {
+                    displayBacking.binarySearch(displayStart, displayBacking.size) {
+                        it.serialNumber.compareTo(serialNumber)
+                    }
                 }
             }
         val shouldShow = linePassesFilter(newLine)
-        when {
+        return when {
             backingIndex >= displayStart && shouldShow -> {
                 displayBacking = displayBacking.set(backingIndex, newLine)
-                publishLines()
+                ViewChange.PUBLISH
             }
 
             backingIndex >= displayStart -> {
                 // Was visible, now filtered out.
                 displayBacking = displayBacking.removeAt(backingIndex)
-                publishLines()
+                compactBacking()
+                ViewChange.PUBLISH
             }
 
             shouldShow -> {
                 // Was filtered out, now visible: rebuild so it lands in serial order.
+                ViewChange.REBUILD
+            }
+
+            // Filtered out before and after - nothing to update.
+            else -> {
+                ViewChange.NONE
+            }
+        }
+    }
+
+    private fun applyViewChange(change: ViewChange) {
+        when (change) {
+            ViewChange.PUBLISH -> {
+                publishLines()
+            }
+
+            ViewChange.REBUILD -> {
                 linesUpdated()
             }
 
-            // else: filtered out before and after - nothing to update.
+            ViewChange.NONE -> {}
         }
+    }
+
+    // The net effect of staging one or more line replacements. REBUILD subsumes PUBLISH subsumes
+    // NONE, so a batch escalates to the strongest change any one line produced (a rebuild reads the
+    // already-updated finishedLines, so it covers the set/remove mutations too).
+    private enum class ViewChange {
+        NONE,
+        PUBLISH,
+        REBUILD,
+        ;
+
+        fun coalesce(other: ViewChange): ViewChange = if (other.ordinal > ordinal) other else this
     }
 
     // Drop the evicted prefix once it is as large as the live portion. The rebuild is O(n) but runs
@@ -365,6 +417,9 @@ class ComposeTextStream(
 
         override fun equals(other: Any?): Boolean = this === other
 
+        // Kept O(1) and consistent with the identity equals above (equal instances are the same
+        // instance, so they trivially share a hash) rather than AbstractList's O(n) content hash. This
+        // list is never used as a hash key; the override only exists to avoid that content hash.
         override fun hashCode(): Int = size
     }
 
@@ -417,6 +472,11 @@ class ComposeTextStream(
     fun setSuppressPrompts(suppressPrompts: Boolean) {
         if (this.suppressPrompts == suppressPrompts) return
         this.suppressPrompts = suppressPrompts
+        scheduleRelayout()
+    }
+
+    // Re-run the filter and rebuild the displayed list on the work queue. Callable from any thread.
+    private fun scheduleRelayout() {
         scope.launch {
             workQueue.submit {
                 mutex.withLock { linesUpdated() }
@@ -451,11 +511,7 @@ class ComposeTextStream(
     override fun setNameFilter(value: Boolean) {
         if (nameFilter == value) return
         nameFilter = value
-        scope.launch {
-            workQueue.submit {
-                mutex.withLock { linesUpdated() }
-            }
-        }
+        scheduleRelayout()
     }
 }
 

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -103,7 +104,7 @@ fun DesktopWindowView(
         defaultFontSize = JewelTheme.defaultTextStyle.fontSize,
         surface = { surfaceModifier, content ->
             val frameShape = RoundedCornerShape(4.dp)
-            androidx.compose.foundation.layout.Box(
+            Box(
                 modifier =
                     surfaceModifier
                         // Clip so a body that paints its own background (dialog panels, user styles) does not

--- a/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
+++ b/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
@@ -1,0 +1,388 @@
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import warlockfe.warlock3.compose.model.LiteralHighlight
+import warlockfe.warlock3.compose.model.ViewHighlight
+import warlockfe.warlock3.compose.ui.window.ComposeTextStream
+import warlockfe.warlock3.compose.ui.window.StreamImageLine
+import warlockfe.warlock3.compose.ui.window.StreamLine
+import warlockfe.warlock3.compose.ui.window.StreamTextLine
+import warlockfe.warlock3.compose.ui.window.StreamWorkQueue
+import warlockfe.warlock3.compose.util.HighlightIndex
+import warlockfe.warlock3.core.text.StyleDefinition
+import warlockfe.warlock3.core.text.StyledString
+import warlockfe.warlock3.core.text.StyledStringLeaf
+import warlockfe.warlock3.core.text.StyledStringSubstring
+import warlockfe.warlock3.core.text.StyledStringVariable
+import warlockfe.warlock3.core.util.SoundPlayer
+import warlockfe.warlock3.wrayth.util.CompiledAlteration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [ComposeTextStream]'s displayed-line buffer: ordering, eviction at capacity, the
+ * prompt/name filters, partial-line accumulation, component updates, and image lines.
+ *
+ * The stream does its work on a [StreamWorkQueue] (a FIFO channel drained by a single worker on
+ * Dispatchers.Default). For the methods that submit directly, [Fixture.drain] queues a barrier op
+ * after them and awaits it, so when it returns the prior ops have run. The two non-suspending
+ * setters dispatch their rebuild through scope.launch, so those tests wait on the [lines] flow
+ * reaching the expected state instead.
+ */
+class ComposeTextStreamTest {
+    private object SilentSoundPlayer : SoundPlayer {
+        override suspend fun playSound(filename: String): String? = null
+    }
+
+    private class Fixture(
+        maxLines: Int = 1000,
+        suppressPrompts: Boolean = false,
+        showImages: Boolean = true,
+        names: List<ViewHighlight> = emptyList(),
+    ) {
+        private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        private val workQueue = StreamWorkQueue(scope)
+
+        val stream =
+            ComposeTextStream(
+                id = "main",
+                maxLines = maxLines,
+                markLinks = false,
+                showImages = showImages,
+                showTimestamps = false,
+                suppressPrompts = suppressPrompts,
+                highlights = MutableStateFlow(HighlightIndex(emptyList())),
+                names = MutableStateFlow(names),
+                alterations = MutableStateFlow(emptyList<CompiledAlteration>()),
+                presets = MutableStateFlow(emptyMap<String, StyleDefinition>()),
+                soundPlayer = SilentSoundPlayer,
+                workQueue = workQueue,
+                scope = scope,
+            )
+
+        // FIFO barrier: a no-op op queued after the prior direct submits; awaiting it means they ran.
+        suspend fun drain() {
+            val done = CompletableDeferred<Unit>()
+            workQueue.submit { done.complete(Unit) }
+            done.await()
+        }
+
+        suspend fun awaitLines(predicate: (List<StreamLine>) -> Boolean): List<StreamLine> =
+            withTimeout(5_000) { stream.lines.first(predicate) }
+
+        fun close() = scope.cancel()
+    }
+
+    private fun text(value: String): StyledString = StyledString(value)
+
+    // A line that is some fixed text followed by a component reference, e.g. "hp: " + {hp}.
+    private fun lineWithComponent(
+        prefix: String,
+        component: String,
+    ): StyledString =
+        StyledString(
+            persistentListOf<StyledStringLeaf>(
+                StyledStringSubstring(prefix, emptyList()),
+                StyledStringVariable(component, emptyList()),
+            ),
+        )
+
+    private fun List<StreamLine>.texts(): List<String?> = map { (it as StreamTextLine).text?.text }
+
+    private fun List<StreamLine>.serials(): List<Long> = map { it.serialNumber }
+
+    private inline fun withFixture(
+        maxLines: Int = 1000,
+        suppressPrompts: Boolean = false,
+        showImages: Boolean = true,
+        names: List<ViewHighlight> = emptyList(),
+        block: (Fixture) -> Unit,
+    ) {
+        val fixture = Fixture(maxLines, suppressPrompts, showImages, names)
+        try {
+            block(fixture)
+        } finally {
+            fixture.close()
+        }
+    }
+
+    @Test
+    fun appendsLinesInSerialOrder() =
+        runBlocking {
+            withFixture { f ->
+                f.stream.appendLine(text("a"), ignoreWhenBlank = false, showWhenClosed = null)
+                f.stream.appendLine(text("b"), ignoreWhenBlank = false, showWhenClosed = null)
+                f.stream.appendLine(text("c"), ignoreWhenBlank = false, showWhenClosed = null)
+                f.drain()
+
+                assertEquals(
+                    listOf("a", "b", "c"),
+                    f.stream.lines.value
+                        .texts(),
+                )
+                assertEquals(
+                    listOf(0L, 1L, 2L),
+                    f.stream.lines.value
+                        .serials(),
+                )
+            }
+        }
+
+    @Test
+    fun evictsOldestLinesAtCapacity() =
+        runBlocking {
+            withFixture(maxLines = 3) { f ->
+                repeat(5) { i ->
+                    f.stream.appendLine(text("line$i"), ignoreWhenBlank = false, showWhenClosed = null)
+                }
+                f.drain()
+
+                val lines = f.stream.lines.value
+                assertEquals(3, lines.size)
+                assertEquals(listOf("line2", "line3", "line4"), lines.texts())
+                assertEquals(listOf(2L, 3L, 4L), lines.serials())
+            }
+        }
+
+    // Exercises the displayBacking / displayStart / compactBacking machinery across many evictions.
+    @Test
+    fun evictionStaysCorrectOverManyLines() =
+        runBlocking {
+            withFixture(maxLines = 10) { f ->
+                repeat(100) { i ->
+                    f.stream.appendLine(text("l$i"), ignoreWhenBlank = false, showWhenClosed = null)
+                }
+                f.drain()
+
+                val lines = f.stream.lines.value
+                assertEquals(10, lines.size)
+                assertEquals((90 until 100).map { "l$it" }, lines.texts())
+                assertEquals((90L until 100L).toList(), lines.serials())
+            }
+        }
+
+    @Test
+    fun clearEmptiesTheBuffer() =
+        runBlocking {
+            withFixture { f ->
+                f.stream.appendLine(text("a"), ignoreWhenBlank = false, showWhenClosed = null)
+                f.drain()
+                assertEquals(1, f.stream.lines.value.size)
+
+                f.stream.clear()
+                f.drain()
+                assertTrue(
+                    f.stream.lines.value
+                        .isEmpty(),
+                )
+            }
+        }
+
+    @Test
+    fun setMaxLinesTrimsExistingBuffer() =
+        runBlocking {
+            withFixture(maxLines = 100) { f ->
+                repeat(10) { i ->
+                    f.stream.appendLine(text("l$i"), ignoreWhenBlank = false, showWhenClosed = null)
+                }
+                f.drain()
+                assertEquals(10, f.stream.lines.value.size)
+
+                f.stream.setMaxLines(3)
+                f.drain()
+
+                // Shrinking the cap trims to exactly maxLines, keeping the most recent lines.
+                assertEquals(
+                    listOf("l7", "l8", "l9"),
+                    f.stream.lines.value
+                        .texts(),
+                )
+
+                // A following append stays at the cap rather than overshooting to maxLines + 1.
+                f.stream.appendLine(text("l10"), ignoreWhenBlank = false, showWhenClosed = null)
+                f.drain()
+                assertEquals(
+                    listOf("l8", "l9", "l10"),
+                    f.stream.lines.value
+                        .texts(),
+                )
+            }
+        }
+
+    @Test
+    fun suppressPromptsFromConstructorHidesPromptLines() =
+        runBlocking {
+            withFixture(suppressPrompts = true) { f ->
+                f.stream.appendLine(text("normal"), ignoreWhenBlank = false, showWhenClosed = null)
+                f.stream.appendPartial(text(">"), isPrompt = true)
+                f.drain()
+
+                assertEquals(
+                    listOf("normal"),
+                    f.stream.lines.value
+                        .texts(),
+                )
+            }
+        }
+
+    @Test
+    fun togglingSuppressPromptsHidesThenShowsPrompt() =
+        runBlocking {
+            withFixture(suppressPrompts = false) { f ->
+                f.stream.appendLine(text("normal"), ignoreWhenBlank = false, showWhenClosed = null)
+                f.stream.appendPartial(text(">"), isPrompt = true)
+                f.drain()
+                assertEquals(
+                    listOf("normal", ">"),
+                    f.stream.lines.value
+                        .texts(),
+                )
+
+                f.stream.setSuppressPrompts(true)
+                assertEquals(listOf("normal"), f.awaitLines { it.size == 1 }.texts())
+
+                f.stream.setSuppressPrompts(false)
+                assertEquals(listOf("normal", ">"), f.awaitLines { it.size == 2 }.texts())
+            }
+        }
+
+    @Test
+    fun nameFilterShowsOnlyMatchingLines() =
+        runBlocking {
+            val orc = LiteralHighlight(literal = "orc", matchPartialWord = false, ignoreCase = true, style = null, sound = null)
+            withFixture(names = listOf(orc)) { f ->
+                f.stream.appendLine(text("an orc appears"), ignoreWhenBlank = false, showWhenClosed = null)
+                f.stream.appendLine(text("nothing here"), ignoreWhenBlank = false, showWhenClosed = null)
+                f.drain()
+                assertEquals(2, f.stream.lines.value.size)
+
+                f.stream.setNameFilter(true)
+                assertEquals(listOf("an orc appears"), f.awaitLines { it.size == 1 }.texts())
+
+                f.stream.setNameFilter(false)
+                assertEquals(2, f.awaitLines { it.size == 2 }.size)
+            }
+        }
+
+    @Test
+    fun partialLineAccumulatesOnASingleSerial() =
+        runBlocking {
+            withFixture { f ->
+                f.stream.appendPartial(text("hel"), isPrompt = false)
+                f.stream.appendPartial(text("lo"), isPrompt = false)
+                f.drain()
+                assertEquals(
+                    listOf("hello"),
+                    f.stream.lines.value
+                        .texts(),
+                )
+                assertEquals(
+                    listOf(0L),
+                    f.stream.lines.value
+                        .serials(),
+                )
+
+                f.stream.appendPartialAndEol(text("!"))
+                f.drain()
+                assertEquals(
+                    listOf("hello!"),
+                    f.stream.lines.value
+                        .texts(),
+                )
+
+                f.stream.appendLine(text("next"), ignoreWhenBlank = false, showWhenClosed = null)
+                f.drain()
+                assertEquals(
+                    listOf("hello!", "next"),
+                    f.stream.lines.value
+                        .texts(),
+                )
+                assertEquals(
+                    listOf(0L, 1L),
+                    f.stream.lines.value
+                        .serials(),
+                )
+            }
+        }
+
+    // A single component value change must re-render every line that references it.
+    @Test
+    fun updateComponentRefreshesAllOccurrences() =
+        runBlocking {
+            withFixture { f ->
+                repeat(3) { i ->
+                    f.stream.appendLine(lineWithComponent("row$i ", "hp"), ignoreWhenBlank = false, showWhenClosed = null)
+                }
+                f.drain()
+                assertEquals(
+                    listOf("row0 ", "row1 ", "row2 "),
+                    f.stream.lines.value
+                        .texts(),
+                )
+
+                f.stream.updateComponent("hp", text("100"))
+                f.drain()
+                assertEquals(
+                    listOf("row0 100", "row1 100", "row2 100"),
+                    f.stream.lines.value
+                        .texts(),
+                )
+            }
+        }
+
+    @Test
+    fun imageLinesRespectMaxLines() =
+        runBlocking {
+            withFixture(maxLines = 3) { f ->
+                repeat(5) { i ->
+                    f.stream.appendResource("img$i.png")
+                }
+                f.drain()
+
+                val lines = f.stream.lines.value
+                assertEquals(3, lines.size)
+                assertEquals(listOf("img2.png", "img3.png", "img4.png"), lines.map { (it as StreamImageLine).url })
+            }
+        }
+
+    @Test
+    fun imageLinesIgnoredWhenImagesDisabled() =
+        runBlocking {
+            withFixture(showImages = false) { f ->
+                f.stream.appendResource("img.png")
+                f.drain()
+                assertTrue(
+                    f.stream.lines.value
+                        .isEmpty(),
+                )
+            }
+        }
+
+    // Streaming updates to a suppressed prompt must not surface it or throw (the line is never in the
+    // displayed list, so replaceLineInView keeps hitting the filtered-out path).
+    @Test
+    fun streamingSuppressedPromptNeverAppears() =
+        runBlocking {
+            withFixture(suppressPrompts = true) { f ->
+                f.stream.appendLine(text("normal"), ignoreWhenBlank = false, showWhenClosed = null)
+                f.stream.appendPartial(text(">"), isPrompt = true)
+                f.stream.appendPartial(text(" ready"), isPrompt = true)
+                f.stream.appendPartial(text(">"), isPrompt = true)
+                f.drain()
+
+                assertEquals(
+                    listOf("normal"),
+                    f.stream.lines.value
+                        .texts(),
+                )
+            }
+        }
+}


### PR DESCRIPTION
Follow-up to the post-merge review of #183 (see that PR's review comment). This addresses the concrete correctness, efficiency, and cleanup findings. The two deeper altitude items (generalizing `nameFilter`/`suppressPrompts` into a predicate set, and replacing the per-setting fan-out boilerplate with a single settings broadcast) are intentionally left out to keep this reviewable; happy to do them separately.

## Fixes

**#1 `OffsetList` / `StateFlow` equality (latent correctness).** `lines` was seeded with `emptyList()` (content equality), so the first published empty `OffsetList` compared equal to it and StateFlow swallowed the emission. Now seeded with `OffsetList(persistentListOf(), 0)` so every value shares the referential-equality contract.

**#2 Missing compaction in `replaceLineInView` (correctness/memory).** The "now filtered out" `removeAt` branch never called `compactBacking()`, so filter churn with no new appends could pin a dead prefix. It now compacts like the append path.

**#3 `updateComponent` over-emission (efficiency).** A component on K lines emitted K snapshots. `replaceLineInView` now returns a `ViewChange`; `updateComponent` re-renders all affected lines and publishes once (a single `REBUILD` subsumes the batch).

**#4 Image path bypassed the fast path + eviction (efficiency/correctness).** `appendResource` did a full O(n) `linesUpdated()` and never called `removeLines()`, so image-only windows grew unbounded. It now calls `removeLines()` and routes through `appendLineToView`, matching the text path.

**#6 Duplicated relayout boilerplate (cleanup).** Extracted `scheduleRelayout()`, shared by `setSuppressPrompts` and `setNameFilter`.

**#8 `OffsetList.hashCode` (cleanup).** Documented the O(1) `hashCode` as an intentional identity-consistent stub (avoids `AbstractList`'s O(n) content hash; the list is never used as a hash key).

**#9 Fully-qualified `Box` (cleanup).** Imported `Box` in `DesktopWindowView` instead of the inline FQN.

**#10 Wasted binary search (efficiency).** `replaceLineInView` now skips the search when the serial is newer than the last displayed line (e.g. a streaming suppressed/filtered partial line), since it cannot be in the live window.

## Testing

- `:compose:compileKotlinJvm`, `:core:compileKotlinJvm`, `:compose:compileAndroidMain` pass.
- `:compose:ktlintCheck`, `:core:ktlintCheck` pass.
- No behavioral change to the displayed output: batching only collapses redundant emissions, and the image/eviction change makes image windows respect `maxLines` (as text already did). No unit tests cover `ComposeTextStream`, so this rests on the type checker + reasoning, same as #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
