### PR TITLE
Drop the ComposeTextStream mutex; keep the shared work queue

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -1106,12 +1106,12 @@ class GameViewModel(
     }
 
     override fun scroll(event: ScrollEvent) {
-        _scrollEvents.update { it.add(event) }
+        _scrollEvents.update { it.adding(event) }
     }
 
     fun handledScrollEvent(event: ScrollEvent) {
         _scrollEvents.update { oldList ->
-            oldList.remove(event)
+            oldList.removing(event)
         }
     }
 

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -12,8 +12,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import warlockfe.warlock3.compose.model.LiteralHighlight
 import warlockfe.warlock3.compose.model.RegexHighlight
 import warlockfe.warlock3.compose.model.ViewHighlight
@@ -89,15 +87,13 @@ class ComposeTextStream(
 
     var actionHandler: ((WarlockAction) -> Unit)? = null
 
-    val mutex = Mutex()
-
     init {
         // Re-filter displayed lines whenever the names list changes
         names
             .onEach {
                 if (nameFilter) {
                     workQueue.submit {
-                        mutex.withLock { linesUpdated() }
+                        linesUpdated()
                     }
                 }
             }.launchIn(scope)
@@ -108,18 +104,14 @@ class ComposeTextStream(
         isPrompt: Boolean,
     ) {
         workQueue.submit {
-            mutex.withLock {
-                doAppendPartial(text, isPrompt)
-            }
+            doAppendPartial(text, isPrompt)
         }
     }
 
     override suspend fun appendPartialAndEol(text: StyledString) {
         workQueue.submit {
-            mutex.withLock {
-                doAppendPartial(text, isPrompt = false)
-                partialLine = null
-            }
+            doAppendPartial(text, isPrompt = false)
+            partialLine = null
         }
     }
 
@@ -150,16 +142,14 @@ class ComposeTextStream(
 
     override suspend fun clear() {
         workQueue.submit {
-            mutex.withLock {
-                finishedLines.clear()
-                partialLine = null
-                componentLocations.clear()
-                components.clear()
-                nextSerialNumber = 0L
-                removedLines = 0L
-                cacheLines.clear()
-                linesUpdated()
-            }
+            finishedLines.clear()
+            partialLine = null
+            componentLocations.clear()
+            components.clear()
+            nextSerialNumber = 0L
+            removedLines = 0L
+            cacheLines.clear()
+            linesUpdated()
         }
     }
 
@@ -169,12 +159,10 @@ class ComposeTextStream(
         showWhenClosed: String?,
     ) {
         workQueue.submit {
-            mutex.withLock {
-                // It's possible a component is added that is set prior
-                // I don't think this happens in DR, so it's probably OK that we don't handle that case.
-                partialLine = null
-                doAppendLine(text, ignoreWhenBlank, showWhenClosed, isPrompt = false)
-            }
+            // It's possible a component is added that is set prior
+            // I don't think this happens in DR, so it's probably OK that we don't handle that case.
+            partialLine = null
+            doAppendLine(text, ignoreWhenBlank, showWhenClosed, isPrompt = false)
         }
     }
 
@@ -234,20 +222,18 @@ class ComposeTextStream(
 
     override suspend fun appendResource(url: String) {
         workQueue.submit {
-            mutex.withLock {
-                // Images must be on their own line
-                partialLine = null
-                if (!showImages) return@withLock
-                cacheLines.add(null)
-                val line =
-                    StreamImageLine(
-                        url = url,
-                        serialNumber = nextSerialNumber++,
-                    )
-                finishedLines.add(line)
-                removeLines()
-                appendLineToView(line)
-            }
+            // Images must be on their own line
+            partialLine = null
+            if (!showImages) return@submit
+            cacheLines.add(null)
+            val line =
+                StreamImageLine(
+                    url = url,
+                    serialNumber = nextSerialNumber++,
+                )
+            finishedLines.add(line)
+            removeLines()
+            appendLineToView(line)
         }
     }
 
@@ -256,20 +242,18 @@ class ComposeTextStream(
         value: StyledString,
     ) {
         workQueue.submit {
-            mutex.withLock {
-                components[name] = value
-                // A component can appear on many lines; re-render them all, then publish once instead
-                // of emitting a fresh snapshot per affected line.
-                var change = ViewChange.NONE
-                componentLocations[name]?.forEach { serialNumber ->
-                    val lineNumber = (serialNumber - removedLines).toInt()
-                    // If the component has scrolled back past the buffer, ignore it
-                    if (lineNumber >= 0) {
-                        change = change.coalesce(updateLine(lineNumber))
-                    }
+            components[name] = value
+            // A component can appear on many lines; re-render them all, then publish once instead
+            // of emitting a fresh snapshot per affected line.
+            var change = ViewChange.NONE
+            componentLocations[name]?.forEach { serialNumber ->
+                val lineNumber = (serialNumber - removedLines).toInt()
+                // If the component has scrolled back past the buffer, ignore it
+                if (lineNumber >= 0) {
+                    change = change.coalesce(updateLine(lineNumber))
                 }
-                applyViewChange(change)
             }
+            applyViewChange(change)
         }
     }
 
@@ -298,7 +282,7 @@ class ComposeTextStream(
             }
         }
         if (linePassesFilter(line)) {
-            displayBacking = displayBacking.add(line)
+            displayBacking = displayBacking.adding(line)
             changed = true
         }
         if (changed) {
@@ -338,13 +322,13 @@ class ComposeTextStream(
         val shouldShow = linePassesFilter(newLine)
         return when {
             backingIndex >= displayStart && shouldShow -> {
-                displayBacking = displayBacking.set(backingIndex, newLine)
+                displayBacking = displayBacking.replacingAt(backingIndex, newLine)
                 ViewChange.PUBLISH
             }
 
             backingIndex >= displayStart -> {
                 // Was visible, now filtered out.
-                displayBacking = displayBacking.removeAt(backingIndex)
+                displayBacking = displayBacking.removingAt(backingIndex)
                 compactBacking()
                 ViewChange.PUBLISH
             }
@@ -456,7 +440,7 @@ class ComposeTextStream(
     }
 
     suspend fun setMaxLines(maxLines: Int) {
-        mutex.withLock {
+        workQueue.submit {
             this@ComposeTextStream.maxLines = maxLines
             removeLines()
             linesUpdated()
@@ -481,7 +465,7 @@ class ComposeTextStream(
     private fun scheduleRelayout() {
         scope.launch {
             workQueue.submit {
-                mutex.withLock { linesUpdated() }
+                linesUpdated()
             }
         }
     }
@@ -801,14 +785,13 @@ private fun buildReplacement(
     val sb = StringBuilder(replacement.length)
     var i = 0
     while (i < replacement.length) {
-        val c = replacement[i]
-        when {
-            c == '\\' && i + 1 < replacement.length -> {
+        when (val c = replacement[i]) {
+            '\\' if i + 1 < replacement.length -> {
                 sb.append(replacement[i + 1])
                 i += 2
             }
 
-            c == '$' && i + 1 < replacement.length -> {
+            '$' if i + 1 < replacement.length -> {
                 val next = replacement[i + 1]
                 if (next.isDigit()) {
                     val n = next.digitToInt()

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowRegistryImpl.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowRegistryImpl.kt
@@ -223,7 +223,7 @@ class WindowRegistryImpl(
         while (true) {
             val current = streams.load()
             current[name]?.let { return it }
-            if (streams.compareAndSet(current, current.put(name, candidate))) {
+            if (streams.compareAndSet(current, current.putting(name, candidate))) {
                 return candidate
             }
         }
@@ -237,7 +237,7 @@ class WindowRegistryImpl(
         while (true) {
             val current = dialogs.load()
             current[name]?.let { return it }
-            if (dialogs.compareAndSet(current, current.put(name, candidate))) {
+            if (dialogs.compareAndSet(current, current.putting(name, candidate))) {
                 return candidate
             }
         }


### PR DESCRIPTION
## Summary

Keeps the **single shared `StreamWorkQueue`** (one worker per connection, so all streams' ops stay globally ordered / in sync) and removes the now-redundant `Mutex`.

- Every stream mutation already runs on the shared queue's single worker, so the mutex never actually contended. `setMaxLines` and `scheduleRelayout` are routed through the queue (the mutex was the only thing covering `setMaxLines`'s off-queue access), then the mutex and its `withLock` wrappers are removed.
- Staying with one shared queue rather than per-stream queues preserves cross-stream ordering and avoids allocating an N×(1000-capacity) channel buffer per stream.
- Also clears the deprecated persistent-collection API (`add`/`remove`/`put`/`set` → `adding`/`removing`/`putting`/`replacingAt`/`removingAt`) and tidies `buildReplacement` with `when` guards.

## Why this shape (vs per-stream queues)
Per-stream queues would isolate slow streams and add parallelism, but each stream would own a 1000-slot channel and global ordering would be lost. Keeping the shared queue keeps state in sync and memory bounded; the mutex removal is safe because a single worker already serializes all access.

## Testing
- `:compose` compiles (JVM + Android); `ComposeTextStreamTest` passes; `ktlintCheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)