### PR TITLE
Tolerate --no-sandbox injected by the AppImage launcher

### DIFF
--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -629,7 +629,14 @@ private class WarlockCommand : CliktCommand() {
 }
 
 @OptIn(ExperimentalResourceApi::class)
-fun main(args: Array<String>) = WarlockCommand().versionOption(version ?: "Development").main(args)
+fun main(args: Array<String>) =
+    WarlockCommand()
+        .versionOption(version ?: "Development")
+        // Nucleus packs the Linux AppImage via electron-builder, whose AppRun injects --no-sandbox
+        // when the kernel blocks unprivileged user namespaces (Ubuntu 24.04+ default), assuming an
+        // Electron binary. We're a JVM app with no sandbox to disable, so drop the flag rather than
+        // abort startup on an unknown option.
+        .main(args.filterNot { it == "--no-sandbox" })
 
 @Composable
 private fun UpdateDialog(


### PR DESCRIPTION
## Problem

Launching the Linux AppImage on Ubuntu 24.04+ fails immediately:

```
$ ./warlock-3.1.0-beta.12-linux-x86_64.AppImage
Usage: warlock [<options>] [<sal_file>]
Error: no such option --no-sandbox
```

## Root cause

Nucleus packages the AppImage by shelling out to electron-builder. Its `AppRun` launcher probes for unprivileged user namespaces (`unshare -Ur true`) and, when they are blocked, prepends `--no-sandbox` to the launched binary, assuming it is an Electron/Chromium app that understands the flag:

```bash
if [ $HAVE_NO_SANDBOX -eq 0 ] && ! unshare -Ur true 2>/dev/null ; then
  NO_SANDBOX=(--no-sandbox)
fi
exec "$BIN" "${NO_SANDBOX[@]}" "${args[@]}"
```

Ubuntu 24.04+ blocks unprivileged user namespaces by default (`kernel.apparmor_restrict_unprivileged_userns=1`), so the probe fails and the flag is always injected. Our `$BIN` is the jpackage launcher for a JVM app, which forwards `--no-sandbox` to the Clikt CLI, and Clikt aborts on the unknown option.

This is why it appeared between beta.6 and beta.12 with no change on our side: Nucleus invokes `npx electron-builder` **unpinned**, so each build resolves whatever electron-builder was latest that day. The smart-sandbox `AppRun` change (electron-builder PR #9590) reached the 26.x line between the two build dates, so beta.6's AppRun lacked it and beta.12's shipped it.

## Fix

Drop `--no-sandbox` before Clikt parses argv. Every other argument (`--input`, `.sal` files, etc.) still reaches the CLI unchanged, and we stay immune regardless of which `AppRun` template a future build resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)