### PR TITLE
Use staircase icons for compass up/down

### DIFF
--- a/compose/src/commonMain/composeResources/drawable/stairs_down.xml
+++ b/compose/src/commonMain/composeResources/drawable/stairs_down.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="72"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:pathData="M120,540h140v100h140v100h140v100h140"/>
+  <path
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="72"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:pathData="M160,200L560,480"/>
+  <path
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="72"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:pathData="M380,480H560V300"/>
+</vector>

--- a/compose/src/commonMain/composeResources/drawable/stairs_up.xml
+++ b/compose/src/commonMain/composeResources/drawable/stairs_up.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="72"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:pathData="M120,840h140v-100h140v-100h140v-100h140"/>
+  <path
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="72"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:pathData="M160,480L560,200"/>
+  <path
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="72"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:pathData="M380,200H560V380"/>
+</vector>

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/components/CompassButtons.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/components/CompassButtons.kt
@@ -28,6 +28,8 @@ import org.jetbrains.compose.resources.painterResource
 import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.generated.resources.arrow_right_alt
 import warlockfe.warlock3.compose.generated.resources.logout
+import warlockfe.warlock3.compose.generated.resources.stairs_down
+import warlockfe.warlock3.compose.generated.resources.stairs_up
 import warlockfe.warlock3.core.compass.Direction
 
 /** Colors for [CompassButtons]: a "lit" available direction versus a dim unavailable one. */
@@ -119,10 +121,11 @@ fun CompassButtons(
                 colors = colors,
                 onClick = { onClick(Direction("up")) },
             ) { contentColor ->
-                DirectionArrow(
-                    rotationDegrees = 270f,
-                    size = arrowIconSize,
-                    color = contentColor,
+                // Up reads as an arrow climbing a staircase (left to right), not a plain arrow.
+                Image(
+                    modifier = Modifier.size(arrowIconSize),
+                    painter = painterResource(Res.drawable.stairs_up),
+                    colorFilter = ColorFilter.tint(contentColor),
                     contentDescription = "up",
                 )
             }
@@ -132,10 +135,11 @@ fun CompassButtons(
                 colors = colors,
                 onClick = { onClick(Direction("down")) },
             ) { contentColor ->
-                DirectionArrow(
-                    rotationDegrees = 90f,
-                    size = arrowIconSize,
-                    color = contentColor,
+                // Down reads as an arrow descending a staircase (left to right), not a plain arrow.
+                Image(
+                    modifier = Modifier.size(arrowIconSize),
+                    painter = painterResource(Res.drawable.stairs_down),
+                    colorFilter = ColorFilter.tint(contentColor),
                     contentDescription = "down",
                 )
             }

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/MovementSheet.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/MovementSheet.kt
@@ -30,8 +30,6 @@ import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.generated.resources.east
-import warlockfe.warlock3.compose.generated.resources.keyboard_double_arrow_down
-import warlockfe.warlock3.compose.generated.resources.keyboard_double_arrow_up
 import warlockfe.warlock3.compose.generated.resources.logout
 import warlockfe.warlock3.compose.generated.resources.north
 import warlockfe.warlock3.compose.generated.resources.north_east
@@ -39,6 +37,8 @@ import warlockfe.warlock3.compose.generated.resources.north_west
 import warlockfe.warlock3.compose.generated.resources.south
 import warlockfe.warlock3.compose.generated.resources.south_east
 import warlockfe.warlock3.compose.generated.resources.south_west
+import warlockfe.warlock3.compose.generated.resources.stairs_down
+import warlockfe.warlock3.compose.generated.resources.stairs_up
 import warlockfe.warlock3.compose.generated.resources.west
 import warlockfe.warlock3.core.compass.Direction
 
@@ -104,13 +104,13 @@ private fun DirectionGrid(
         ) {
             DirectionPill(
                 label = "up",
-                icon = Res.drawable.keyboard_double_arrow_up,
+                icon = Res.drawable.stairs_up,
                 lit = available.contains("up"),
                 onClick = { onMove("up") },
             )
             DirectionPill(
                 label = "down",
-                icon = Res.drawable.keyboard_double_arrow_down,
+                icon = Res.drawable.stairs_down,
                 lit = available.contains("down"),
                 onClick = { onMove("down") },
             )


### PR DESCRIPTION
## What

The compass **up** and **down** directions reused the east-pointing `arrow_right_alt` rotated 270°/90°, which read as plain vertical arrows. This replaces them with dedicated staircase icons:

- **up** — an arrow climbing a staircase (left to right)
- **down** — an arrow descending a staircase (left to right)

matching the game-screen design.

## Icons

| up | down |
|----|------|
| ascending stairs + up-right arrow | descending stairs + down-right arrow |

Two new vector drawables under `compose/src/commonMain/composeResources/drawable/`:

- `stairs_up.xml`
- `stairs_down.xml`

These are the design's stroked (Lucide/Feather-style) paths, copied verbatim and scaled from the source 24-grid onto the project's 960 grid (×40 → clean integers; stroke `1.8`→`72`). They're stroked rather than filled; every call site tints via a SrcIn color filter (`ColorFilter.tint` / `Icon(tint = …)`), so the strokes recolor to the cell's content color exactly like the existing filled icons.

## Wiring

- **Desktop compass** — `CompassButtons.kt`: the up/down cells now render `stairs_up`/`stairs_down` instead of the rotated arrow. The eight cardinal/diagonal directions are unchanged.
- **Mobile movement sheet** — `MovementSheet.kt`: the up/down pills now use `stairs_up`/`stairs_down` instead of the `keyboard_double_arrow_*` chevrons. Those chevron drawables remain (still used by `ActionsView` list reordering).

## Verification

- `:compose:compileKotlinJvm` and `:compose:compileAndroidMain` build (resource accessors regenerated; `mobileMain` covered by the Android compilation).
- `:compose:ktlintCheck` clean.
- Rendered preview of the two icons confirms the geometry matches the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)