### PR TITLE
Reduce multi-window stream lag + network benchmark harness

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -176,6 +176,37 @@ benchmark {
     }
 }
 
+// End-to-end multi-connection stream lag harness (StreamNetworkBenchmark.kt). Not a JMH benchmark:
+// it stands up a loopback replay server and drives real WraythClients through the full parse+render
+// pipeline, so it runs as a plain main() on the jvmBenchmark compilation's classpath. Knobs are passed
+// as -P properties; -PgcLog/-Pzgc mirror the desktop app's diagnostic flags.
+//   ./gradlew :compose:streamNetworkBenchmark -Pconnections=4 -Pwindows=6 -PlinesPerSec=4000 -PgcLog
+val streamBenchmarkCompilation = kotlin.jvm().compilations.getByName("benchmark")
+tasks.register<JavaExec>("streamNetworkBenchmark") {
+    group = "benchmark"
+    description = "Run the end-to-end multi-connection stream lag harness over a loopback socket."
+    dependsOn(streamBenchmarkCompilation.compileTaskProvider)
+    classpath(
+        streamBenchmarkCompilation.output.allOutputs,
+        streamBenchmarkCompilation.runtimeDependencyFiles,
+    )
+    mainClass.set("warlockfe.warlock3.compose.util.StreamNetworkBenchmarkKt")
+    for (knob in listOf("connections", "windows", "lines", "highlights", "linesPerSec", "log")) {
+        (project.findProperty(knob) as? String)?.let { systemProperty(knob, it) }
+    }
+    if (project.hasProperty("gcLog")) {
+        val gcLogPath =
+            layout.buildDirectory
+                .get()
+                .asFile
+                .resolve("gc-bench-%p.log")
+        jvmArgs("-Xlog:gc*,safepoint:file=$gcLogPath:time,uptime,level,tags:filecount=5,filesize=20M")
+    }
+    if (project.hasProperty("zgc")) {
+        jvmArgs("-XX:+UseZGC")
+    }
+}
+
 // The default skin is authored as a directory (skin.json + referenced images) under skin/ and
 // packaged into a zip at build time, instead of committing a binary zip. Reproducible so it doesn't
 // churn between builds. The zip readers on every platform (java.util.zip on JVM/Android, kompress on

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -191,7 +191,7 @@ tasks.register<JavaExec>("streamNetworkBenchmark") {
         streamBenchmarkCompilation.runtimeDependencyFiles,
     )
     mainClass.set("warlockfe.warlock3.compose.util.StreamNetworkBenchmarkKt")
-    for (knob in listOf("connections", "windows", "lines", "highlights", "linesPerSec", "log")) {
+    for (knob in listOf("connections", "windows", "lines", "highlights", "linesPerSec", "scripts", "uiCostMicros", "log")) {
         (project.findProperty(knob) as? String)?.let { systemProperty(knob, it) }
     }
     if (project.hasProperty("gcLog")) {

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -57,7 +57,8 @@ class ComposeTextStream(
     private val soundPlayer: SoundPlayer,
     private val workQueue: StreamWorkQueue,
     private val scope: CoroutineScope,
-) : TextStream {
+) : TextStream,
+    StreamWorkQueue.Flushable {
     // ArrayDeque so trimming the oldest line (removeAt(0)) once the buffer fills is O(1) rather than
     // the O(n) front shift of an ArrayList.
     private val cacheLines = ArrayDeque<CachedLine?>(maxLines)
@@ -79,6 +80,10 @@ class ComposeTextStream(
     private var nextSerialNumber = 0L
     private var removedLines = 0L
 
+    // Set when the displayed lines changed but the new snapshot has not been emitted yet; the work
+    // queue coalesces this into a single publish per drain batch (see publishLines/flush).
+    private var pendingPublish = false
+
     private var applyStyling: Boolean = true
 
     // When true, only lines that match a name in the names list are shown
@@ -95,7 +100,7 @@ class ComposeTextStream(
         names
             .onEach {
                 if (nameFilter) {
-                    workQueue.submit {
+                    workQueue.submit("namefilter") {
                         linesUpdated()
                     }
                 }
@@ -112,7 +117,7 @@ class ComposeTextStream(
             highlights.drop(1).map { },
             alterations.drop(1).map { },
         ).onEach {
-            workQueue.submit {
+            workQueue.submit("rerender") {
                 rerenderAllLines()
             }
         }.launchIn(scope)
@@ -122,13 +127,13 @@ class ComposeTextStream(
         text: StyledString,
         isPrompt: Boolean,
     ) {
-        workQueue.submit {
+        workQueue.submit("partial") {
             doAppendPartial(text, isPrompt)
         }
     }
 
     override suspend fun appendPartialAndEol(text: StyledString) {
-        workQueue.submit {
+        workQueue.submit("partial") {
             doAppendPartial(text, isPrompt = false)
             partialLine = null
         }
@@ -160,7 +165,7 @@ class ComposeTextStream(
     }
 
     override suspend fun clear() {
-        workQueue.submit {
+        workQueue.submit("clear") {
             finishedLines.clear()
             partialLine = null
             componentLocations.clear()
@@ -177,7 +182,7 @@ class ComposeTextStream(
         ignoreWhenBlank: Boolean,
         showWhenClosed: String?,
     ) {
-        workQueue.submit {
+        workQueue.submit("append") {
             // It's possible a component is added that is set prior
             // I don't think this happens in DR, so it's probably OK that we don't handle that case.
             partialLine = null
@@ -240,7 +245,7 @@ class ComposeTextStream(
     }
 
     override suspend fun appendResource(url: String) {
-        workQueue.submit {
+        workQueue.submit("resource") {
             // Images must be on their own line
             partialLine = null
             if (!showImages) return@submit
@@ -260,20 +265,31 @@ class ComposeTextStream(
         name: String,
         value: StyledString,
     ) {
-        workQueue.submit {
-            components[name] = value
-            // A component can appear on many lines; re-render them all, then publish once instead
-            // of emitting a fresh snapshot per affected line.
-            var change = ViewChange.NONE
-            componentLocations[name]?.forEach { serialNumber ->
-                val lineNumber = (serialNumber - removedLines).toInt()
-                // If the component has scrolled back past the buffer, ignore it
-                if (lineNumber >= 0) {
-                    change = change.coalesce(updateLine(lineNumber))
-                }
-            }
-            applyViewChange(change)
+        workQueue.submit("component") {
+            updateComponentSync(name, value)
         }
+    }
+
+    // The body of a component update, runnable directly on the work-queue consumer. WindowRegistry
+    // batches one server component update into a single queue op that calls this on every stream,
+    // instead of each stream enqueuing its own op (which multiplied queue traffic by the open-window
+    // count for every component change). Must only be called from the work queue.
+    fun updateComponentSync(
+        name: String,
+        value: StyledString,
+    ) {
+        components[name] = value
+        // A component can appear on many lines; re-render them all, then publish once instead
+        // of emitting a fresh snapshot per affected line.
+        var change = ViewChange.NONE
+        componentLocations[name]?.forEach { serialNumber ->
+            val lineNumber = (serialNumber - removedLines).toInt()
+            // If the component has scrolled back past the buffer, ignore it
+            if (lineNumber >= 0) {
+                change = change.coalesce(updateLine(lineNumber))
+            }
+        }
+        applyViewChange(change)
     }
 
     // Re-render every buffered line from its cached source against the current presets, highlights,
@@ -415,6 +431,16 @@ class ComposeTextStream(
     }
 
     private fun publishLines() {
+        // Coalesce: mark the displayed lines dirty and let the work queue publish once the current
+        // drain batch finishes, instead of emitting a fresh snapshot (and waking the UI) per op.
+        pendingPublish = true
+        workQueue.scheduleFlush(this)
+    }
+
+    // Emit the latest displayed lines. Run by the work queue after a drain batch, on the consumer.
+    override fun flush() {
+        if (!pendingPublish) return
+        pendingPublish = false
         lines.value = OffsetList(displayBacking, displayStart)
     }
 
@@ -473,7 +499,7 @@ class ComposeTextStream(
     }
 
     suspend fun setMaxLines(maxLines: Int) {
-        workQueue.submit {
+        workQueue.submit("maxlines") {
             this@ComposeTextStream.maxLines = maxLines
             removeLines()
             linesUpdated()
@@ -497,7 +523,7 @@ class ComposeTextStream(
     // Re-run the filter and rebuild the displayed list on the work queue. Callable from any thread.
     private fun scheduleRelayout() {
         scope.launch {
-            workQueue.submit {
+            workQueue.submit("relayout") {
                 linesUpdated()
             }
         }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/StreamProfiling.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/StreamProfiling.kt
@@ -1,0 +1,26 @@
+package warlockfe.warlock3.compose.ui.window
+
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Lightweight instrumentation for diagnosing multi-window / multi-connection lag. Disabled by
+ * default; flip [enabled] to true to turn it on.
+ *
+ * When enabled, [StreamWorkQueue] records, per connection, how long each op waited in the queue
+ * before running (queue backlog), how long it took to run (render cost), the peak queue depth, and a
+ * per-op-type breakdown. A summary line is logged every [reportInterval], and any op that waited
+ * longer than [stallThreshold] is logged immediately with a wall-clock timestamp (so a stall can be
+ * lined up against a GC/safepoint pause in the JVM log). All of this is under the "StreamWorkQueue"
+ * log tag.
+ */
+object StreamProfiling {
+    var enabled: Boolean = false
+
+    val reportInterval = 5.seconds
+
+    // An op whose queue-wait exceeds this is logged immediately with a wall-clock timestamp, so the
+    // stall can be lined up against a GC/safepoint pause in the JVM log. ~15ms is roughly one dropped
+    // frame, well above normal sub-millisecond waits.
+    val stallThreshold = 15.milliseconds
+}

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/StreamWorkQueue.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/StreamWorkQueue.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.decrementAndFetch
@@ -29,8 +30,10 @@ class StreamWorkQueue(
 ) {
     private val logger = Logger.withTag("StreamWorkQueue")
 
-    // Identifies which connection/character this queue belongs to in profiling output. Set once the
-    // character id is known; only read from the consumer coroutine for logging, so a plain var is fine.
+    // Identifies which connection/character this queue belongs to in profiling output. Written from
+    // the registry's setCharacterId on a different coroutine than the consumer that reads it, so it is
+    // @Volatile for safe publication; it only labels diagnostic output.
+    @Volatile
     var tag: String = "?"
 
     // Something with coalesced output to publish once a drain batch finishes (a ComposeTextStream).
@@ -38,19 +41,15 @@ class StreamWorkQueue(
         fun flush()
     }
 
-    private class Job(
-        val label: String,
-        val op: suspend () -> Unit,
-        val submittedAt: TimeSource.Monotonic.ValueTimeMark,
-    )
-
     private val channel =
-        Channel<Job>(
+        Channel<suspend () -> Unit>(
             capacity = capacity,
             onBufferOverflow = BufferOverflow.SUSPEND,
         )
 
-    // Submitted-but-not-yet-started ops. Written by producers (submit) and the consumer, so atomic.
+    // Submitted-but-not-yet-started op count, maintained only while profiling is enabled (it feeds the
+    // queue-depth metric). It is an upper bound during backpressure: a producer increments before its
+    // channel.send() may suspend, so a blocked producer is counted before its op is actually enqueued.
     private val pending = AtomicInt(0)
 
     // Streams that produced output during the current drain batch and barriers waiting for it to be
@@ -62,46 +61,40 @@ class StreamWorkQueue(
     private val stats = ProfileStats()
 
     init {
-        scope.launch(Dispatchers.Default) {
-            for (firstJob in channel) {
-                runJob(firstJob)
-                // Greedily run whatever else is already queued without publishing between ops, so a
-                // burst's many line updates collapse into a single published snapshot per stream.
-                var sinceFlush = 1
-                while (true) {
-                    val next = channel.tryReceive().getOrNull() ?: break
-                    runJob(next)
-                    if (++sinceFlush >= MAX_OPS_BETWEEN_FLUSHES) {
-                        flushAll()
-                        sinceFlush = 0
+        val consumer =
+            scope.launch(Dispatchers.Default) {
+                for (firstOp in channel) {
+                    runOp(firstOp)
+                    // Greedily run whatever else is already queued without publishing between ops, so a
+                    // burst's many line updates collapse into a single published snapshot per stream.
+                    var sinceFlush = 1
+                    while (true) {
+                        val next = channel.tryReceive().getOrNull() ?: break
+                        runOp(next)
+                        if (++sinceFlush >= MAX_OPS_BETWEEN_FLUSHES) {
+                            flushAll()
+                            sinceFlush = 0
+                        }
                     }
+                    // Channel drained: publish the coalesced output, then release anyone awaiting it.
+                    flushAll()
+                    completeBarriers()
                 }
-                // Channel drained: publish the coalesced output, then release anyone awaiting it.
-                flushAll()
-                completeBarriers()
+            }
+        // If the consumer stops (its scope is cancelled) while barriers are still pending, fail their
+        // awaiters instead of leaving awaitFlushed() suspended forever.
+        consumer.invokeOnCompletion { cause ->
+            while (pendingBarriers.isNotEmpty()) {
+                pendingBarriers.removeFirst().completeExceptionally(
+                    cause ?: CancellationException("StreamWorkQueue stopped"),
+                )
             }
         }
     }
 
-    private suspend fun runJob(job: Job) {
-        val depth = pending.decrementAndFetch()
+    private suspend fun runOp(op: suspend () -> Unit) {
         try {
-            if (StreamProfiling.enabled) {
-                val waited = job.submittedAt.elapsedNow()
-                if (waited >= StreamProfiling.stallThreshold) {
-                    // The stall happened in roughly [now - waited, now]; match that window
-                    // against a GC/safepoint pause in the JVM log.
-                    logger.w {
-                        "[$tag] STALL: '${job.label}' waited $waited (queueDepth=$depth) ending ${Clock.System.now()}"
-                    }
-                }
-                val execMark = TimeSource.Monotonic.markNow()
-                job.op()
-                stats.record(label = job.label, waited = waited, exec = execMark.elapsedNow(), depth = depth)
-                stats.maybeReport(logger, tag)
-            } else {
-                job.op()
-            }
+            op()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
@@ -137,8 +130,30 @@ class StreamWorkQueue(
         label: String = "?",
         op: suspend () -> Unit,
     ) {
+        // Default path (profiling disabled): enqueue the op directly. No clock read, no atomic, and no
+        // wrapper allocation, so the work queue adds nothing measurable to the per-op hot path.
+        if (!StreamProfiling.enabled) {
+            channel.send(op)
+            return
+        }
+        // Profiling enabled: wrap the op so the consumer records its queue-wait, exec time, and depth.
+        val submittedAt = TimeSource.Monotonic.markNow()
         pending.incrementAndFetch()
-        channel.send(Job(label = label, op = op, submittedAt = TimeSource.Monotonic.markNow()))
+        channel.send {
+            val depth = pending.decrementAndFetch()
+            val waited = submittedAt.elapsedNow()
+            if (waited >= StreamProfiling.stallThreshold) {
+                // The stall happened in roughly [now - waited, now]; match that window against a
+                // GC/safepoint pause in the JVM log.
+                logger.w {
+                    "[$tag] STALL: '$label' waited $waited (queueDepth=$depth) ending ${Clock.System.now()}"
+                }
+            }
+            val execMark = TimeSource.Monotonic.markNow()
+            op()
+            stats.record(label = label, waited = waited, exec = execMark.elapsedNow(), depth = depth)
+            stats.maybeReport(logger, tag)
+        }
     }
 
     // Suspend until everything submitted so far has run and its coalesced output has been published.

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/StreamWorkQueue.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/StreamWorkQueue.kt
@@ -2,39 +2,211 @@ package warlockfe.warlock3.compose.ui.window
 
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.TimeSource
 
+// During a sustained burst the channel never drains, so cap how many ops run between coalesced
+// flushes to bound how stale the displayed lines can get. At a few tens of microseconds per op this
+// is well under one frame, while still collapsing a deep burst's hundreds of publishes into a few.
+private const val MAX_OPS_BETWEEN_FLUSHES = 256
+
+@OptIn(ExperimentalAtomicApi::class, ExperimentalTime::class)
 class StreamWorkQueue(
     scope: CoroutineScope,
     capacity: Int = 1000,
 ) {
     private val logger = Logger.withTag("StreamWorkQueue")
 
+    // Identifies which connection/character this queue belongs to in profiling output. Set once the
+    // character id is known; only read from the consumer coroutine for logging, so a plain var is fine.
+    var tag: String = "?"
+
+    // Something with coalesced output to publish once a drain batch finishes (a ComposeTextStream).
+    fun interface Flushable {
+        fun flush()
+    }
+
+    private class Job(
+        val label: String,
+        val op: suspend () -> Unit,
+        val submittedAt: TimeSource.Monotonic.ValueTimeMark,
+    )
+
     private val channel =
-        Channel<suspend () -> Unit>(
+        Channel<Job>(
             capacity = capacity,
             onBufferOverflow = BufferOverflow.SUSPEND,
         )
 
+    // Submitted-but-not-yet-started ops. Written by producers (submit) and the consumer, so atomic.
+    private val pending = AtomicInt(0)
+
+    // Streams that produced output during the current drain batch and barriers waiting for it to be
+    // published. Both are only touched from the single consumer coroutine, so need no synchronization.
+    private val pendingFlushes = LinkedHashSet<Flushable>()
+    private val pendingBarriers = ArrayDeque<CompletableDeferred<Unit>>()
+
+    // Only touched by the single consumer coroutine below, so no synchronization is needed.
+    private val stats = ProfileStats()
+
     init {
         scope.launch(Dispatchers.Default) {
-            for (op in channel) {
-                try {
-                    op()
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Throwable) {
-                    logger.e(e) { "Stream op threw" }
+            for (firstJob in channel) {
+                runJob(firstJob)
+                // Greedily run whatever else is already queued without publishing between ops, so a
+                // burst's many line updates collapse into a single published snapshot per stream.
+                var sinceFlush = 1
+                while (true) {
+                    val next = channel.tryReceive().getOrNull() ?: break
+                    runJob(next)
+                    if (++sinceFlush >= MAX_OPS_BETWEEN_FLUSHES) {
+                        flushAll()
+                        sinceFlush = 0
+                    }
                 }
+                // Channel drained: publish the coalesced output, then release anyone awaiting it.
+                flushAll()
+                completeBarriers()
             }
         }
     }
 
-    suspend fun submit(op: suspend () -> Unit) {
-        channel.send(op)
+    private suspend fun runJob(job: Job) {
+        val depth = pending.decrementAndFetch()
+        try {
+            if (StreamProfiling.enabled) {
+                val waited = job.submittedAt.elapsedNow()
+                if (waited >= StreamProfiling.stallThreshold) {
+                    // The stall happened in roughly [now - waited, now]; match that window
+                    // against a GC/safepoint pause in the JVM log.
+                    logger.w {
+                        "[$tag] STALL: '${job.label}' waited $waited (queueDepth=$depth) ending ${Clock.System.now()}"
+                    }
+                }
+                val execMark = TimeSource.Monotonic.markNow()
+                job.op()
+                stats.record(label = job.label, waited = waited, exec = execMark.elapsedNow(), depth = depth)
+                stats.maybeReport(logger, tag)
+            } else {
+                job.op()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            logger.e(e) { "Stream op threw" }
+        }
+    }
+
+    // Request that [flushable] publish its coalesced output once the current drain batch finishes.
+    // Called from within an op, i.e. on the consumer coroutine.
+    fun scheduleFlush(flushable: Flushable) {
+        pendingFlushes.add(flushable)
+    }
+
+    private fun flushAll() {
+        if (pendingFlushes.isEmpty()) return
+        for (flushable in pendingFlushes) {
+            try {
+                flushable.flush()
+            } catch (e: Throwable) {
+                logger.e(e) { "Stream flush threw" }
+            }
+        }
+        pendingFlushes.clear()
+    }
+
+    private fun completeBarriers() {
+        while (pendingBarriers.isNotEmpty()) {
+            pendingBarriers.removeFirst().complete(Unit)
+        }
+    }
+
+    suspend fun submit(
+        label: String = "?",
+        op: suspend () -> Unit,
+    ) {
+        pending.incrementAndFetch()
+        channel.send(Job(label = label, op = op, submittedAt = TimeSource.Monotonic.markNow()))
+    }
+
+    // Suspend until everything submitted so far has run and its coalesced output has been published.
+    // The barrier op registers a completion that the consumer fires only after the post-drain flush,
+    // so on return the displayed [lines] reflect all prior submits. Intended for tests.
+    suspend fun awaitFlushed() {
+        val done = CompletableDeferred<Unit>()
+        submit("await-flush") { pendingBarriers.add(done) }
+        done.await()
+    }
+}
+
+// Accumulates work-queue timings and periodically logs a summary. Single-consumer-thread only.
+private class ProfileStats {
+    private var windowStart = TimeSource.Monotonic.markNow()
+    private var count = 0
+    private var sumWait = Duration.ZERO
+    private var maxWait = Duration.ZERO
+    private var sumExec = Duration.ZERO
+    private var maxExec = Duration.ZERO
+    private var maxDepth = 0
+    private val countByLabel = HashMap<String, Int>()
+    private val execByLabel = HashMap<String, Duration>()
+
+    fun record(
+        label: String,
+        waited: Duration,
+        exec: Duration,
+        depth: Int,
+    ) {
+        count++
+        sumWait += waited
+        if (waited > maxWait) maxWait = waited
+        sumExec += exec
+        if (exec > maxExec) maxExec = exec
+        if (depth > maxDepth) maxDepth = depth
+        countByLabel[label] = (countByLabel[label] ?: 0) + 1
+        execByLabel[label] = (execByLabel[label] ?: Duration.ZERO) + exec
+    }
+
+    fun maybeReport(
+        logger: Logger,
+        tag: String,
+    ) {
+        val elapsed = windowStart.elapsedNow()
+        if (elapsed < StreamProfiling.reportInterval) return
+        if (count > 0) {
+            val breakdown =
+                execByLabel.entries
+                    .sortedByDescending { it.value }
+                    .joinToString(", ") { (label, total) -> "$label x${countByLabel[label]}=$total" }
+            logger.i {
+                "[$tag] $count ops in $elapsed | queue-wait avg=${sumWait / count} max=$maxWait" +
+                    " | exec avg=${sumExec / count} max=$maxExec | peakDepth=$maxDepth | $breakdown"
+            }
+        }
+        reset()
+    }
+
+    private fun reset() {
+        windowStart = TimeSource.Monotonic.markNow()
+        count = 0
+        sumWait = Duration.ZERO
+        maxWait = Duration.ZERO
+        sumExec = Duration.ZERO
+        maxExec = Duration.ZERO
+        maxDepth = 0
+        countByLabel.clear()
+        execByLabel.clear()
     }
 }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowRegistryImpl.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowRegistryImpl.kt
@@ -23,6 +23,7 @@ import warlockfe.warlock3.core.prefs.repositories.HighlightRepository
 import warlockfe.warlock3.core.prefs.repositories.NameRepository
 import warlockfe.warlock3.core.prefs.repositories.PresetRepository
 import warlockfe.warlock3.core.text.StyleDefinition
+import warlockfe.warlock3.core.text.StyledString
 import warlockfe.warlock3.core.util.SoundPlayer
 import warlockfe.warlock3.core.window.DialogState
 import warlockfe.warlock3.core.window.TextStream
@@ -231,6 +232,19 @@ class WindowRegistryImpl(
 
     override fun getStreams(): Collection<TextStream> = streams.load().values
 
+    // A server component update affects every window that displays that component. Batch it into one
+    // work-queue op that touches each stream, instead of each stream enqueuing its own op: with many
+    // windows open the per-stream broadcast multiplied queue traffic by the window count for every
+    // component change. Streams that don't display the component fall through cheaply.
+    override suspend fun updateComponent(
+        name: String,
+        value: StyledString,
+    ) {
+        workQueue.submit("component") {
+            streams.load().values.forEach { it.updateComponentSync(name, value) }
+        }
+    }
+
     override fun getOrCreateDialog(name: String): DialogState {
         dialogs.load()[name]?.let { return it }
         val candidate = ComposeDialogState(id = name)
@@ -245,6 +259,7 @@ class WindowRegistryImpl(
 
     override fun setCharacterId(characterId: String) {
         this.characterId.value = characterId
+        workQueue.tag = characterId
     }
 
     override fun close() {

--- a/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
+++ b/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
@@ -431,7 +431,11 @@ private fun syntheticLines(
                 }
 
                 1 -> {
-                    "<pushBold/>You attack the <a exist=\"$i\" noun=\"orc\">orc</a> and <preset id=\"speech\">$name staggers back</preset>!"
+                    // Bold is opened and closed on the same line, as the real protocol does: an
+                    // unbalanced push would pile up on WraythClient's style stack and be re-applied to
+                    // every later line (a quadratic blowup that is a malformed-input artifact).
+                    "<pushBold/>You attack the <a exist=\"$i\" noun=\"orc\">orc</a> and " +
+                        "<preset id=\"speech\">$name staggers back</preset>!<popBold/>"
                 }
 
                 2 -> {
@@ -451,6 +455,9 @@ private fun syntheticLines(
                 }
             },
         )
+        // A prompt every few lines, as the server sends after each push. Besides being realistic, a
+        // prompt clears the style stack, so transient styling can't leak across the whole session.
+        if (i % 8 == 7) out.add("<prompt>&gt;</prompt>")
     }
     return out
 }

--- a/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
+++ b/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
@@ -1,14 +1,19 @@
 package warlockfe.warlock3.compose.util
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.SystemFileSystem
 import warlockfe.warlock3.compose.model.LiteralHighlight
@@ -17,6 +22,7 @@ import warlockfe.warlock3.compose.ui.window.ComposeDialogState
 import warlockfe.warlock3.compose.ui.window.ComposeTextStream
 import warlockfe.warlock3.compose.ui.window.StreamProfiling
 import warlockfe.warlock3.compose.ui.window.StreamWorkQueue
+import warlockfe.warlock3.core.client.ClientTextEvent
 import warlockfe.warlock3.core.prefs.config.ClientConfigStore
 import warlockfe.warlock3.core.prefs.dao.ClientSettingDao
 import warlockfe.warlock3.core.prefs.models.ClientSettingEntity
@@ -64,6 +70,9 @@ import kotlin.time.TimeSource
  *   lines        synthetic protocol lines streamed per connection                (40000)
  *   highlights   size of the shared highlight index (the real profile is ~975)   (975)
  *   linesPerSec  server send pacing per connection; 0/absent = max-speed firehose (0)
+ *   scripts      script-style eventFlow subscribers per conn (regex per text line) (0)
+ *   uiCostMicros per-text-event CPU cost on a shared single UI thread, modelling   (0)
+ *                a busy Main thread the GameViewModel collector contends for
  *   log          replay this real capture instead of synthetic lines (per conn)  (none)
  *
  * [StreamProfiling] is enabled, so its per-connection queue summaries (queue-wait, exec, peak depth,
@@ -77,6 +86,8 @@ private data class BenchConfig(
     val lines: Int,
     val highlights: Int,
     val linesPerSec: Int,
+    val scripts: Int,
+    val uiCostMicros: Long,
     val logPath: String?,
 )
 
@@ -93,6 +104,8 @@ fun main() {
             lines = intProp("lines", 40_000),
             highlights = intProp("highlights", 975),
             linesPerSec = intProp("linesPerSec", 0),
+            scripts = intProp("scripts", 0),
+            uiCostMicros = System.getProperty("uiCostMicros")?.trim()?.toLongOrNull() ?: 0L,
             logPath = System.getProperty("log")?.takeIf { it.isNotBlank() },
         )
     StreamProfiling.enabled = true
@@ -123,6 +136,15 @@ private suspend fun runBenchmark(config: BenchConfig) {
     val loggingRepository = LoggingRepository(clientSettings, appScope)
     val characterRepository = CharacterRepository(clientConfigStore)
 
+    // A single shared thread modelling the desktop UI thread: every connection's GameViewModel-style
+    // eventFlow collector runs here, so the parse loops contend for it exactly as they do for the real
+    // Main thread. uiCostMicros makes that collector burn CPU per text event (modelling recomposition).
+    // Measured finding: even a deliberately slow shared UI collector does NOT throttle the parsers, so
+    // the zero-buffer eventFlow is not the per-line rendezvous bottleneck it looks like on paper; emit
+    // does not gate the parse loop on its subscribers.
+    val uiExecutor = Executors.newSingleThreadExecutor { Thread(it, "bench-ui").apply { isDaemon = true } }
+    val uiDispatcher = uiExecutor.asCoroutineDispatcher()
+
     // Loopback replay server: one accepted socket per connection, each streaming a private copy of the
     // line list (after consuming the client's two-line handshake), optionally paced.
     val server = ReplayServer(linesPerSec = config.linesPerSec)
@@ -133,7 +155,7 @@ private suspend fun runBenchmark(config: BenchConfig) {
             "highlights=${config.highlights} " +
             (if (realLog != null) "log=${config.logPath} (${realLog.size} lines)" else "lines=${config.lines} (synthetic)") +
             " pacing=" + (if (config.linesPerSec > 0) "${config.linesPerSec}/s" else "firehose") +
-            " port=${server.port}",
+            " scripts=${config.scripts} uiCostMicros=${config.uiCostMicros} port=${server.port}",
     )
 
     val started = TimeSource.Monotonic.markNow()
@@ -153,6 +175,9 @@ private suspend fun runBenchmark(config: BenchConfig) {
                         presets = presets,
                         characterRepository = characterRepository,
                         loggingRepository = loggingRepository,
+                        scripts = config.scripts,
+                        uiDispatcher = uiDispatcher,
+                        uiCostMicros = config.uiCostMicros,
                     )
                 }
             }.awaitAll()
@@ -160,10 +185,11 @@ private suspend fun runBenchmark(config: BenchConfig) {
     val elapsed = started.elapsedNow()
     server.stop()
     appScope.cancel()
+    uiExecutor.shutdownNow()
 
     println("----- stream-network-benchmark results -----")
     results.sortedBy { it.index }.forEach { r ->
-        println("conn ${r.index} [${r.tag}]: ${r.lines} lines, finished in ${r.elapsed}")
+        println("conn ${r.index} [${r.tag}]: ${r.lines} lines, ${r.textEvents} text events to subscribers, finished in ${r.elapsed}")
     }
     val seconds = elapsed.inWholeMicroseconds / 1_000_000.0
     val rate = if (seconds > 0) (totalLines / seconds).toLong() else 0
@@ -177,6 +203,7 @@ private data class ConnectionResult(
     val index: Int,
     val tag: String,
     val lines: Int,
+    val textEvents: Long,
     val elapsed: kotlin.time.Duration,
 )
 
@@ -187,6 +214,9 @@ private suspend fun runConnection(
     presets: StateFlow<Map<String, StyleDefinition>>,
     characterRepository: CharacterRepository,
     loggingRepository: LoggingRepository,
+    scripts: Int,
+    uiDispatcher: CoroutineDispatcher,
+    uiCostMicros: Long,
 ): ConnectionResult {
     val ioDispatcher = Dispatchers.IO
     val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
@@ -209,6 +239,46 @@ private suspend fun runConnection(
             socket = socket,
         )
 
+    // Representative eventFlow subscribers, the per-line cost the parse loop rendezvous-blocks on that
+    // the bare harness omitted. One always-on GameViewModel-style collector that ignores text, plus
+    // `scripts` script-style collectors that run a trigger set against every ClientTextEvent
+    // synchronously inside the collector, as WslContext does. onSubscription gates the connect so all
+    // are registered before the first event, otherwise the rendezvous cost wouldn't apply from line 1.
+    val textEvents =
+        java.util.concurrent.atomic
+            .AtomicLong()
+    val subscribed = mutableListOf<CompletableDeferred<Unit>>()
+    val gameViewReady = CompletableDeferred<Unit>()
+    subscribed.add(gameViewReady)
+    scope.launch(uiDispatcher) {
+        client.eventFlow.onSubscription { gameViewReady.complete(Unit) }.collect { event ->
+            // GameViewModel ignores text events, but receiving each one still occupies the shared UI
+            // thread; uiCostMicros models the time that thread is otherwise busy (recomposition).
+            if (event is ClientTextEvent) {
+                textEvents.incrementAndGet()
+                // Busy-spin, not parkNanos/sleep: this thread is a coroutine dispatcher thread, where
+                // park is unreliable (the dispatcher holds permits), and recomposition is CPU-bound
+                // work anyway, so a spin is the faithful model of the UI thread being busy.
+                if (uiCostMicros > 0) {
+                    val deadline = System.nanoTime() + uiCostMicros * 1_000
+                    while (System.nanoTime() < deadline) { /* busy */ }
+                }
+            }
+        }
+    }
+    repeat(scripts) {
+        val ready = CompletableDeferred<Unit>()
+        subscribed.add(ready)
+        scope.launch {
+            client.eventFlow.onSubscription { ready.complete(Unit) }.collect { event ->
+                if (event is ClientTextEvent) {
+                    for (trigger in SCRIPT_TRIGGERS) trigger.containsMatchIn(event.text)
+                }
+            }
+        }
+    }
+    subscribed.forEach { it.await() }
+
     val started = TimeSource.Monotonic.markNow()
     client.connect("benchmark-key-$index")
 
@@ -222,7 +292,7 @@ private suspend fun runConnection(
     val lineCount = registry.getStreams().sumOf { (it as ComposeTextStream).lines.value.size }
     val tag = "dr:bench$index"
     registry.close()
-    return ConnectionResult(index = index, tag = tag, lines = lineCount, elapsed = elapsed)
+    return ConnectionResult(index = index, tag = tag, lines = lineCount, textEvents = textEvents.get(), elapsed = elapsed)
 }
 
 /**
@@ -386,6 +456,33 @@ private class ReplayServer(
         val CRLF = byteArrayOf('\r'.code.toByte(), '\n'.code.toByte())
     }
 }
+
+// A representative script trigger set: the patterns a running script matches against every line of
+// game text. Modeled on common hunting/utility scripts (combat outcomes, room cues, social text).
+// Each script-style eventFlow subscriber runs all of these against every ClientTextEvent.
+private val SCRIPT_TRIGGERS: List<Regex> =
+    listOf(
+        "You attack",
+        "staggers",
+        "Obvious exits",
+        "Also here",
+        "You see",
+        "Roundtime",
+        "swings? at you",
+        "falls to the ground",
+        "is dead",
+        "You hit",
+        "misses? you",
+        "You feel fully",
+        "loses? its footing",
+        "stands? back up",
+        "begins? to",
+        "glances? at you",
+        "nods?",
+        "smiles?",
+        "whispers?",
+        "shouts?",
+    ).map { Regex(it, RegexOption.IGNORE_CASE) }
 
 // A pool of Capitalized proper names so the case-sensitive name-highlight match path does real work
 // per line (lowercasing a Capitalized needle is the per-line cost the highlight index has to handle).

--- a/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
+++ b/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
@@ -114,7 +115,10 @@ fun main() {
 
 private suspend fun runBenchmark(config: BenchConfig) {
     // Lines a single connection streams: a real capture (replayed to every connection) or synthetic.
-    val realLog: List<String>? = config.logPath?.let { File(it).readLines() }
+    // Read latin-1 (byte-preserving) so the exact on-disk bytes reach NetworkSocket, which decodes
+    // them as Windows-1252 like the live game connection; the default UTF-8 read would mangle any
+    // 0x80-0xFF byte before it ever hit the real decoder.
+    val realLog: List<String>? = config.logPath?.let { File(it).readLines(Charsets.ISO_8859_1) }
 
     // One shared highlight index, sized to the real-world profile, the way the app shares one index
     // across a character's windows. Built once here rather than per line on the render path.
@@ -166,7 +170,7 @@ private suspend fun runBenchmark(config: BenchConfig) {
             .map { index ->
                 val lines = realLog ?: syntheticLines(config.lines, config.windows, index)
                 totalLines += lines.size
-                server.enqueue(lines)
+                server.enqueue(index, lines)
                 appScope.async {
                     runConnection(
                         index = index,
@@ -189,7 +193,10 @@ private suspend fun runBenchmark(config: BenchConfig) {
 
     println("----- stream-network-benchmark results -----")
     results.sortedBy { it.index }.forEach { r ->
-        println("conn ${r.index} [${r.tag}]: ${r.lines} lines, ${r.textEvents} text events to subscribers, finished in ${r.elapsed}")
+        println(
+            "conn ${r.index} [${r.tag}]: ${r.lines} lines, ${r.textEvents} text events, " +
+                "${r.recompositions} recompositions, finished in ${r.elapsed}",
+        )
     }
     val seconds = elapsed.inWholeMicroseconds / 1_000_000.0
     val rate = if (seconds > 0) (totalLines / seconds).toLong() else 0
@@ -204,6 +211,7 @@ private data class ConnectionResult(
     val tag: String,
     val lines: Int,
     val textEvents: Long,
+    val recompositions: Long,
     val elapsed: kotlin.time.Duration,
 )
 
@@ -227,6 +235,8 @@ private suspend fun runConnection(
             workQueue = workQueue,
             highlights = highlightIndex,
             presets = presets,
+            uiDispatcher = uiDispatcher,
+            uiCostMicros = uiCostMicros,
         )
     val socket = NetworkSocket(ioDispatcher)
     socket.connect("127.0.0.1", port)
@@ -239,11 +249,13 @@ private suspend fun runConnection(
             socket = socket,
         )
 
-    // Representative eventFlow subscribers, the per-line cost the parse loop rendezvous-blocks on that
-    // the bare harness omitted. One always-on GameViewModel-style collector that ignores text, plus
-    // `scripts` script-style collectors that run a trigger set against every ClientTextEvent
-    // synchronously inside the collector, as WslContext does. onSubscription gates the connect so all
-    // are registered before the first event, otherwise the rendezvous cost wouldn't apply from line 1.
+    // Representative eventFlow subscribers. The always-on GameViewModel-style collector runs on the
+    // shared UI thread and (like the real one) does no work for text events, but still has to RECEIVE
+    // each one there; that handoff is what couples the parse loop to the UI thread's availability. The
+    // UI thread's actual busyness is modelled on the publish/recomposition path (see BenchWindow
+    // Registry), so when recomposition is heavy this collector is starved and the parser stalls. The
+    // `scripts` collectors run a trigger set against every ClientTextEvent, as WslContext does.
+    // onSubscription gates connect so all are registered before the first event.
     val textEvents =
         java.util.concurrent.atomic
             .AtomicLong()
@@ -252,18 +264,7 @@ private suspend fun runConnection(
     subscribed.add(gameViewReady)
     scope.launch(uiDispatcher) {
         client.eventFlow.onSubscription { gameViewReady.complete(Unit) }.collect { event ->
-            // GameViewModel ignores text events, but receiving each one still occupies the shared UI
-            // thread; uiCostMicros models the time that thread is otherwise busy (recomposition).
-            if (event is ClientTextEvent) {
-                textEvents.incrementAndGet()
-                // Busy-spin, not parkNanos/sleep: this thread is a coroutine dispatcher thread, where
-                // park is unreliable (the dispatcher holds permits), and recomposition is CPU-bound
-                // work anyway, so a spin is the faithful model of the UI thread being busy.
-                if (uiCostMicros > 0) {
-                    val deadline = System.nanoTime() + uiCostMicros * 1_000
-                    while (System.nanoTime() < deadline) { /* busy */ }
-                }
-            }
+            if (event is ClientTextEvent) textEvents.incrementAndGet()
         }
     }
     repeat(scripts) {
@@ -291,8 +292,16 @@ private suspend fun runConnection(
 
     val lineCount = registry.getStreams().sumOf { (it as ComposeTextStream).lines.value.size }
     val tag = "dr:bench$index"
+    val recompositions = registry.recompositionCount()
     registry.close()
-    return ConnectionResult(index = index, tag = tag, lines = lineCount, textEvents = textEvents.get(), elapsed = elapsed)
+    return ConnectionResult(
+        index = index,
+        tag = tag,
+        lines = lineCount,
+        textEvents = textEvents.get(),
+        recompositions = recompositions,
+        elapsed = elapsed,
+    )
 }
 
 /**
@@ -306,29 +315,53 @@ private class BenchWindowRegistry(
     private val workQueue: StreamWorkQueue,
     private val highlights: StateFlow<HighlightIndex>,
     override val presets: StateFlow<Map<String, StyleDefinition>>,
+    private val uiDispatcher: CoroutineDispatcher,
+    private val uiCostMicros: Long,
 ) : WindowRegistry {
     private val names = MutableStateFlow<List<ViewHighlight>>(emptyList())
     private val alterations = MutableStateFlow<List<warlockfe.warlock3.wrayth.util.CompiledAlteration>>(emptyList())
     private val streams = ConcurrentHashMap<String, ComposeTextStream>()
     private val dialogs = ConcurrentHashMap<String, ComposeDialogState>()
+    private val recompositions =
+        java.util.concurrent.atomic
+            .AtomicLong()
 
+    // Observed lines-snapshot changes across all windows = recompositions the shared UI thread did.
+    // It is a conflated count (a StateFlow collector only sees the latest value), so it already reflects
+    // the UI coalescing that StateFlow/Compose do on top of the work queue's per-batch publish coalescing.
+    fun recompositionCount(): Long = recompositions.get()
+
+    // computeIfAbsent (not Kotlin's getOrPut) so the builder runs at most once per name even under
+    // concurrent calls; a duplicate ComposeTextStream would leak the flow collectors its init launches.
     override fun getOrCreateStream(name: String): TextStream =
-        streams.getOrPut(name) {
-            ComposeTextStream(
-                id = name,
-                maxLines = ClientSettingRepository.DEFAULT_MAX_SCROLL_LINES,
-                markLinks = false,
-                showImages = true,
-                showTimestamps = false,
-                suppressPrompts = false,
-                highlights = highlights,
-                names = names,
-                alterations = alterations,
-                presets = presets,
-                soundPlayer = SilentSoundPlayer,
-                workQueue = workQueue,
-                scope = scope,
-            )
+        streams.computeIfAbsent(name) {
+            val stream =
+                ComposeTextStream(
+                    id = name,
+                    maxLines = ClientSettingRepository.DEFAULT_MAX_SCROLL_LINES,
+                    markLinks = false,
+                    showImages = true,
+                    showTimestamps = false,
+                    suppressPrompts = false,
+                    highlights = highlights,
+                    names = names,
+                    alterations = alterations,
+                    presets = presets,
+                    soundPlayer = SilentSoundPlayer,
+                    workQueue = workQueue,
+                    scope = scope,
+                )
+            // Model the window's UI: each observed lines snapshot is one recomposition on the single
+            // shared UI thread, costing uiCostMicros. All windows of all connections share that thread,
+            // so this is where UI-thread load (and the parser stalls it induces via the eventFlow
+            // rendezvous) actually comes from.
+            scope.launch(uiDispatcher) {
+                stream.lines.drop(1).collect {
+                    recompositions.incrementAndGet()
+                    if (uiCostMicros > 0) busySpinMicros(uiCostMicros)
+                }
+            }
+            stream
         }
 
     override fun getStreams(): Collection<TextStream> = streams.values
@@ -342,7 +375,7 @@ private class BenchWindowRegistry(
         }
     }
 
-    override fun getOrCreateDialog(name: String): DialogState = dialogs.getOrPut(name) { ComposeDialogState(name) }
+    override fun getOrCreateDialog(name: String): DialogState = dialogs.computeIfAbsent(name) { ComposeDialogState(name) }
 
     override fun setCharacterId(characterId: String) {
         workQueue.tag = characterId
@@ -390,15 +423,18 @@ private class ReplayServer(
     private val linesPerSec: Int,
 ) {
     private val serverSocket = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
-    private val pending = java.util.concurrent.LinkedBlockingQueue<List<String>>()
+    private val byIndex = ConcurrentHashMap<Int, List<String>>()
     private val workers = Executors.newCachedThreadPool { r -> Thread(r, "replay-worker").apply { isDaemon = true } }
     private val acceptThread = Thread({ acceptLoop() }, "replay-accept").apply { isDaemon = true }
     private val live = CopyOnWriteArrayList<java.net.Socket>()
 
     val port: Int get() = serverSocket.localPort
 
-    fun enqueue(lines: List<String>) {
-        pending.add(lines)
+    fun enqueue(
+        index: Int,
+        lines: List<String>,
+    ) {
+        byIndex[index] = lines
     }
 
     fun start() {
@@ -410,24 +446,24 @@ private class ReplayServer(
             while (!serverSocket.isClosed) {
                 val socket = serverSocket.accept()
                 live.add(socket)
-                val lines = pending.take()
-                workers.submit { serve(socket, lines) }
+                workers.submit { serve(socket) }
             }
         } catch (_: Exception) {
             // Socket closed during stop(); exit the loop.
         }
     }
 
-    private fun serve(
-        socket: java.net.Socket,
-        lines: List<String>,
-    ) {
+    private fun serve(socket: java.net.Socket) {
         try {
             socket.tcpNoDelay = true
             val reader = BufferedReader(InputStreamReader(socket.getInputStream(), Charsets.ISO_8859_1))
-            // Consume the client's handshake: the key line and the "/FE:WRAYTH ..." line.
+            // The client's first handshake line is its key, "benchmark-key-<index>". Pair the socket
+            // with that connection's line list by index, not by accept order (which is racy). The
+            // second line is the "/FE:WRAYTH ..." info.
+            val keyLine = reader.readLine()
             reader.readLine()
-            reader.readLine()
+            val index = keyLine?.substringAfterLast('-')?.toIntOrNull()
+            val lines = index?.let { byIndex[it] } ?: return
             val out = socket.getOutputStream()
             val delayNanos = if (linesPerSec > 0) 1_000_000_000L / linesPerSec else 0L
             for (line in lines) {
@@ -455,6 +491,14 @@ private class ReplayServer(
     private companion object {
         val CRLF = byteArrayOf('\r'.code.toByte(), '\n'.code.toByte())
     }
+}
+
+// Burn CPU for [micros] microseconds. Models the UI thread being busy with recomposition; a busy-spin
+// rather than park/sleep because these run on coroutine dispatcher threads (where park is unreliable)
+// and recomposition is CPU-bound work anyway.
+private fun busySpinMicros(micros: Long) {
+    val deadline = System.nanoTime() + micros * 1_000
+    while (System.nanoTime() < deadline) { /* busy */ }
 }
 
 // A representative script trigger set: the patterns a running script matches against every line of

--- a/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
+++ b/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
@@ -1,0 +1,456 @@
+package warlockfe.warlock3.compose.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.files.SystemFileSystem
+import warlockfe.warlock3.compose.model.LiteralHighlight
+import warlockfe.warlock3.compose.model.ViewHighlight
+import warlockfe.warlock3.compose.ui.window.ComposeDialogState
+import warlockfe.warlock3.compose.ui.window.ComposeTextStream
+import warlockfe.warlock3.compose.ui.window.StreamProfiling
+import warlockfe.warlock3.compose.ui.window.StreamWorkQueue
+import warlockfe.warlock3.core.prefs.config.ClientConfigStore
+import warlockfe.warlock3.core.prefs.dao.ClientSettingDao
+import warlockfe.warlock3.core.prefs.models.ClientSettingEntity
+import warlockfe.warlock3.core.prefs.repositories.CharacterRepository
+import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
+import warlockfe.warlock3.core.prefs.repositories.LoggingRepository
+import warlockfe.warlock3.core.text.StyleDefinition
+import warlockfe.warlock3.core.text.StyledString
+import warlockfe.warlock3.core.text.WarlockColor
+import warlockfe.warlock3.core.util.SoundPlayer
+import warlockfe.warlock3.core.util.WarlockDirs
+import warlockfe.warlock3.core.window.DialogState
+import warlockfe.warlock3.core.window.TextStream
+import warlockfe.warlock3.core.window.WindowRegistry
+import warlockfe.warlock3.wrayth.network.NetworkSocket
+import warlockfe.warlock3.wrayth.network.WraythClient
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStreamReader
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.locks.LockSupport
+import kotlin.time.TimeSource
+
+/**
+ * End-to-end benchmark for the multi-window / multi-connection lag the way a user actually hits it:
+ * over the network. A loopback TCP server replays game protocol into a real [NetworkSocket] -> real
+ * [WraythClient] (socket read + ANTLR protocol parse + event dispatch) -> a lean [WindowRegistry] of
+ * real [ComposeTextStream]s on a real [StreamWorkQueue], with a dialed-in highlight index. This
+ * exercises the whole pipeline the prior in-process line-feed benchmark skipped (which was
+ * producer-bound and never touched the socket or the parser).
+ *
+ * Run, with parity to the desktop app's diagnostic flags:
+ *
+ *   ./gradlew :compose:streamNetworkBenchmark \
+ *       -Pconnections=4 -Pwindows=6 -Plines=40000 -Phighlights=975 \
+ *       [-PlinesPerSec=4000] [-Plog=/path/to/capture.log] [-PgcLog] [-Pzgc]
+ *
+ * Knobs (all optional, with the defaults below):
+ *   connections  simultaneous game connections                                  (2)
+ *   windows      distinct stream windows each connection routes text across      (6)
+ *   lines        synthetic protocol lines streamed per connection                (40000)
+ *   highlights   size of the shared highlight index (the real profile is ~975)   (975)
+ *   linesPerSec  server send pacing per connection; 0/absent = max-speed firehose (0)
+ *   log          replay this real capture instead of synthetic lines (per conn)  (none)
+ *
+ * [StreamProfiling] is enabled, so its per-connection queue summaries (queue-wait, exec, peak depth,
+ * per-op breakdown) and immediate STALL lines print during the run; the harness prints the headline
+ * end-to-end timing at the end.
+ */
+
+private data class BenchConfig(
+    val connections: Int,
+    val windows: Int,
+    val lines: Int,
+    val highlights: Int,
+    val linesPerSec: Int,
+    val logPath: String?,
+)
+
+private fun intProp(
+    name: String,
+    default: Int,
+): Int = System.getProperty(name)?.trim()?.toIntOrNull() ?: default
+
+fun main() {
+    val config =
+        BenchConfig(
+            connections = intProp("connections", 2),
+            windows = intProp("windows", 6),
+            lines = intProp("lines", 40_000),
+            highlights = intProp("highlights", 975),
+            linesPerSec = intProp("linesPerSec", 0),
+            logPath = System.getProperty("log")?.takeIf { it.isNotBlank() },
+        )
+    StreamProfiling.enabled = true
+    runBlocking { runBenchmark(config) }
+}
+
+private suspend fun runBenchmark(config: BenchConfig) {
+    // Lines a single connection streams: a real capture (replayed to every connection) or synthetic.
+    val realLog: List<String>? = config.logPath?.let { File(it).readLines() }
+
+    // One shared highlight index, sized to the real-world profile, the way the app shares one index
+    // across a character's windows. Built once here rather than per line on the render path.
+    val highlightIndex = MutableStateFlow(HighlightIndex(buildHighlights(config.highlights)))
+    val presets = MutableStateFlow(emptyMap<String, StyleDefinition>())
+
+    // A minimal-but-real repository stack for WraythClient. Backed by a throwaway temp config dir and
+    // an in-memory settings DAO; logging is forced off (LogType.NONE) so the hot path never touches
+    // the filesystem. No SQLite, no DB.
+    val tempDir =
+        java.nio.file.Files
+            .createTempDirectory("warlock-bench")
+            .toString()
+    val clientConfigStore = ClientConfigStore(tempDir, SystemFileSystem)
+    clientConfigStore.mutateClient { it.copy(logType = "NONE") }
+    val warlockDirs = WarlockDirs(homeDir = tempDir, dataDir = tempDir, configDir = tempDir, logDir = tempDir)
+    val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val clientSettings = ClientSettingRepository(InMemoryClientSettingDao(), clientConfigStore, warlockDirs)
+    val loggingRepository = LoggingRepository(clientSettings, appScope)
+    val characterRepository = CharacterRepository(clientConfigStore)
+
+    // Loopback replay server: one accepted socket per connection, each streaming a private copy of the
+    // line list (after consuming the client's two-line handshake), optionally paced.
+    val server = ReplayServer(linesPerSec = config.linesPerSec)
+    server.start()
+
+    println(
+        "stream-network-benchmark: connections=${config.connections} windows=${config.windows} " +
+            "highlights=${config.highlights} " +
+            (if (realLog != null) "log=${config.logPath} (${realLog.size} lines)" else "lines=${config.lines} (synthetic)") +
+            " pacing=" + (if (config.linesPerSec > 0) "${config.linesPerSec}/s" else "firehose") +
+            " port=${server.port}",
+    )
+
+    val started = TimeSource.Monotonic.markNow()
+    var totalLines = 0L
+
+    val results =
+        (0 until config.connections)
+            .map { index ->
+                val lines = realLog ?: syntheticLines(config.lines, config.windows, index)
+                totalLines += lines.size
+                server.enqueue(lines)
+                appScope.async {
+                    runConnection(
+                        index = index,
+                        port = server.port,
+                        highlightIndex = highlightIndex,
+                        presets = presets,
+                        characterRepository = characterRepository,
+                        loggingRepository = loggingRepository,
+                    )
+                }
+            }.awaitAll()
+
+    val elapsed = started.elapsedNow()
+    server.stop()
+    appScope.cancel()
+
+    println("----- stream-network-benchmark results -----")
+    results.sortedBy { it.index }.forEach { r ->
+        println("conn ${r.index} [${r.tag}]: ${r.lines} lines, finished in ${r.elapsed}")
+    }
+    val seconds = elapsed.inWholeMicroseconds / 1_000_000.0
+    val rate = if (seconds > 0) (totalLines / seconds).toLong() else 0
+    println(
+        "TOTAL: $totalLines lines across ${config.connections} connections in $elapsed " +
+            "($rate lines/sec aggregate)",
+    )
+}
+
+private data class ConnectionResult(
+    val index: Int,
+    val tag: String,
+    val lines: Int,
+    val elapsed: kotlin.time.Duration,
+)
+
+private suspend fun runConnection(
+    index: Int,
+    port: Int,
+    highlightIndex: StateFlow<HighlightIndex>,
+    presets: StateFlow<Map<String, StyleDefinition>>,
+    characterRepository: CharacterRepository,
+    loggingRepository: LoggingRepository,
+): ConnectionResult {
+    val ioDispatcher = Dispatchers.IO
+    val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    val workQueue = StreamWorkQueue(scope)
+    val registry =
+        BenchWindowRegistry(
+            scope = scope,
+            workQueue = workQueue,
+            highlights = highlightIndex,
+            presets = presets,
+        )
+    val socket = NetworkSocket(ioDispatcher)
+    socket.connect("127.0.0.1", port)
+    val client =
+        WraythClient(
+            characterRepository = characterRepository,
+            windowRegistry = registry,
+            fileLogging = loggingRepository,
+            ioDispatcher = ioDispatcher,
+            socket = socket,
+        )
+
+    val started = TimeSource.Monotonic.markNow()
+    client.connect("benchmark-key-$index")
+
+    // The read loop ends (and flips disconnected) when the server closes the socket at end of stream.
+    client.disconnected.first { it }
+    // The socket is drained and parsed, but the produced stream ops may still be in flight; wait for
+    // the queue to publish them so the timing covers the full render pipeline, not just the parse.
+    workQueue.awaitFlushed()
+    val elapsed = started.elapsedNow()
+
+    val lineCount = registry.getStreams().sumOf { (it as ComposeTextStream).lines.value.size }
+    val tag = "dr:bench$index"
+    registry.close()
+    return ConnectionResult(index = index, tag = tag, lines = lineCount, elapsed = elapsed)
+}
+
+/**
+ * A lean [WindowRegistry] that builds real [ComposeTextStream]s sharing one [StreamWorkQueue], with
+ * constant highlight/name/alteration/preset flows supplied directly. Mirrors the production registry's
+ * batched [updateComponent] broadcast (one op touching every stream) so the multi-window component
+ * amplification is exercised, without the production registry's DB/file-backed repositories.
+ */
+private class BenchWindowRegistry(
+    private val scope: CoroutineScope,
+    private val workQueue: StreamWorkQueue,
+    private val highlights: StateFlow<HighlightIndex>,
+    override val presets: StateFlow<Map<String, StyleDefinition>>,
+) : WindowRegistry {
+    private val names = MutableStateFlow<List<ViewHighlight>>(emptyList())
+    private val alterations = MutableStateFlow<List<warlockfe.warlock3.wrayth.util.CompiledAlteration>>(emptyList())
+    private val streams = ConcurrentHashMap<String, ComposeTextStream>()
+    private val dialogs = ConcurrentHashMap<String, ComposeDialogState>()
+
+    override fun getOrCreateStream(name: String): TextStream =
+        streams.getOrPut(name) {
+            ComposeTextStream(
+                id = name,
+                maxLines = ClientSettingRepository.DEFAULT_MAX_SCROLL_LINES,
+                markLinks = false,
+                showImages = true,
+                showTimestamps = false,
+                suppressPrompts = false,
+                highlights = highlights,
+                names = names,
+                alterations = alterations,
+                presets = presets,
+                soundPlayer = SilentSoundPlayer,
+                workQueue = workQueue,
+                scope = scope,
+            )
+        }
+
+    override fun getStreams(): Collection<TextStream> = streams.values
+
+    override suspend fun updateComponent(
+        name: String,
+        value: StyledString,
+    ) {
+        workQueue.submit("component") {
+            streams.values.forEach { it.updateComponentSync(name, value) }
+        }
+    }
+
+    override fun getOrCreateDialog(name: String): DialogState = dialogs.getOrPut(name) { ComposeDialogState(name) }
+
+    override fun setCharacterId(characterId: String) {
+        workQueue.tag = characterId
+    }
+
+    override fun close() {
+        scope.cancel()
+    }
+}
+
+private object SilentSoundPlayer : SoundPlayer {
+    override suspend fun playSound(filename: String): String? = null
+}
+
+/** In-memory [ClientSettingDao] so the settings repository needs no SQLite. */
+private class InMemoryClientSettingDao : ClientSettingDao {
+    private val values = ConcurrentHashMap<String, String>()
+    private val flows = ConcurrentHashMap<String, MutableStateFlow<String?>>()
+
+    override suspend fun getAll(): List<ClientSettingEntity> = values.map { ClientSettingEntity(it.key, it.value) }
+
+    override suspend fun getByKey(key: String): String? = values[key]
+
+    override fun observeByKey(key: String): kotlinx.coroutines.flow.Flow<String?> = flows.getOrPut(key) { MutableStateFlow(values[key]) }
+
+    override suspend fun removeByKey(key: String) {
+        values.remove(key)
+        flows[key]?.value = null
+    }
+
+    override suspend fun save(entity: ClientSettingEntity) {
+        val value = entity.value
+        if (value == null) values.remove(entity.key) else values[entity.key] = value
+        flows.getOrPut(entity.key) { MutableStateFlow(value) }.value = value
+    }
+}
+
+/**
+ * Loopback TCP server that replays queued line lists. Accepts one socket per [enqueue]d list, reads
+ * the client's two handshake lines, then writes the lines (CRLF-terminated, optionally paced) and
+ * closes the socket to signal end of stream. Blocking sockets on daemon threads so they never hold
+ * the JVM open.
+ */
+private class ReplayServer(
+    private val linesPerSec: Int,
+) {
+    private val serverSocket = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+    private val pending = java.util.concurrent.LinkedBlockingQueue<List<String>>()
+    private val workers = Executors.newCachedThreadPool { r -> Thread(r, "replay-worker").apply { isDaemon = true } }
+    private val acceptThread = Thread({ acceptLoop() }, "replay-accept").apply { isDaemon = true }
+    private val live = CopyOnWriteArrayList<java.net.Socket>()
+
+    val port: Int get() = serverSocket.localPort
+
+    fun enqueue(lines: List<String>) {
+        pending.add(lines)
+    }
+
+    fun start() {
+        acceptThread.start()
+    }
+
+    private fun acceptLoop() {
+        try {
+            while (!serverSocket.isClosed) {
+                val socket = serverSocket.accept()
+                live.add(socket)
+                val lines = pending.take()
+                workers.submit { serve(socket, lines) }
+            }
+        } catch (_: Exception) {
+            // Socket closed during stop(); exit the loop.
+        }
+    }
+
+    private fun serve(
+        socket: java.net.Socket,
+        lines: List<String>,
+    ) {
+        try {
+            socket.tcpNoDelay = true
+            val reader = BufferedReader(InputStreamReader(socket.getInputStream(), Charsets.ISO_8859_1))
+            // Consume the client's handshake: the key line and the "/FE:WRAYTH ..." line.
+            reader.readLine()
+            reader.readLine()
+            val out = socket.getOutputStream()
+            val delayNanos = if (linesPerSec > 0) 1_000_000_000L / linesPerSec else 0L
+            for (line in lines) {
+                out.write(line.toByteArray(Charsets.ISO_8859_1))
+                out.write(CRLF)
+                if (delayNanos > 0) {
+                    out.flush()
+                    LockSupport.parkNanos(delayNanos)
+                }
+            }
+            out.flush()
+        } catch (_: Exception) {
+            // Connection torn down; nothing to do.
+        } finally {
+            runCatching { socket.close() }
+        }
+    }
+
+    fun stop() {
+        runCatching { serverSocket.close() }
+        live.forEach { runCatching { it.close() } }
+        workers.shutdownNow()
+    }
+
+    private companion object {
+        val CRLF = byteArrayOf('\r'.code.toByte(), '\n'.code.toByte())
+    }
+}
+
+// A pool of Capitalized proper names so the case-sensitive name-highlight match path does real work
+// per line (lowercasing a Capitalized needle is the per-line cost the highlight index has to handle).
+private val NAMES = listOf("Zarnok", "Vexil", "Quorth", "Kobold", "Goblin", "Troll", "Mordrin", "Sable", "Drake", "Quorth")
+
+// A realistic highlight profile: mostly literal, whole-word, case-sensitive Capitalized proper names.
+// The first few are names that actually appear in the streamed lines (so they match); the rest are
+// filler so the index is the size the real app carries (~975), making per-line matching do real work.
+private fun buildHighlights(count: Int): List<ViewHighlight> =
+    (0 until count).map { i ->
+        LiteralHighlight(
+            literal = if (i < NAMES.size) NAMES[i] else "Hlword$i",
+            matchPartialWord = false,
+            ignoreCase = false,
+            style = StyleDefinition(bold = true, textColor = WarlockColor(red = 255, green = 200, blue = 0)),
+            sound = null,
+        )
+    }
+
+/**
+ * Representative SGE protocol for one connection: an [app] line to set the character (which also sets
+ * the log name and routes highlights), then a mix of room/combat/text lines routed across [windows]
+ * stream windows and periodic component updates (which broadcast to every window). Each string is a
+ * complete protocol line. Content varies by index so highlight matching and parsing aren't hitting a
+ * single cached shape.
+ */
+private fun syntheticLines(
+    count: Int,
+    windows: Int,
+    connIndex: Int,
+): List<String> {
+    val out = ArrayList<String>(count + 1)
+    out.add("<app char=\"Bench$connIndex\" game=\"dr\"/>")
+    for (i in 0 until count) {
+        val w = i % windows
+        val name = NAMES[i % NAMES.size]
+        val name2 = NAMES[(i / NAMES.size) % NAMES.size]
+        out.add(
+            when (i % 6) {
+                0 -> {
+                    "<pushStream id=\"win$w\"/><style id=\"roomName\"/>[Chamber $i]<style id=\"\"/>" +
+                        " Obvious exits: north, east, down. Also here: $name, $name2.<popStream/>"
+                }
+
+                1 -> {
+                    "<pushBold/>You attack the <a exist=\"$i\" noun=\"orc\">orc</a> and <preset id=\"speech\">$name staggers back</preset>!"
+                }
+
+                2 -> {
+                    "<pushStream id=\"win$w\"/>You see a tall orc warrior standing guard by the gate, gripping a rusty halberd. ($i)<popStream/>"
+                }
+
+                3 -> {
+                    "<component id=\"room desc\">A wide cobbled plaza with a $name statue ($i).</component>"
+                }
+
+                4 -> {
+                    "<style id=\"roomName\"/>[Town Square $i]<style id=\"\"/> A $name merchant nods as you pass."
+                }
+
+                else -> {
+                    "<component id=\"room objs\">a leather backpack, a $name idol, and a rusty halberd ($i)</component>"
+                }
+            },
+        )
+    }
+    return out
+}

--- a/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
+++ b/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
@@ -1,5 +1,4 @@
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -76,11 +75,11 @@ class ComposeTextStreamTest {
                 scope = scope,
             )
 
-        // FIFO barrier: a no-op op queued after the prior direct submits; awaiting it means they ran.
+        // FIFO barrier: awaits a marker queued after the prior direct submits, and (since publishing
+        // is coalesced per drain batch) only returns once their output has been published, so reading
+        // stream.lines.value afterward sees the result.
         suspend fun drain() {
-            val done = CompletableDeferred<Unit>()
-            workQueue.submit { done.complete(Unit) }
-            done.await()
+            workQueue.awaitFlushed()
         }
 
         suspend fun awaitLines(predicate: (List<StreamLine>) -> Boolean): List<StreamLine> =

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/window/WindowRegistry.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/window/WindowRegistry.kt
@@ -2,6 +2,7 @@ package warlockfe.warlock3.core.window
 
 import kotlinx.coroutines.flow.StateFlow
 import warlockfe.warlock3.core.text.StyleDefinition
+import warlockfe.warlock3.core.text.StyledString
 
 interface WindowRegistry {
     val presets: StateFlow<Map<String, StyleDefinition>>
@@ -9,6 +10,13 @@ interface WindowRegistry {
     fun getOrCreateStream(name: String): TextStream
 
     fun getStreams(): Collection<TextStream>
+
+    // Apply a server component update (vitals, room objects, hands, etc.) to every window that
+    // displays it, as a single batched operation.
+    suspend fun updateComponent(
+        name: String,
+        value: StyledString,
+    )
 
     fun getOrCreateDialog(name: String): DialogState
 

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -88,6 +88,23 @@ nucleus.application {
 
     // SQLite calls a restricted method
     jvmArgs += "--enable-native-access=ALL-UNNAMED"
+    // Opt-in GC + safepoint logging for diagnosing stream-render stalls:
+    //   ./gradlew :desktopApp:run -PgcLog
+    // Writes per-pid logs (so multiple connections/processes don't collide) under the build dir with
+    // wall-clock timestamps, to correlate against StreamWorkQueue "STALL" lines. Diagnostic only.
+    if (project.hasProperty("gcLog")) {
+        val gcLogPath =
+            project.layout.buildDirectory
+                .get()
+                .asFile
+                .resolve("gc-%p.log")
+        jvmArgs += "-Xlog:gc*,safepoint:file=$gcLogPath:time,uptime,level,tags:filecount=5,filesize=20M"
+    }
+    // Confirmation experiment: ./gradlew :desktopApp:run -Pzgc swaps in the low-pause collector. If the
+    // lag/STALL lines vanish under ZGC, the stalls were GC pauses; if they persist, it is pool/scheduling.
+    if (project.hasProperty("zgc")) {
+        jvmArgs += "-XX:+UseZGC"
+    }
     // Only inject a version for real releases; leaving it unset in dev lets the app
     // detect dev mode (version == null) and enable debug logging.
     if (resolvedReleaseVersion != null) {

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -139,7 +139,11 @@ class WraythClient(
 
     private var gameCode: String? = null
 
-    private val _eventFlow = MutableSharedFlow<ClientEvent>()
+    // A buffer (vs the default rendezvous) so the parse loop can run ahead of a momentarily-busy
+    // subscriber (notably the UI-thread GameViewModel collector during a recomposition burst) instead
+    // of blocking on it per text event. No replay; SUSPEND overflow keeps every event (scripts rely on
+    // seeing them all) once the buffer fills.
+    private val _eventFlow = MutableSharedFlow<ClientEvent>(extraBufferCapacity = 256)
     override val eventFlow: SharedFlow<ClientEvent> = _eventFlow.asSharedFlow()
 
     private val _characterId = MutableStateFlow<String?>(null)

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -527,9 +527,7 @@ class WraythClient(
                             }
                     }
                     val newValue = elementBuffer ?: StyledString()
-                    windowRegistry.getStreams().forEach { stream ->
-                        stream.updateComponent(componentId!!, newValue)
-                    }
+                    windowRegistry.updateComponent(componentId!!, newValue)
                     elementBuffer = null
                     componentId = null
                 } else {


### PR DESCRIPTION
## Summary

Addresses a user report of significant lag when running multiple windows across simultaneous connections. Production fixes that cut per-burst work and decouple the parser from a busy UI thread, plus an over-the-network benchmark harness used to find and validate them.

### Fixes (production)
- **Targeted component broadcast** — `WindowRegistry.updateComponent` batches a single work-queue op that updates every stream in place, instead of each stream enqueuing its own op (which multiplied queue traffic by the open-window count for every server component update).
- **Coalesced publishes** — `StreamWorkQueue` greedily drains its channel and publishes each stream's snapshot once per drain batch (`Flushable`/`scheduleFlush`), bounded by `MAX_OPS_BETWEEN_FLUSHES`. Cuts `StreamFlow` writes / allocations per burst.
- **Buffer `eventFlow`** — the zero-buffer (rendezvous) `eventFlow` made the parse loop wait, per text event, for every subscriber to receive it, including the `GameViewModel` collector on the UI thread. When the UI thread is busy recomposing (a multi-window burst), the parser lock-steps behind it. A 256-event buffer (no replay; SUSPEND overflow keeps every event for scripts) lets the parser run ahead. In the benchmark's recomposition-cost model this removed a ~44x throughput collapse under a busy UI thread.
- **StreamProfiling** — opt-in per-connection queue instrumentation, off by default (`StreamProfiling.enabled = false`); the disabled path is allocation-free (no clock read / atomic / wrapper). `desktopApp` gains opt-in `-PgcLog`/`-Pzgc` JVM flags.

### Benchmark harness (`:compose:streamNetworkBenchmark`)
A loopback TCP server replays game protocol into a real `NetworkSocket` -> real `WraythClient` (socket read + ANTLR parse + event dispatch) -> real `ComposeTextStream`/`StreamWorkQueue`. Reproduces the user's path the prior in-process benchmark could not. Knobs: synthetic or real-capture (`-Plog`) replay, pacing (`-PlinesPerSec`), eventFlow subscribers (`-Pscripts`), and a shared-UI-thread recomposition cost (`-PuiCostMicros`).

## What the benchmark found

- **The parse/render pipeline is fast and linear** — a real 21,619-line capture replays in ~0.6s (~35k lines/sec, single connection), per-op exec ~6-20µs, highlight matching ~4µs. Two scary leads turned out to be artifacts: an apparent O(n^2) per-line deceleration (malformed synthetic protocol, fixed) and the parse-stage cost.
- **The real cross-client coupling is the single UI thread.** `lines` is a `StateFlow` (non-blocking) and the UI already conflates publishes hard, so recomposition does not block the render pipeline. But the zero-buffer `eventFlow` *does* tie every connection's parse loop to the UI thread's availability, so a busy UI thread (multi-window burst) stalls the parsers. The buffer fixes that; further publish-coalescing has no headroom (StateFlow already conflates).
- Getting here took correcting an earlier wrong "eventFlow ruled out" conclusion: it was reached with the benchmark's `-Pscripts`/`-PuiCostMicros` knobs silently dropped (a bug fixed here) and an unrealistic per-text-event UI model. The honest result is the buffer above.

## Testing
- `:compose:jvmTest` (`ComposeTextStreamTest`) passes; compose/wrayth/desktopApp compile; ktlint clean.
- Exercised end-to-end against synthetic and a real 21,619-line capture, including the recomposition-cost UI model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)