### PR TITLE
Let callers supply the progress-bar label text style

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogProgressBar.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogProgressBar.kt
@@ -15,11 +15,9 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import warlockfe.warlock3.compose.model.SkinObject
 import warlockfe.warlock3.compose.util.CONTRAST_CROSSOVER_LUMINANCE
 import warlockfe.warlock3.compose.util.getColorGroup
@@ -35,12 +33,13 @@ private val labelOutlineColor = Color(0xFF101216)
 private val barHorizontalPadding = 2.dp
 
 // Corner radius of the track/fill, matching the design's rounded vital bars.
-private val barCornerRadius = 2.dp
+private val barCornerRadius = 4.dp
 
 @Composable
 fun DialogProgressBar(
     skinObject: SkinObject?,
     data: DialogObject.ProgressBar,
+    style: TextStyle,
     modifier: Modifier = Modifier,
     barColorOverride: WarlockColor = WarlockColor.Unspecified,
     backgroundColorOverride: WarlockColor = WarlockColor.Unspecified,
@@ -81,11 +80,7 @@ fun DialogProgressBar(
                     text = text,
                     constraints = Constraints(maxWidth = size.width.toInt()),
                     maxLines = 1,
-                    style =
-                        TextStyle(
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Medium,
-                        ),
+                    style = style,
                 )
             val topLeft =
                 Offset(

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopDialogContent.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopDialogContent.kt
@@ -174,6 +174,7 @@ private fun ProgressBarWithColorMenu(
             barColorOverride = barColor,
             backgroundColorOverride = backgroundColor,
             textColorOverride = textColor,
+            style = labelStyle,
         )
     }
 

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/DialogContent.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.LocalContentColor
@@ -24,19 +23,15 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import warlockfe.warlock3.compose.components.ColorPickerDialog
-import warlockfe.warlock3.compose.model.SkinColor
 import warlockfe.warlock3.compose.model.SkinObject
 import warlockfe.warlock3.compose.util.LocalSkin
 import warlockfe.warlock3.compose.util.getColorGroup
 import warlockfe.warlock3.compose.util.toColor
-import warlockfe.warlock3.core.client.DataDistance
 import warlockfe.warlock3.core.client.DialogObject
-import warlockfe.warlock3.core.client.Percentage
 import warlockfe.warlock3.core.text.StyleDefinition
 import warlockfe.warlock3.core.text.WarlockColor
 import warlockfe.warlock3.core.util.getIgnoringCase
@@ -157,6 +152,7 @@ private fun ProgressBarWithColorMenu(
             barColorOverride = barColor,
             backgroundColorOverride = backgroundColor,
             textColorOverride = textColor,
+            style = MaterialTheme.typography.labelSmall,
         )
         DropdownMenu(
             expanded = menuOpen,


### PR DESCRIPTION
## Summary

`DialogProgressBar` hardcoded its label as `10sp` / `FontWeight.Medium`. This makes it take a `style: TextStyle` parameter so each platform owns the label typography:

- **Desktop** passes its existing `labelStyle` — no visual change.
- **Mobile** passes `MaterialTheme.typography.labelSmall`, so the label now follows the Material theme instead of a hardcoded style.

Also:
- Bump the bar corner radius `2dp` → `4dp` to match the design's rounded vital bars.
- Drop the mobile imports left unused after the change.

## Test plan
- [ ] Vital/progress bars render with correct label styling on desktop (unchanged) and mobile (Material `labelSmall`).
- [x] `ktlintFormat` clean; pre-commit `ktlintCheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)