### PR TITLE
Fix SGE/reconnect bugs and add reconnect progress UI

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/MudMobileConnectUseCase.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/MudMobileConnectUseCase.kt
@@ -9,14 +9,17 @@ import warlockfe.warlock3.compose.model.GameScreen
 import warlockfe.warlock3.compose.model.GameState
 import warlockfe.warlock3.compose.ui.game.GameViewModelFactory
 import warlockfe.warlock3.compose.ui.window.WindowRegistryFactory
+import warlockfe.warlock3.core.client.WarlockClient
 import warlockfe.warlock3.core.client.WarlockClientFactory
 import warlockfe.warlock3.core.mudmobile.CreateSessionResult
 import warlockfe.warlock3.core.mudmobile.MudMobileApi
+import warlockfe.warlock3.core.mudmobile.SessionConnectInfo
 import warlockfe.warlock3.core.mudmobile.SessionStatusResult
 import warlockfe.warlock3.core.sge.AutoConnectResult
 import warlockfe.warlock3.core.sge.ConnectionProxySettings
 import warlockfe.warlock3.core.sge.SgeClientFactory
 import warlockfe.warlock3.core.sge.SgeSettings
+import warlockfe.warlock3.core.sge.SimuGameCredentials
 import warlockfe.warlock3.core.sge.StoredConnection
 import warlockfe.warlock3.core.util.sha256Hex
 import warlockfe.warlock3.wrayth.network.NetworkSocket
@@ -130,10 +133,32 @@ class MudMobileConnectUseCase(
             is ReadinessResult.Failed -> return MudMobileConnectResult.Failure(readiness.reason)
         }
 
-        // 4. Connect to the router and play. One attempt, generous timeout, no reconnect loop —
-        // the router holds the connection through the cloud machine's cold boot (~25-60s).
+        // 4. Connect to the router and play. The hosted session is already routable here, so this is
+        // one attempt with a generous timeout (the router holds the connection through the cloud
+        // machine's cold boot, ~25-60s).
         onStatus("Connecting to the game...")
-        return withContext(ioDispatcher) {
+        return connectToRouter(connect, credentials, gameState)
+    }
+
+    /**
+     * Open the game socket to the router and hand off to a [GameScreen.ConnectedGameState]. Used for
+     * both the initial connect and reconnects.
+     *
+     * A reconnect re-dials this same router endpoint with the same game key - no SGE login and no new
+     * session. The hosted session persists across a client disconnect, and the router still bridges
+     * any connection whose sha256(key) matches what [invoke] registered, so re-dialing simply
+     * re-attaches to the live session.
+     */
+    private suspend fun connectToRouter(
+        connect: SessionConnectInfo,
+        credentials: SimuGameCredentials,
+        gameState: GameState,
+    ): MudMobileConnectResult =
+        withContext(ioDispatcher) {
+            // Tracks the client until it's handed off to the GameViewModel. If we're cancelled (the
+            // user returned to the dashboard mid-reconnect) or fail before that handoff, the finally
+            // closes it so we don't leak the socket and the hosted session it holds open.
+            var createdClient: WarlockClient? = null
             try {
                 val streamRegistry = windowRegistryFactory.create()
                 val socket = NetworkSocket(ioDispatcher, secure = connect.tls)
@@ -143,16 +168,16 @@ class MudMobileConnectUseCase(
                         windowRegistry = streamRegistry,
                         socket = socket,
                     )
+                createdClient = client
                 // Same handshake bytes Warlock sends to play.net; the router matches sha256(key).
                 client.connect(credentials.key)
                 val gameViewModel =
                     gameViewModelFactory.create(
                         client = client,
                         windowRegistry = streamRegistry,
-                        // A "reconnect" is just registering the session again with a fresh key.
+                        // Reconnect re-dials the same router with the same key; no SGE, no new session.
                         reconnect = {
-                            val result =
-                                invoke(token, sgeSettings, connection, password, gameState)
+                            val result = connectToRouter(connect, credentials, gameState)
                             if (result is MudMobileConnectResult.Failure) {
                                 gameState.setScreen(
                                     GameScreen.ErrorState(result.message, returnTo = GameScreen.Dashboard),
@@ -161,14 +186,17 @@ class MudMobileConnectUseCase(
                         },
                     )
                 gameState.setScreen(GameScreen.ConnectedGameState(gameViewModel))
+                // Ownership has passed to the GameViewModel; don't tear it down in finally.
+                createdClient = null
                 MudMobileConnectResult.Success
             } catch (e: Exception) {
                 ensureActive()
                 logger.e(e) { "Failed to connect to MUD Mobile router" }
                 MudMobileConnectResult.Failure("Error connecting to ${connect.host}:${connect.port}: ${e.message}")
+            } finally {
+                createdClient?.close()
             }
         }
-    }
 
     /**
      * Polls `GET /api/sessions/{id}`, surfacing each status update via [onStatus]. Returns as soon

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -24,6 +24,8 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -354,6 +356,14 @@ class GameViewModel(
     val disconnected = client.disconnected
 
     val canReconnect: Boolean = reconnectAction != null
+
+    // True while a reconnect is in flight, so the UI can show a progress dialog/indicator. A reconnect
+    // re-dials the existing host/port/key (no SGE login), but the connection can still take a moment -
+    // for a hosted session the router may hold the dial through a cold boot - so the user needs feedback.
+    private val _reconnecting = MutableStateFlow(false)
+    val reconnecting: StateFlow<Boolean> = _reconnecting.asStateFlow()
+
+    private var reconnectJob: Job? = null
 
     val menuData = client.menuData
 
@@ -1116,6 +1126,18 @@ class GameViewModel(
     }
 
     suspend fun close() {
+        // If a reconnect is still in flight (e.g. the user returned to the dashboard while it was
+        // running), cancel it first so the in-progress attempt is unwound: cancellation runs the
+        // connect use case's finally blocks, which close any half-opened client/socket so nothing leaks.
+        reconnectJob?.let { job ->
+            reconnectJob = null
+            job.cancelAndJoin()
+        }
+        closeClient()
+    }
+
+    /** Tear down this game's client and window registry without touching any reconnect in flight. */
+    private suspend fun closeClient() {
         if (!client.disconnected.value) {
             client.sendCommandDirect("quit")
         }
@@ -1126,14 +1148,23 @@ class GameViewModel(
     /**
      * Reconnect using the same credentials. This spins up a fresh client, window registry, and
      * GameViewModel (replacing this screen), so all prior game state is cleared. The old client and
-     * window registry are then released. No-op if reconnecting isn't supported for this session.
+     * window registry are then released. No-op if reconnecting isn't supported for this session, or
+     * if a reconnect is already running.
      */
     fun reconnect() {
         val action = reconnectAction ?: return
-        viewModelScope.launch {
-            action()
-            close()
-        }
+        if (_reconnecting.value) return
+        _reconnecting.value = true
+        reconnectJob =
+            viewModelScope.launch {
+                try {
+                    action()
+                    // The reconnect installed a fresh game screen; release this (old) client.
+                    closeClient()
+                } finally {
+                    _reconnecting.value = false
+                }
+            }
     }
 
     fun getCurrentTime(): Instant = client.getCurrentTime()

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/sge/SgeViewModel.kt
@@ -56,6 +56,10 @@ class SgeViewModel(
     private var characterName: String? = null
     private var gameCode: String? = null
 
+    // Set once the game screen is opening, after which the SGE client is shut down and its events
+    // (e.g. the connection-closed error from tearing down the SGE socket) must not navigate anymore.
+    private var gameLaunched = false
+
     // The saved accounts shown on the first step of the wizard, so the user can pick one (logging in
     // with its saved password) instead of re-typing it. Re-queried live so a delete in settings shows.
     val accounts: Flow<List<AccountEntity>> = accountRepository.observeAll()
@@ -71,6 +75,9 @@ class SgeViewModel(
                 navigate(SgeViewState.SgeAccountSelector)
                 client.eventFlow.collect { event ->
                     logger.d { "Got event: $event" }
+                    // Once the game is launching the SGE client is being torn down; ignore any of its
+                    // remaining events so a late error can't navigate us off the game screen.
+                    if (gameLaunched) return@collect
                     when (event) {
                         SgeEvent.SgeLoginSucceededEvent -> {
                             client.requestGameList()
@@ -125,7 +132,16 @@ class SgeViewModel(
                                 }
                             }
 
+                            // The SGE login is finished and the game is about to open. Shut the SGE
+                            // client down first: closing the connection makes its read loop emit a
+                            // late error event, and this collector is still active, so that event
+                            // would otherwise navigate us off the game screen to an error notice.
+                            // close() cancels the read loop feeding eventFlow, and gameLaunched stops
+                            // this collector from acting on anything already in flight.
+                            gameLaunched = true
+                            client.close()
                             connectToGame(credentials)
+                            return@collect
                         }
                     }
                 }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopReconnectingDialog.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopReconnectingDialog.kt
@@ -1,0 +1,70 @@
+package warlockfe.warlock3.compose.desktop.ui.game
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.ui.component.HorizontalProgressBar
+import org.jetbrains.jewel.ui.component.Text
+import warlockfe.warlock3.compose.desktop.shim.WarlockDialog
+import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
+
+/**
+ * Modal progress dialog shown while a game reconnect is in flight. The reconnect re-runs the full
+ * connect (for hosted sessions: a fresh SGE login plus a wait for the cloud session to come up),
+ * which can take many seconds, so without this the user just sees a frozen, still-disconnected game.
+ *
+ * The only action is "Go to dashboard", which leaves the game screen; that path closes the game
+ * client and cancels the reconnect (tearing down the SGE client it opened) via GameViewModel.close.
+ */
+@Composable
+fun DesktopReconnectingDialog(
+    onGoToDashboard: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // No close (X) action: the reconnect is running; the deliberate way out is "Go to dashboard".
+    WarlockDialog(
+        title = "Reconnecting",
+        onCloseRequest = {},
+        width = 420.dp,
+        height = 180.dp,
+    ) {
+        Column(
+            modifier = modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text("Reconnecting to the game...")
+            // Jewel ships only a determinate progress bar, so loop it 0 -> 100% to convey activity.
+            val transition = rememberInfiniteTransition()
+            val progress by transition.animateFloat(
+                initialValue = 0f,
+                targetValue = 1f,
+                animationSpec =
+                    infiniteRepeatable(
+                        animation = tween(durationMillis = 1200, easing = LinearEasing),
+                        repeatMode = RepeatMode.Restart,
+                    ),
+            )
+            HorizontalProgressBar(
+                progress = progress,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.weight(1f))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                WarlockOutlinedButton(onClick = onGoToDashboard, text = "Go to dashboard")
+            }
+        }
+    }
+}

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -160,6 +161,29 @@ fun GameView(
                     }
                 },
                 text = { Text(macroError!!) },
+            )
+        }
+        val reconnecting by viewModel.reconnecting.collectAsState()
+        if (reconnecting) {
+            AlertDialog(
+                // Not dismissible: a reconnect is in flight; the only out is going to the dashboard,
+                // which tears the connection down (see navigateToDashboard -> GameViewModel.close).
+                onDismissRequest = {},
+                title = { Text("Reconnecting") },
+                text = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        CircularProgressIndicator()
+                        Text("Reconnecting to the game...")
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = navigateToDashboard) {
+                        Text("Go to dashboard")
+                    }
+                },
             )
         }
     }

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
@@ -18,6 +18,7 @@ import warlockfe.warlock3.compose.AppContainer
 import warlockfe.warlock3.compose.desktop.shim.WarlockAlertDialog
 import warlockfe.warlock3.compose.desktop.shim.WarlockButton
 import warlockfe.warlock3.compose.desktop.ui.DesktopMainScreen
+import warlockfe.warlock3.compose.desktop.ui.game.DesktopReconnectingDialog
 import warlockfe.warlock3.compose.model.GameScreen
 import warlockfe.warlock3.compose.model.GameState
 import warlockfe.warlock3.compose.util.createPlatformDialogSettings
@@ -78,6 +79,19 @@ fun DecoratedWindowScope.WarlockApp(
     val gameViewModel = (gameState.screen as? GameScreen.ConnectedGameState)?.viewModel
     val disconnectedFlow = remember(gameViewModel) { gameViewModel?.disconnected ?: MutableStateFlow(false) }
     val disconnected by disconnectedFlow.collectAsState()
+    val reconnectingFlow = remember(gameViewModel) { gameViewModel?.reconnecting ?: MutableStateFlow(false) }
+    val reconnecting by reconnectingFlow.collectAsState()
+    // Leaving the game for the dashboard: close the game client and cancel any in-flight reconnect
+    // (which also closes the SGE client it opened). Shared by the title bar and the reconnect dialog.
+    val goToDashboard: () -> Unit = {
+        val screen = gameState.screen
+        if (screen is GameScreen.ConnectedGameState) {
+            scope.launch {
+                screen.viewModel.close()
+                gameState.setScreen(GameScreen.Dashboard)
+            }
+        }
+    }
     TitleBarView(
         title = title,
         sideBarVisible = sideBarVisible,
@@ -86,15 +100,7 @@ fun DecoratedWindowScope.WarlockApp(
         disconnected = disconnected,
         canReconnect = gameViewModel?.canReconnect == true,
         reconnect = { (gameState.screen as? GameScreen.ConnectedGameState)?.viewModel?.reconnect() },
-        goToDashboard = {
-            val screen = gameState.screen
-            if (screen is GameScreen.ConnectedGameState) {
-                scope.launch {
-                    screen.viewModel.close()
-                    gameState.setScreen(GameScreen.Dashboard)
-                }
-            }
-        },
+        goToDashboard = goToDashboard,
         openNewWindow = openNewWindow,
         showSettingsDialog = { showSettings = true },
         disconnect = {
@@ -202,6 +208,9 @@ fun DecoratedWindowScope.WarlockApp(
     }
     if (showAboutDialog) {
         AboutDialog(warlockVersion) { showAboutDialog = false }
+    }
+    if (reconnecting) {
+        DesktopReconnectingDialog(onGoToDashboard = goToDashboard)
     }
 
     DesktopMainScreen(

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/SgeClientImpl.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/SgeClientImpl.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -353,46 +355,55 @@ class SgeClientImpl(
             logger.e { "Unable to connect to server" }
             return AutoConnectResult.Failure("Could not connect to SGE")
         }
-        login(username = connection.username, password = password)
 
+        // Drive the login as one continuous collection rather than re-subscribing per step. eventFlow
+        // has no replay or buffer, so a response that arrived in the gap between two eventFlow.first()
+        // subscriptions was dropped, and the next step then waited out the whole timeout. A single
+        // uninterrupted collector always has a subscriber present (the read loop's emits rendezvous
+        // with it instead of being dropped), and sending the login from onSubscription guarantees we
+        // are subscribed before the first response can come back. Each step returns null to keep
+        // collecting; the first non-null result completes the flow.
         return withTimeoutOrNull(30.seconds) {
-            while (true) {
-                when (val event = eventFlow.first()) {
-                    is SgeEvent.SgeLoginSucceededEvent -> {
-                        selectGame(connection.code)
-                    }
+            eventFlow
+                .onSubscription {
+                    login(username = connection.username, password = password)
+                }.mapNotNull { event ->
+                    when (event) {
+                        is SgeEvent.SgeLoginSucceededEvent -> {
+                            selectGame(connection.code)
+                            null
+                        }
 
-                    is SgeEvent.SgeGameSelectedEvent -> {
-                        requestCharacterList()
-                    }
+                        is SgeEvent.SgeGameSelectedEvent -> {
+                            requestCharacterList()
+                            null
+                        }
 
-                    is SgeEvent.SgeCharactersReadyEvent -> {
-                        val characters = event.characters
-                        val sgeCharacter = characters.firstOrNull { it.name.equals(connection.character, true) }
-                        if (sgeCharacter == null) {
-                            return@withTimeoutOrNull AutoConnectResult.Failure(
-                                "Could not find character: ${connection.character}",
-                            )
-                        } else {
-                            selectCharacter(sgeCharacter.code)
+                        is SgeEvent.SgeCharactersReadyEvent -> {
+                            val sgeCharacter =
+                                event.characters.firstOrNull { it.name.equals(connection.character, true) }
+                            if (sgeCharacter == null) {
+                                AutoConnectResult.Failure("Could not find character: ${connection.character}")
+                            } else {
+                                selectCharacter(sgeCharacter.code)
+                                null
+                            }
+                        }
+
+                        is SgeEvent.SgeReadyToPlayEvent -> {
+                            AutoConnectResult.Success(event.credentials)
+                        }
+
+                        is SgeEvent.SgeErrorEvent -> {
+                            AutoConnectResult.Failure("Error code (${event.errorCode})")
+                        }
+
+                        else -> {
+                            logger.i { "Unrecognized event: $event" }
+                            null
                         }
                     }
-
-                    is SgeEvent.SgeReadyToPlayEvent -> {
-                        return@withTimeoutOrNull AutoConnectResult.Success(event.credentials)
-                    }
-
-                    is SgeEvent.SgeErrorEvent -> {
-                        return@withTimeoutOrNull AutoConnectResult.Failure("Error code (${event.errorCode})")
-                    }
-
-                    else -> {
-                        logger.i { "Unrecognized event: $event" }
-                    }
-                }
-            }
-            @Suppress("UNREACHABLE_CODE")
-            null
+                }.first()
         } ?: AutoConnectResult.Failure("Timed out waiting for SGE response")
     }
 }


### PR DESCRIPTION
## Background

After a successful MUD Mobile connect, hitting **Reconnect** appeared to do nothing and, a few seconds later, the app navigated to an "SGE connection timed out" error screen. Investigation turned up several related issues in the SGE/reconnect path; this PR fixes them and adds proper reconnect feedback.

## Changes (one per commit)

**Shut down the SGE client when the game opens** (`SgeViewModel`)
The wizard kept the SGE client and its `eventFlow` collector alive after the game opened. Tearing down the SGE socket emits a late error event, which the still-active collector could turn into a navigation off the game screen. Now the SGE client is closed and the collector stopped the moment the game launches.

**Fix event-loss race in SGE auto-connect** (`SgeClientImpl`)
`autoConnect` re-subscribed per step via `eventFlow.first()`. The flow has no replay/buffer, so a response arriving in the gap between two subscriptions was dropped and the step hung until the 30s timeout ("Timed out waiting for SGE response"). Replaced with one continuous collection: `login()` is sent from `onSubscription` (subscriber present before the first response), each event maps to the next command, and the first result completes the flow. A single uninterrupted subscriber means emits rendezvous instead of being dropped.

**Reconnect MUD Mobile without SGE** (`MudMobileConnectUseCase`)
Reconnect re-ran the whole flow (fresh SGE login + new session), which is what was timing out. Extracted `connectToRouter` so reconnect re-dials the **existing router endpoint with the existing key** — no SGE, no new session. Per the spec the hosted session persists across a client disconnect and the router bridges any connection whose `sha256(key)` matches what the initial connect registered, so re-dialing re-attaches to the live session. A half-opened client is closed in a `finally` if the attempt is cancelled or fails before handoff.

**Show reconnect progress and clean up on abort to the dashboard** (`GameViewModel`, mobile `GameView`, desktop `DesktopReconnectingDialog` + `WarlockApp`)
Reconnect ran with no UI. Added a `reconnecting` flow surfaced as a progress dialog on desktop and an M3 progress indicator on mobile, each with a **Go to dashboard** action. `close()` now cancels an in-flight reconnect before tearing down the client, so leaving for the dashboard mid-reconnect unwinds the attempt (closing any half-opened client) and closes the game client.

## Note

The direct play.net and New Game wizard reconnect paths already reused their credentials and never ran SGE on reconnect, so they're unchanged.

## Testing

- `:compose:compileKotlinJvm`, `:compose:compileAndroidMain`, `:desktopApp:compileKotlin` all compile.
- `:wrayth:jvmTest` and `:compose:jvmTest` pass.
- ktlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)