### PR TITLE
StyledString: fix value equality, drop deprecated API, tidy up

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -703,7 +703,7 @@ private fun logSlowLine(
     // pulls more candidates than a short line does.
     val candidates = highlightIndex.candidateCount(wordTokensOf(first.line.text?.text ?: ""))
     streamLineLogger.w {
-        val before = source.toString().take(200).replace("\n", "\\n")
+        val before = source.toText().take(200).replace("\n", "\\n")
         val after =
             first.line.text
                 ?.text

--- a/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
+++ b/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
@@ -89,9 +89,9 @@ class ComposeTextStreamTest {
         component: String,
     ): StyledString =
         StyledString(
-            persistentListOf<StyledStringLeaf>(
-                StyledStringSubstring(prefix, emptyList()),
-                StyledStringVariable(component, emptyList()),
+            persistentListOf(
+                StyledStringSubstring(prefix, persistentListOf()),
+                StyledStringVariable(component, persistentListOf()),
             ),
         )
 

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/StyledString.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/StyledString.kt
@@ -1,53 +1,65 @@
 package warlockfe.warlock3.core.text
 
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.mutate
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toImmutableList
 
 data class StyledString(
     val substrings: PersistentList<StyledStringLeaf> = persistentListOf(),
 ) {
     constructor(text: String, styles: List<WarlockStyle> = emptyList()) :
-        this(persistentListOf<StyledStringSubstring>(StyledStringSubstring(text, styles)))
+        this(persistentListOf(StyledStringSubstring(text, styles.toImmutableList())))
 
     constructor(text: String, style: WarlockStyle) : this(text, listOf(style))
 
-    // addAll on a persistent list appends in O(elements added) with structural sharing, so folding
+    // addingAll on a persistent list appends in O(elements added) with structural sharing, so folding
     // many fragments into one line (e.g. a room description) is O(total) rather than the O(n²) of
     // repeated (a + b) whole-list copies.
-    operator fun plus(string: StyledString): StyledString = copy(substrings = substrings.addAll(string.substrings))
+    operator fun plus(string: StyledString): StyledString = copy(substrings = substrings.addingAll(string.substrings))
 
-    fun applyStyle(style: WarlockStyle): StyledString = copy(substrings = substrings.map { it.applyStyle(style) }.toPersistentList())
+    fun applyStyle(style: WarlockStyle): StyledString =
+        copy(
+            substrings =
+                substrings.mutate { leaves ->
+                    for (i in leaves.indices) {
+                        leaves[i] = leaves[i].applyStyle(style)
+                    }
+                },
+        )
 
-    override fun toString(): String {
+    /** The plain text, with unresolved component/variable references rendered as %name%; e.g. for logging or matching. */
+    fun toText(): String {
         val builder = StringBuilder()
         substrings.forEach { substring ->
-            if (substring is StyledStringSubstring) {
-                builder.append(substring.text)
+            when (substring) {
+                is StyledStringSubstring -> builder.append(substring.text)
+                is StyledStringVariable -> builder.append("%${substring.name}%")
             }
         }
         return builder.toString()
     }
 }
 
-sealed class StyledStringLeaf(
-    val styles: List<WarlockStyle>,
-)
+sealed interface StyledStringLeaf {
+    val styles: ImmutableList<WarlockStyle>
+}
 
-class StyledStringSubstring(
+data class StyledStringSubstring(
     val text: String,
-    styles: List<WarlockStyle>,
-) : StyledStringLeaf(styles)
+    override val styles: ImmutableList<WarlockStyle>,
+) : StyledStringLeaf
 
-class StyledStringVariable(
+data class StyledStringVariable(
     val name: String,
-    styles: List<WarlockStyle>,
-) : StyledStringLeaf(styles)
+    override val styles: ImmutableList<WarlockStyle>,
+) : StyledStringLeaf
 
 fun StyledStringLeaf.applyStyle(style: WarlockStyle): StyledStringLeaf =
     when (this) {
-        is StyledStringSubstring -> StyledStringSubstring(text = text, styles = styles + style)
-        is StyledStringVariable -> StyledStringVariable(name = name, styles = styles + style)
+        is StyledStringSubstring -> copy(styles = (styles + style).toImmutableList())
+        is StyledStringVariable -> copy(styles = (styles + style).toImmutableList())
     }
 
 fun StyledString.isBlank(): Boolean = substrings.all { it.isBlank() }

--- a/scripting/src/commonTest/kotlin/wsl/WslCommandsTest.kt
+++ b/scripting/src/commonTest/kotlin/wsl/WslCommandsTest.kt
@@ -312,7 +312,7 @@ class WslCommandsTest {
             val client = FakeWarlockClient()
             val ctx = buildTestContext(backgroundScope, client = client)
             ctx.command("echo", "hello world")
-            assertEquals("hello world", client.printed.single().toString())
+            assertEquals("hello world", client.printed.single().toText())
         }
 
     @Test
@@ -344,7 +344,7 @@ class WslCommandsTest {
             assertTrue(
                 client.printed
                     .single()
-                    .toString()
+                    .toText()
                     .contains("alert.wav"),
             )
         }

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -521,9 +521,9 @@ class WraythClient(
                     componentsMutex.withLock {
                         components =
                             if (elementBuffer?.substrings.isNullOrEmpty()) {
-                                components.remove(componentId!!)
+                                components.removing(componentId!!)
                             } else {
-                                components.put(componentId!!, elementBuffer!!)
+                                components.putting(componentId!!, elementBuffer!!)
                             }
                     }
                     val newValue = elementBuffer ?: StyledString()
@@ -794,7 +794,7 @@ class WraythClient(
     ) {
         doAppendToStream(styledText, stream, ignoreWhenBlank)
         if (stream.isMainStream || windows[stream.id]?.ifClosed == "main") {
-            val text = styledText.toString()
+            val text = styledText.toText()
             if (text.isNotBlank()) {
                 logSimple { text }
                 notifyListeners(ClientTextEvent(text))


### PR DESCRIPTION
## Summary

Audit follow-up on `StyledString`.

- **Value equality (correctness):** `StyledStringLeaf` is now a `sealed interface` with **data-class** leaves (`StyledStringSubstring`/`StyledStringVariable`). Previously `StyledString` was a `data class` but its leaves used **reference** equality, so two `StyledString`s with identical content compared **unequal** — silently defeating the generated `equals`/`hashCode`. Nothing relied on it yet (no `==`/`distinctUntilChanged`/keys), so this removes a latent trap rather than fixing an active bug.
- **Deprecation:** `plus()` now uses `addingAll` instead of the deprecated `PersistentList.addAll` (clears the compiler warning).
- **`applyStyle`:** uses `mutate { }` instead of `map { }.toPersistentList()` (no intermediate list); leaf `styles` are now `ImmutableList`.
- **`toString()`/`toText()`:** `toString()` is now the data-class debug form (`StyledString(substrings=[...])`); a new `toText()` returns the plain text (component/variable refs rendered as `%name%`). `WraythClient` logging + the `ClientTextEvent` stream now call `toText()`.

## ⚠️ Behavior change to flag
Previously the plain-text `toString()` **omitted** component/variable references; `toText()` now renders them as **`%name%`**. Since `WraythClient` uses this for **logging and the `ClientTextEvent` stream** (which scripts/triggers see), main-stream lines containing component refs will now show `%name%` where they previously showed nothing. Confirm that's intended — if scripts match on that text, this changes what they see. (Easy to revert `toText()` to omit variables if not wanted.)

## Testing
- `:core`, `:wrayth`, `:compose` (JVM + Android) compile; `ComposeTextStreamTest` passes; `ktlintCheck` passes on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)