### PR TITLE
Stabilize scrollbar thumb with measured line heights

### DIFF
--- a/compose/skin/skin.json
+++ b/compose/skin/skin.json
@@ -280,6 +280,12 @@
       "compassDarkIcon": { "color": { "light": "#BCC0C7", "dark": "#3F444D" } }
     }
   },
+  "scrollbar": {
+    "children": {
+      "gutter": { "color": "#808080" },
+      "thumb": { "color": { "light": "#E6000000", "dark": "#E6D8D2C4" } }
+    }
+  },
   "indicator": {
     "width": 24,
     "height": 24,

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -80,6 +80,12 @@ class ComposeTextStream(
     private var nextSerialNumber = 0L
     private var removedLines = 0L
 
+    // Bumped on clear(), where nextSerialNumber restarts from 0. Anything keyed by serial number (the
+    // scrollbar's measured-height cache) observes this to drop state that would otherwise collide with
+    // the reused low serial numbers.
+    private val _generation = MutableStateFlow(0)
+    val generation: StateFlow<Int> = _generation
+
     // Set when the displayed lines changed but the new snapshot has not been emitted yet; the work
     // queue coalesces this into a single publish per drain batch (see publishLines/flush).
     private var pendingPublish = false
@@ -172,6 +178,7 @@ class ComposeTextStream(
             components.clear()
             nextSerialNumber = 0L
             removedLines = 0L
+            _generation.value += 1
             cacheLines.clear()
             linesUpdated()
         }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/LazyListMeasuredScrollModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/LazyListMeasuredScrollModel.kt
@@ -1,0 +1,109 @@
+package warlockfe.warlock3.compose.ui.window
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+
+/**
+ * Tracks the measured pixel height of every line in a stream [androidx.compose.foundation.lazy.LazyColumn]
+ * so a scrollbar can derive an exact content size and scroll offset instead of extrapolating from the
+ * average height of the items that happen to be on screen.
+ *
+ * The stock lazy-list scrollbar adapter has no choice but to estimate: it only knows the items the
+ * list has currently laid out, so it sets `contentSize = averageVisibleItemHeight * itemCount`. When
+ * lines wrap to wildly different heights, that average shifts every time you drag into a taller or
+ * shorter region, so the computed content size (and therefore the thumb height) jumps around. By
+ * caching the real height of each line as it scrolls into view, regions that have already been seen
+ * contribute their exact height; only never-yet-rendered lines fall back to the running average, and
+ * the estimate converges as the user scrolls.
+ *
+ * Heights are keyed by [StreamLine.serialNumber] (stable across buffer trimming and re-filtering)
+ * rather than by list index, which shifts whenever the scrollback buffer drops its oldest lines.
+ *
+ * @param state the backing list state.
+ * @param itemCount current number of lines (must match the lazy list's item count).
+ * @param keyAt stable serial number of the line at an index, or null if out of range.
+ * @param isRendered whether the line at an index paints a non-zero-height row (see
+ *   [rendersContent]); hidden/collapsed lines occupy a zero-height slot and must contribute 0.
+ * @param measuredHeights cache of measured heights by serial number, populated by the caller as
+ *   items are laid out. Recreate the map (rather than clearing it) whenever the line width or text
+ *   style changes, since those invalidate every cached height.
+ */
+@Stable
+class LazyListMeasuredScrollModel(
+    private val state: LazyListState,
+    private val itemCount: () -> Int,
+    private val keyAt: (index: Int) -> Long?,
+    private val isRendered: (index: Int) -> Boolean,
+    private val measuredHeights: SnapshotStateMap<Long, Int>,
+) {
+    /** Mean of the known heights, used as the fallback for lines that have not been measured yet. */
+    private fun averageHeight(): Double {
+        var sum = 0L
+        var count = 0
+        for (height in measuredHeights.values) {
+            if (height > 0) {
+                sum += height
+                count++
+            }
+        }
+        return if (count == 0) 0.0 else sum.toDouble() / count
+    }
+
+    private fun heightOf(
+        index: Int,
+        average: Double,
+    ): Double {
+        if (!isRendered(index)) return 0.0
+        val key = keyAt(index) ?: return average
+        return measuredHeights[key]?.toDouble() ?: average
+    }
+
+    /** Total height of the content, summing measured heights and estimating the rest. */
+    val contentSize: Double
+        get() {
+            val count = itemCount()
+            val average = averageHeight()
+            var total = 0.0
+            for (i in 0 until count) {
+                total += heightOf(i, average)
+            }
+            return total
+        }
+
+    val viewportSize: Double
+        get() {
+            val info = state.layoutInfo
+            return (info.viewportEndOffset - info.viewportStartOffset).toDouble()
+        }
+
+    /** Distance from the top of the content to the top of the viewport. */
+    val scrollOffset: Double
+        get() {
+            val first = state.firstVisibleItemIndex
+            val average = averageHeight()
+            var offset = 0.0
+            for (i in 0 until first) {
+                offset += heightOf(i, average)
+            }
+            return offset + state.firstVisibleItemScrollOffset
+        }
+
+    /** Jump so the content top sits [scrollOffset] pixels above the viewport top. */
+    suspend fun scrollTo(scrollOffset: Double) {
+        val count = itemCount()
+        if (count == 0) return
+        val target = scrollOffset.coerceAtLeast(0.0)
+        val average = averageHeight()
+        var consumed = 0.0
+        for (i in 0 until count) {
+            val height = heightOf(i, average)
+            if (consumed + height > target) {
+                state.scrollToItem(i, (target - consumed).toInt().coerceAtLeast(0))
+                return
+            }
+            consumed += height
+        }
+        state.scrollToItem(count - 1)
+    }
+}

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/LazyListMeasuredScrollModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/LazyListMeasuredScrollModel.kt
@@ -1,8 +1,11 @@
 package warlockfe.warlock3.compose.ui.window
 
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.snapshots.SnapshotStateMap
+import kotlin.math.abs
 
 /**
  * Tracks the measured pixel height of every line in a stream [androidx.compose.foundation.lazy.LazyColumn]
@@ -13,12 +16,17 @@ import androidx.compose.runtime.snapshots.SnapshotStateMap
  * list has currently laid out, so it sets `contentSize = averageVisibleItemHeight * itemCount`. When
  * lines wrap to wildly different heights, that average shifts every time you drag into a taller or
  * shorter region, so the computed content size (and therefore the thumb height) jumps around. By
- * caching the real height of each line as it scrolls into view, regions that have already been seen
- * contribute their exact height; only never-yet-rendered lines fall back to the running average, and
- * the estimate converges as the user scrolls.
+ * caching the real height of each line as it scrolls into view - and measuring off-screen lines via
+ * [renderedHeight] - regions contribute their exact height; only a line that has not been measured by
+ * either path yet falls back to the running average, which is a brief transient as the caller's
+ * measuring pass catches up.
  *
  * Heights are keyed by [StreamLine.serialNumber] (stable across buffer trimming and re-filtering)
  * rather than by list index, which shifts whenever the scrollback buffer drops its oldest lines.
+ *
+ * The geometry is derived from a [prefixSums] snapshot that is rebuilt only when a height, a line's
+ * visibility, or the line set changes - not on every scroll - so the per-frame `contentSize` /
+ * `scrollOffset` reads the scrollbar makes while dragging are O(1) instead of re-summing the buffer.
  *
  * @param state the backing list state.
  * @param itemCount current number of lines (must match the lazy list's item count).
@@ -26,8 +34,8 @@ import androidx.compose.runtime.snapshots.SnapshotStateMap
  * @param isRendered whether the line at an index paints a non-zero-height row (see
  *   [rendersContent]); hidden/collapsed lines occupy a zero-height slot and must contribute 0.
  * @param measuredHeights cache of measured heights by serial number, populated by the caller as
- *   items are laid out. Recreate the map (rather than clearing it) whenever the line width or text
- *   style changes, since those invalidate every cached height.
+ *   items are laid out (and pre-filled for off-screen lines). Recreate the map (rather than clearing
+ *   it) whenever the line width or text style changes, since those invalidate every cached height.
  */
 @Stable
 class LazyListMeasuredScrollModel(
@@ -37,18 +45,40 @@ class LazyListMeasuredScrollModel(
     private val isRendered: (index: Int) -> Boolean,
     private val measuredHeights: SnapshotStateMap<Long, Int>,
 ) {
-    /** Mean of the known heights, used as the fallback for lines that have not been measured yet. */
-    private fun averageHeight(): Double {
-        var sum = 0L
-        var count = 0
-        for (height in measuredHeights.values) {
-            if (height > 0) {
-                sum += height
-                count++
+    /** Mean of the known heights, the fallback for any line not yet measured. */
+    private val averageHeight =
+        derivedStateOf {
+            var sum = 0L
+            var count = 0
+            for (height in measuredHeights.values) {
+                if (height > 0) {
+                    sum += height
+                    count++
+                }
             }
+            if (count == 0) 0.0 else sum.toDouble() / count
         }
-        return if (count == 0) 0.0 else sum.toDouble() / count
-    }
+
+    /**
+     * Running prefix sums of the line heights: `prefixSums[i]` is the summed height of lines
+     * `0 until i`, so `prefixSums[itemCount]` is the whole content (excluding the list's content
+     * padding). Backed by [derivedStateOf] so it rebuilds only when a height, a line's visibility, or
+     * the line set changes - never on a plain scroll - which keeps `contentSize` and `scrollOffset`
+     * O(1) per read.
+     */
+    private val prefixSums =
+        derivedStateOf {
+            val count = itemCount()
+            val average = averageHeight.value
+            val sums = DoubleArray(count + 1)
+            var total = 0.0
+            for (i in 0 until count) {
+                sums[i] = total
+                total += heightOf(i, average)
+            }
+            sums[count] = total
+            sums
+        }
 
     private fun heightOf(
         index: Int,
@@ -62,13 +92,13 @@ class LazyListMeasuredScrollModel(
     /** Total height of the content, summing measured heights and estimating the rest. */
     val contentSize: Double
         get() {
-            val count = itemCount()
-            val average = averageHeight()
-            var total = 0.0
-            for (i in 0 until count) {
-                total += heightOf(i, average)
-            }
-            return total
+            val sums = prefixSums.value
+            // Content padding is read live here (cheap, and changes only on a relayout) rather than
+            // inside the prefix-sum derivation, so that scrolling does not invalidate the sums. This
+            // matches the stock adapter, which adds beforeContentPadding + afterContentPadding so the
+            // scrollable range (contentSize - viewportSize) reaches the list's true bottom.
+            val info = state.layoutInfo
+            return sums[sums.size - 1] + info.beforeContentPadding + info.afterContentPadding
         }
 
     val viewportSize: Double
@@ -80,29 +110,39 @@ class LazyListMeasuredScrollModel(
     /** Distance from the top of the content to the top of the viewport. */
     val scrollOffset: Double
         get() {
-            val first = state.firstVisibleItemIndex
-            val average = averageHeight()
-            var offset = 0.0
-            for (i in 0 until first) {
-                offset += heightOf(i, average)
-            }
-            return offset + state.firstVisibleItemScrollOffset
+            val sums = prefixSums.value
+            val first = state.firstVisibleItemIndex.coerceIn(0, sums.size - 1)
+            return sums[first] + state.firstVisibleItemScrollOffset
         }
 
     /** Jump so the content top sits [scrollOffset] pixels above the viewport top. */
     suspend fun scrollTo(scrollOffset: Double) {
-        val count = itemCount()
-        if (count == 0) return
+        // For moves within a viewport, scroll incrementally through the list's own scrollBy instead of
+        // snapping to a computed item. snapToItemIndex (used by scrollToItem) bypasses ScrollScope's
+        // scrollBy, so it never sets the list's lastScrolledBackward/Forward flags that the sticky
+        // auto-scroll keys on; a thumb drag would then leave "sticky" engaged and let the next incoming
+        // line yank the view back to the bottom. scrollBy also keeps the motion smooth across lines of
+        // differing height. Snap only for jumps larger than a viewport (track clicks, dragging across
+        // the whole track), where an incremental scroll would be needlessly slow. This mirrors the
+        // stock lazy-list scrollbar adapter.
+        val distance = scrollOffset - this.scrollOffset
+        if (abs(distance) <= viewportSize) {
+            state.scrollBy(distance.toFloat())
+        } else {
+            snapTo(scrollOffset)
+        }
+    }
+
+    private suspend fun snapTo(scrollOffset: Double) {
+        val sums = prefixSums.value
+        val count = sums.size - 1
+        if (count <= 0) return
         val target = scrollOffset.coerceAtLeast(0.0)
-        val average = averageHeight()
-        var consumed = 0.0
         for (i in 0 until count) {
-            val height = heightOf(i, average)
-            if (consumed + height > target) {
-                state.scrollToItem(i, (target - consumed).toInt().coerceAtLeast(0))
+            if (sums[i + 1] > target) {
+                state.scrollToItem(i, (target - sums[i]).toInt().coerceAtLeast(0))
                 return
             }
-            consumed += height
         }
         state.scrollToItem(count - 1)
     }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ScrollbarSkinColors.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ScrollbarSkinColors.kt
@@ -1,0 +1,52 @@
+package warlockfe.warlock3.compose.ui.window
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
+import warlockfe.warlock3.compose.model.forMode
+import warlockfe.warlock3.compose.util.LocalDarkTheme
+import warlockfe.warlock3.compose.util.LocalSkin
+import warlockfe.warlock3.compose.util.toColor
+import warlockfe.warlock3.core.util.getIgnoringCase
+import warlockfe.warlock3.core.util.toWarlockColor
+
+/**
+ * Stream scrollbar colors from the active skin's `scrollbar` section, resolved for the current
+ * light/dark mode. Shared by the desktop and mobile scrollbars so both follow the skin. The bundled
+ * default skin ports IntelliJ's values: a ~10%-alpha track gutter and a low-alpha thumb. Colors may
+ * carry their own alpha (the skin hex supports `#AARRGGBB`).
+ */
+data class ScrollbarSkinColors(
+    /** The track behind the thumb. Low alpha; the desktop view fades it in on hover/drag. */
+    val gutter: Color,
+    /** The drag handle. */
+    val thumb: Color,
+)
+
+/**
+ * The [ScrollbarSkinColors] from the active skin's `scrollbar` section, resolved for the current
+ * [light/dark mode][LocalDarkTheme]. Falls back to IntelliJ's track/thumb if a skin omits the section.
+ */
+val scrollbarSkinColors: ScrollbarSkinColors
+    @Composable
+    @ReadOnlyComposable
+    get() {
+        val children = LocalSkin.current.getIgnoringCase("scrollbar")?.children
+        val isDark = LocalDarkTheme.current
+
+        fun color(
+            name: String,
+            default: Color,
+        ): Color =
+            children
+                ?.getIgnoringCase(name)
+                ?.color
+                .forMode(isDark)
+                ?.toWarlockColor()
+                .toColor(default)
+
+        return ScrollbarSkinColors(
+            gutter = color("gutter", default = Color(0x1A808080)),
+            thumb = color("thumb", default = Color(0x59808080)),
+        )
+    }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewHelpers.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewHelpers.kt
@@ -199,6 +199,29 @@ internal fun StreamTextLine.isShowing(openWindows: List<String>): Boolean =
             it == this.showWhenClosed
         }
 
+/**
+ * Whether the line at [index] actually paints a row in the stream. Text lines with no text, lines
+ * hidden because their window is open, and prompts collapsed into the previous prompt all occupy a
+ * zero-height slot in the [androidx.compose.foundation.lazy.LazyColumn]. This MUST stay in lockstep
+ * with the render branch in WindowViewContent so the scroll model counts the same heights the list
+ * lays out.
+ */
+internal fun List<StreamLine>.rendersContent(
+    index: Int,
+    openWindows: List<String>,
+): Boolean =
+    when (val line = this[index]) {
+        is StreamTextLine -> {
+            line.text != null &&
+                line.isShowing(openWindows) &&
+                (!line.isPrompt || !isPreviousPrompt(index, openWindows))
+        }
+
+        is StreamImageLine -> {
+            true
+        }
+    }
+
 internal fun List<StreamLine>.isPreviousPrompt(
     index: Int,
     openWindows: List<String>,

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewHelpers.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewHelpers.kt
@@ -21,7 +21,11 @@ import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImagePainter
 import coil3.compose.LocalPlatformContext
 import coil3.compose.rememberAsyncImagePainter
@@ -236,3 +240,41 @@ internal fun List<StreamLine>.isPreviousPrompt(
     }
     return false
 }
+
+// Layout constants shared by the stream row in WindowViewContent and the off-screen height measurer
+// ([renderedHeight]), so a computed height matches what the row actually lays out. The row and the
+// measurer MUST reference these same values rather than inline literals, or the two can drift.
+internal val streamRowStartPadding = 4.dp
+internal val streamRowEndPadding = 8.dp
+internal val streamImageRowHeight = 80.dp
+
+/**
+ * Intrinsic pixel height of [this] line when it renders content, computed the way WindowViewContent
+ * lays the row out (the same [textStyle], with the row's horizontal padding already removed from
+ * [textWidthPx]) so the scroll model's estimate of an off-screen line matches its real laid-out
+ * height. Visibility / prompt-collapse gating is applied separately by the scroll model via
+ * [rendersContent]; a text line with no text contributes 0.
+ */
+internal fun StreamLine.renderedHeight(
+    textMeasurer: TextMeasurer,
+    textStyle: TextStyle,
+    textWidthPx: Int,
+    imageHeightPx: Int,
+): Int =
+    when (this) {
+        is StreamTextLine -> {
+            val content = text ?: return 0
+            val layout =
+                textMeasurer.measure(
+                    text = content,
+                    style = textStyle,
+                    softWrap = true,
+                    constraints = Constraints(maxWidth = textWidthPx.coerceAtLeast(0)),
+                )
+            layout.size.height
+        }
+
+        is StreamImageLine -> {
+            imageHeightPx
+        }
+    }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onLayoutRectChanged
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.LiveRegionMode
@@ -53,6 +54,7 @@ import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
@@ -64,6 +66,7 @@ import coil3.compose.LocalPlatformContext
 import coil3.compose.rememberAsyncImagePainter
 import coil3.request.ImageRequest
 import coil3.size.Size
+import kotlinx.coroutines.yield
 import warlockfe.warlock3.compose.util.ClearContextMenuItemKey
 import warlockfe.warlock3.compose.util.CloseContextMenuItemKey
 import warlockfe.warlock3.compose.util.SettingsContextMenuItemKey
@@ -76,6 +79,10 @@ import warlockfe.warlock3.core.macro.ScrollEvent
 import warlockfe.warlock3.core.text.StyleDefinition
 import warlockfe.warlock3.core.window.ClientBackgroundImage
 import warlockfe.warlock3.core.window.WindowLocation
+
+// Off-screen lines are measured in batches of this many between yield()s, so a full-buffer pass never
+// blocks a frame.
+private const val OFFSCREEN_MEASURE_CHUNK = 64
 
 /**
  * Platform-agnostic window view. Holds the structure shared by the desktop and mobile clients (the
@@ -247,8 +254,22 @@ private fun WindowViewContent(
     val fontFamily = style.fontFamily?.let { createFontFamily(it) }
     val fontSize = style.fontSize?.sp ?: defaultFontSize
     val fontWeight = style.fontWeight?.let { FontWeight(it) }
+    // The text style shared by the rendered row and the off-screen height measurer, so a measured
+    // height matches what the row lays out. (Color does not affect height; the measurer ignores it.)
+    val rowTextStyle =
+        remember(textColor, fontFamily, fontSize, fontWeight) {
+            TextStyle(
+                color = textColor,
+                fontFamily = fontFamily,
+                fontSize = fontSize,
+                fontWeight = fontWeight,
+            )
+        }
 
     val lines = stream.lines.collectAsState(emptyList()).value
+    // Bumped when the buffer is cleared (serial numbers restart from 0); keys the measured-height
+    // cache below so it is discarded on clear instead of feeding stale heights to reused serials.
+    val generation by stream.generation.collectAsState()
 
     val findController = LocalWindowFindController.current
     val findUiState by findController.state.collectAsState()
@@ -289,7 +310,7 @@ private fun WindowViewContent(
                 // which makes the thumb jump when lines wrap to different heights. Recreate the cache
                 // whenever the wrap width or text style changes, since both invalidate every height.
                 val measuredHeights =
-                    remember(constraints.maxWidth, style, defaultFontSize) {
+                    remember(constraints.maxWidth, style, defaultFontSize, generation) {
                         mutableStateMapOf<Long, Int>()
                     }
                 val currentLines = rememberUpdatedState(lines)
@@ -308,13 +329,47 @@ private fun WindowViewContent(
                             measuredHeights = measuredHeights,
                         )
                     }
-                LaunchedEffect(measuredHeights) {
-                    snapshotFlow { scrollState.layoutInfo.visibleItemsInfo.map { it.key to it.size } }
-                        .collect { visibleItems ->
-                            visibleItems.forEach { (key, size) ->
-                                val serial = key as? Long ?: return@forEach
-                                if (size > 0 && measuredHeights[serial] != size) {
-                                    measuredHeights[serial] = size
+                val density = LocalDensity.current
+                val textMeasurer = rememberTextMeasurer()
+                val horizontalPaddingPx =
+                    with(density) { (streamRowStartPadding + streamRowEndPadding).roundToPx() }
+                val textWidthPx = (constraints.maxWidth - horizontalPaddingPx).coerceAtLeast(0)
+                val imageHeightPx = with(density) { streamImageRowHeight.roundToPx() }
+                // Measure the lines the LazyColumn never lays out (off-screen scrollback) so the scroll
+                // model has an exact height for every line instead of the running-average estimate that
+                // made the thumb drift when scrolling into unseen regions. Runs on the composition's
+                // dispatcher, chunked with yield() so it never blocks a frame, and skips serials already
+                // measured (visible items are measured for real by the effect above).
+                LaunchedEffect(measuredHeights, textMeasurer, rowTextStyle, textWidthPx, imageHeightPx) {
+                    snapshotFlow { currentLines.value }
+                        .collect { snapshot ->
+                            // Evict heights for lines trimmed off the front of the scrollback: their
+                            // serials sit below the oldest live line and would otherwise accumulate in
+                            // the cache (and skew the average) for the lifetime of the window.
+                            val oldestSerial = snapshot.firstOrNull()?.serialNumber
+                            if (oldestSerial != null) {
+                                measuredHeights.keys
+                                    .filter { it < oldestSerial }
+                                    .forEach { measuredHeights.remove(it) }
+                            }
+                            var sinceYield = 0
+                            snapshot.forEach { line ->
+                                if (!measuredHeights.containsKey(line.serialNumber)) {
+                                    val height =
+                                        line.renderedHeight(
+                                            textMeasurer = textMeasurer,
+                                            textStyle = rowTextStyle,
+                                            textWidthPx = textWidthPx,
+                                            imageHeightPx = imageHeightPx,
+                                        )
+                                    if (height > 0) {
+                                        measuredHeights[line.serialNumber] = height
+                                    }
+                                    sinceYield++
+                                    if (sinceYield >= OFFSCREEN_MEASURE_CHUNK) {
+                                        sinceYield = 0
+                                        yield()
+                                    }
                                 }
                             }
                         }
@@ -337,21 +392,33 @@ private fun WindowViewContent(
                         ) { index ->
                             when (val line = lines[index]) {
                                 is StreamTextLine -> {
-                                    if (line.text != null &&
-                                        line.isShowing(openWindows) &&
-                                        (!line.isPrompt || !lines.isPreviousPrompt(index, openWindows))
-                                    ) {
+                                    // rendersContent is the single source of truth for whether a line
+                                    // paints a row; the scroll model keys its heights off the same
+                                    // predicate, so the two cannot drift. It guarantees non-null text
+                                    // for a shown text line (hence the unreachable elvis below).
+                                    if (lines.rendersContent(index, openWindows)) {
+                                        val lineText = line.text ?: return@items
                                         var positionInParent by remember { mutableStateOf(Offset.Zero) }
                                         Box(
                                             modifier =
                                                 Modifier
                                                     .fillMaxWidth()
-                                                    .onGloballyPositioned {
+                                                    // Record this visible row's real laid-out height,
+                                                    // correcting the off-screen estimate. Fires only on
+                                                    // a size change, so there is no per-frame work.
+                                                    .onSizeChanged { size ->
+                                                        val height = size.height
+                                                        if (height > 0 &&
+                                                            measuredHeights[line.serialNumber] != height
+                                                        ) {
+                                                            measuredHeights[line.serialNumber] = height
+                                                        }
+                                                    }.onGloballyPositioned {
                                                         positionInParent = it.positionInParent()
                                                     }.background(
                                                         line.entireLineStyle?.backgroundColor?.toColor()
                                                             ?: Color.Unspecified,
-                                                    ).padding(start = 4.dp, end = 8.dp),
+                                                    ).padding(start = streamRowStartPadding, end = streamRowEndPadding),
                                         ) {
                                             BasicText(
                                                 modifier =
@@ -376,7 +443,7 @@ private fun WindowViewContent(
                                                         val ranges =
                                                             activeFind.matchRangesBySerial[line.serialNumber]
                                                         if (ranges != null) {
-                                                            line.text.withFindHighlight(
+                                                            lineText.withFindHighlight(
                                                                 ranges = ranges,
                                                                 currentRange =
                                                                     if (line.serialNumber == activeFind.currentSerial) {
@@ -386,25 +453,19 @@ private fun WindowViewContent(
                                                                     },
                                                             )
                                                         } else {
-                                                            line.text
+                                                            lineText
                                                         }
                                                     } else {
-                                                        line.text
+                                                        lineText
                                                     },
-                                                style =
-                                                    TextStyle(
-                                                        color = textColor,
-                                                        fontFamily = fontFamily,
-                                                        fontSize = fontSize,
-                                                        fontWeight = fontWeight,
-                                                    ),
+                                                style = rowTextStyle,
                                             )
                                         }
                                     }
                                 }
 
                                 is StreamImageLine -> {
-                                    val defaultHeight = 80.dp
+                                    val defaultHeight = streamImageRowHeight
                                     Box(Modifier.height(defaultHeight).fillMaxWidth().zIndex(1f)) {
                                         val painter =
                                             rememberAsyncImagePainter(

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
@@ -27,10 +27,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -99,7 +101,11 @@ internal fun WindowViewScaffold(
     defaultFontSize: TextUnit,
     surface: @Composable (modifier: Modifier, content: @Composable () -> Unit) -> Unit,
     header: @Composable (title: String, onSettingsClick: () -> Unit) -> Unit,
-    listContainer: @Composable (scrollState: LazyListState, content: @Composable () -> Unit) -> Unit,
+    listContainer: @Composable (
+        scrollState: LazyListState,
+        heightModel: LazyListMeasuredScrollModel,
+        content: @Composable () -> Unit,
+    ) -> Unit,
     actionContextMenu: @Composable (offset: Offset?, menuData: WarlockMenuData, onDismiss: () -> Unit) -> Unit,
     settingsDialog: @Composable (onCloseRequest: () -> Unit) -> Unit,
     dialogContent: @Composable (data: DialogWindowData, style: StyleDefinition) -> Unit,
@@ -228,7 +234,11 @@ private fun WindowViewContent(
     menuData: WarlockMenuData?,
     onActionClick: (WarlockAction) -> Int?,
     defaultFontSize: TextUnit,
-    listContainer: @Composable (scrollState: LazyListState, content: @Composable () -> Unit) -> Unit,
+    listContainer: @Composable (
+        scrollState: LazyListState,
+        heightModel: LazyListMeasuredScrollModel,
+        content: @Composable () -> Unit,
+    ) -> Unit,
     actionContextMenu: @Composable (offset: Offset?, menuData: WarlockMenuData, onDismiss: () -> Unit) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -274,7 +284,42 @@ private fun WindowViewContent(
                         modifier = Modifier.align(image.backgroundAlignment()),
                     )
                 }
-                listContainer(scrollState) {
+                // Cache each line's measured height so the scrollbar can size its thumb from the
+                // real content height instead of extrapolating from the visible items' average,
+                // which makes the thumb jump when lines wrap to different heights. Recreate the cache
+                // whenever the wrap width or text style changes, since both invalidate every height.
+                val measuredHeights =
+                    remember(constraints.maxWidth, style, defaultFontSize) {
+                        mutableStateMapOf<Long, Int>()
+                    }
+                val currentLines = rememberUpdatedState(lines)
+                val currentOpenWindows = rememberUpdatedState(openWindows)
+                val heightModel =
+                    remember(measuredHeights) {
+                        LazyListMeasuredScrollModel(
+                            state = scrollState,
+                            itemCount = { currentLines.value.size },
+                            keyAt = { index -> currentLines.value.getOrNull(index)?.serialNumber },
+                            isRendered = { index ->
+                                val list = currentLines.value
+                                index in list.indices &&
+                                    list.rendersContent(index, currentOpenWindows.value)
+                            },
+                            measuredHeights = measuredHeights,
+                        )
+                    }
+                LaunchedEffect(measuredHeights) {
+                    snapshotFlow { scrollState.layoutInfo.visibleItemsInfo.map { it.key to it.size } }
+                        .collect { visibleItems ->
+                            visibleItems.forEach { (key, size) ->
+                                val serial = key as? Long ?: return@forEach
+                                if (size > 0 && measuredHeights[serial] != size) {
+                                    measuredHeights[serial] = size
+                                }
+                            }
+                        }
+                }
+                listContainer(scrollState, heightModel) {
                     LazyColumn(
                         modifier =
                             Modifier

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowView.kt
@@ -1,8 +1,10 @@
 package warlockfe.warlock3.compose.desktop.ui.window
 
+import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.defaultScrollbarStyle
 import androidx.compose.foundation.interaction.HoverInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -10,6 +12,7 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -43,7 +46,6 @@ import kotlinx.coroutines.launch
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.PopupMenu
 import org.jetbrains.jewel.ui.component.Text
-import org.jetbrains.jewel.ui.component.VerticallyScrollableContainer
 import org.jetbrains.jewel.ui.component.separator
 import org.jetbrains.jewel.ui.theme.menuStyle
 import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
@@ -149,12 +151,32 @@ fun DesktopWindowView(
                 onCloseClick = onCloseClick,
             )
         },
-        listContainer = { scrollState, content ->
-            VerticallyScrollableContainer(
-                scrollState = scrollState,
-                modifier = Modifier.fillMaxSize(),
-            ) {
+        listContainer = { _, heightModel, content ->
+            // The stock lazy-list scrollbar (Jewel's VerticallyScrollableContainer) extrapolates the
+            // content size from the average height of the visible lines, so its thumb jumps when
+            // lines wrap to different heights. Drive a native scrollbar from a custom adapter backed
+            // by per-line measured heights instead; the LazyColumn still handles wheel scrolling.
+            Box(Modifier.fillMaxSize()) {
                 content()
+                val adapter = remember(heightModel) { MeasuredScrollbarAdapter(heightModel) }
+                VerticalScrollbar(
+                    adapter = adapter,
+                    modifier =
+                        Modifier
+                            .align(Alignment.CenterEnd)
+                            .fillMaxHeight()
+                            .background(gameChrome.border.copy(alpha = 0.5f))
+                            .padding(top = 2.dp, bottom = 4.dp),
+                    style =
+                        defaultScrollbarStyle().copy(
+                            minimalHeight = 24.dp,
+                            // gameChrome.border is a hairline barely distinct from the panel, so it
+                            // reads as invisible on the thumb. textFaint/textMuted are the theme's
+                            // visible-but-subtle element colors and contrast in both light and dark.
+                            unhoverColor = gameChrome.textFaint,
+                            hoverColor = gameChrome.textMuted,
+                        ),
+                )
             }
         },
         actionContextMenu = { offset, menu, onDismiss ->

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowView.kt
@@ -1,5 +1,6 @@
 package warlockfe.warlock3.compose.desktop.ui.window
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -7,6 +8,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.defaultScrollbarStyle
 import androidx.compose.foundation.interaction.HoverInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -54,6 +56,7 @@ import warlockfe.warlock3.compose.desktop.ui.settings.DesktopWindowSettingsDialo
 import warlockfe.warlock3.compose.ui.window.WindowHeader
 import warlockfe.warlock3.compose.ui.window.WindowUiState
 import warlockfe.warlock3.compose.ui.window.WindowViewScaffold
+import warlockfe.warlock3.compose.ui.window.scrollbarSkinColors
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.core.client.WarlockAction
 import warlockfe.warlock3.core.client.WarlockMenuData
@@ -159,22 +162,34 @@ fun DesktopWindowView(
             Box(Modifier.fillMaxSize()) {
                 content()
                 val adapter = remember(heightModel) { MeasuredScrollbarAdapter(heightModel) }
+                val scrollbar = scrollbarSkinColors
+                // Share an interaction source with the scrollbar so the track gutter follows the
+                // thumb's own state: VerticalScrollbar drives its highlight from this same source
+                // (hoverable + DragInteraction), so the gutter fades in (to its skin alpha) exactly
+                // when the thumb does and stays hidden while idle. canScroll keeps the lane clear when
+                // content fits.
+                val interactionSource = remember { MutableInteractionSource() }
+                val hovered by interactionSource.collectIsHoveredAsState()
+                val dragged by interactionSource.collectIsDraggedAsState()
+                val canScroll = heightModel.contentSize > heightModel.viewportSize
+                val gutterAlpha by animateFloatAsState(
+                    targetValue = if (canScroll && (hovered || dragged)) 0.1f else 0f,
+                    label = "scrollbarGutter",
+                )
                 VerticalScrollbar(
                     adapter = adapter,
+                    interactionSource = interactionSource,
                     modifier =
                         Modifier
                             .align(Alignment.CenterEnd)
                             .fillMaxHeight()
-                            .background(gameChrome.border.copy(alpha = 0.5f))
+                            .background(scrollbar.gutter.copy(alpha = gutterAlpha))
                             .padding(top = 2.dp, bottom = 4.dp),
                     style =
                         defaultScrollbarStyle().copy(
                             minimalHeight = 24.dp,
-                            // gameChrome.border is a hairline barely distinct from the panel, so it
-                            // reads as invisible on the thumb. textFaint/textMuted are the theme's
-                            // visible-but-subtle element colors and contrast in both light and dark.
-                            unhoverColor = gameChrome.textFaint,
-                            hoverColor = gameChrome.textMuted,
+                            unhoverColor = scrollbar.thumb,
+                            hoverColor = scrollbar.thumb,
                         ),
                 )
             }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/MeasuredScrollbarAdapter.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/MeasuredScrollbarAdapter.kt
@@ -1,0 +1,25 @@
+package warlockfe.warlock3.compose.desktop.ui.window
+
+import androidx.compose.foundation.v2.ScrollbarAdapter
+import warlockfe.warlock3.compose.ui.window.LazyListMeasuredScrollModel
+
+/**
+ * Adapts the platform-agnostic [LazyListMeasuredScrollModel] to the desktop scrollbar's
+ * [ScrollbarAdapter] contract. The model supplies an exact content size built from per-line measured
+ * heights, so the scrollbar thumb keeps a stable size while dragging through stream lines of varying
+ * height (instead of the average-based estimate used by the stock lazy-list adapter).
+ */
+internal class MeasuredScrollbarAdapter(
+    private val model: LazyListMeasuredScrollModel,
+) : ScrollbarAdapter {
+    override val scrollOffset: Double
+        get() = model.scrollOffset
+
+    override val contentSize: Double
+        get() = model.contentSize
+
+    override val viewportSize: Double
+        get() = model.viewportSize
+
+    override suspend fun scrollTo(scrollOffset: Double) = model.scrollTo(scrollOffset)
+}

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/MeasuredScrollbarAdapter.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/MeasuredScrollbarAdapter.kt
@@ -1,0 +1,25 @@
+package warlockfe.warlock3.compose.ui.window
+
+import io.github.oikvpqya.compose.fastscroller.ScrollbarAdapter
+
+/**
+ * Adapts the platform-agnostic [LazyListMeasuredScrollModel] to fastscroller's [ScrollbarAdapter]
+ * contract. The model supplies an exact content size built from per-line measured heights, so the
+ * drag handle keeps a stable length while scrolling through stream lines of varying height instead
+ * of the average-based estimate used by `rememberScrollbarAdapter`. This is the mobile counterpart
+ * to the desktop adapter, which implements the native `androidx.compose.foundation.v2` interface.
+ */
+internal class MeasuredScrollbarAdapter(
+    private val model: LazyListMeasuredScrollModel,
+) : ScrollbarAdapter {
+    override val scrollOffset: Double
+        get() = model.scrollOffset
+
+    override val contentSize: Double
+        get() = model.contentSize
+
+    override val viewportSize: Double
+        get() = model.viewportSize
+
+    override suspend fun scrollTo(scrollOffset: Double) = model.scrollTo(scrollOffset)
+}

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowView.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import io.github.oikvpqya.compose.fastscroller.VerticalScrollbar
-import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import warlockfe.warlock3.compose.components.ScrollableColumn
@@ -118,13 +117,20 @@ fun WindowView(
                 onCloseClick = onCloseClick,
             )
         },
-        listContainer = { scrollState, _, content ->
-            // The measured-height scroll model (third slot arg) is desktop-only for now; mobile keeps
-            // the stock lazy-list adapter.
+        listContainer = { _, heightModel, content ->
+            // Drive the fastscroller scrollbar from the measured-height scroll model (the same height
+            // logic the desktop scrollbar uses) so the drag handle's length stays stable instead of
+            // jumping when lines wrap to different heights, which is what the stock lazy-list adapter's
+            // visible-average estimate causes.
+            // TODO: migrate to Modifier.scrollIndicator once foundation ships ScrollIndicatorFactory +
+            // the scrollIndicator modifier (absent in foundation 1.11.2; only the read-only
+            // ScrollIndicatorState exists). It would need a custom ScrollIndicatorState wrapping this
+            // model (Double -> Int) and is draw-only, so keep fastscroller for the drag-to-scroll thumb.
             Box(Modifier.fillMaxSize()) {
                 content()
+                val adapter = remember(heightModel) { MeasuredScrollbarAdapter(heightModel) }
                 VerticalScrollbar(
-                    adapter = rememberScrollbarAdapter(scrollState),
+                    adapter = adapter,
                     style = defaultScrollbarStyle(),
                     modifier =
                         Modifier

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowView.kt
@@ -118,7 +118,9 @@ fun WindowView(
                 onCloseClick = onCloseClick,
             )
         },
-        listContainer = { scrollState, content ->
+        listContainer = { scrollState, _, content ->
+            // The measured-height scroll model (third slot arg) is desktop-only for now; mobile keeps
+            // the stock lazy-list adapter.
             Box(Modifier.fillMaxSize()) {
                 content()
                 VerticalScrollbar(

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowView.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -30,6 +31,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
+import io.github.oikvpqya.compose.fastscroller.ThumbStyle
+import io.github.oikvpqya.compose.fastscroller.TrackStyle
 import io.github.oikvpqya.compose.fastscroller.VerticalScrollbar
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
@@ -129,9 +132,25 @@ fun WindowView(
             Box(Modifier.fillMaxSize()) {
                 content()
                 val adapter = remember(heightModel) { MeasuredScrollbarAdapter(heightModel) }
+                val scrollbar = scrollbarSkinColors
                 VerticalScrollbar(
                     adapter = adapter,
-                    style = defaultScrollbarStyle(),
+                    // Same skin colors the desktop scrollbar uses (gutter track + thumb).
+                    style =
+                        defaultScrollbarStyle(
+                            thumbStyle =
+                                ThumbStyle(
+                                    shape = RoundedCornerShape(4.dp),
+                                    unhoverColor = scrollbar.thumb,
+                                    hoverColor = scrollbar.thumb,
+                                ),
+                            trackStyle =
+                                TrackStyle(
+                                    shape = RoundedCornerShape(4.dp),
+                                    unhoverColor = scrollbar.gutter,
+                                    hoverColor = scrollbar.gutter,
+                                ),
+                        ),
                     modifier =
                         Modifier
                             .align(Alignment.CenterEnd)


### PR DESCRIPTION
## Problem

The stream window scrollbar sized its thumb (drag handle) from the **average height of the currently-visible lines**, because the stock lazy-list scrollbar adapter only knows the items the `LazyColumn` has laid out (`contentSize ≈ averageVisibleItemHeight × itemCount`). When lines wrap to different heights, that average shifts as you drag into a taller/shorter region, so the thumb height jumps around.

## Approach

Track each line's measured height (keyed by stable `serialNumber`, so it survives scrollback trimming and re-filtering) and compute an exact content size / scroll offset from it. Lines that have never been laid out fall back to the running average, so the estimate converges as you scroll; the bottom of the buffer is always exact because visible items are always measured.

- **`LazyListMeasuredScrollModel`** (commonMain) — the shared, platform-agnostic geometry: `contentSize` / `scrollOffset` / `viewportSize` / `scrollTo`, plus a `rendersContent` helper so hidden/collapsed lines correctly contribute 0.
- **Desktop** — Jewel's `VerticallyScrollableContainer` can't take a custom adapter, so it's replaced with the native `VerticalScrollbar` driven by a `MeasuredScrollbarAdapter` (implements `androidx.compose.foundation.v2.ScrollbarAdapter`). Wheel scrolling still rides on the `LazyColumn`.
- **Mobile** — keeps fastscroller's `VerticalScrollbar`, but fed by a `MeasuredScrollbarAdapter` (implements fastscroller's common `ScrollbarAdapter`) instead of `rememberScrollbarAdapter`.

A note on the newer `Modifier.scrollIndicator` API: it would be a natural fit, but its factory + modifier are absent in the resolved foundation 1.11.2 (only the read-only `ScrollIndicatorState` shipped), and it's draw-only (no drag-to-scroll). A TODO marks the migration for when it lands.

## Verification

- `:compose:compileKotlinJvm`, `:compose:compileAndroidMain`, `:compose:jvmTest` all pass; ktlint clean.
- iOS is skipped by default (`iosSkip=true`); the mobile adapter targets fastscroller's common interface so it resolves to the iOS typealias when built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)