### PR TITLE
Set 3-day retention on CI and release artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-reports
+          retention-days: 3
           path: |
             **/build/reports/tests/**
             **/build/test-results/**

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,6 +71,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: release-assets-${{ runner.os }}-${{ matrix.arch }}
+          retention-days: 3
           path: |
             desktopApp/build/compose/binaries/**/*.dmg
             desktopApp/build/compose/binaries/**/*.pkg


### PR DESCRIPTION
## What

Adds `retention-days: 3` to both `actions/upload-artifact` steps:

- **`ci.yaml`** — `test-reports` (uploaded on every push/PR)
- **`release.yaml`** — `release-assets-*` (the per-OS/arch binary bundles)

## Why

The release job uploads ~190 MB binaries for each of 5 OS/arch combos as *intermediate* artifacts, purely to pass them from the build matrix to the `publish` job. Under the default 90-day retention these had accumulated to ~29 GB. They only need to survive within a single workflow run, so 3 days is more than enough. CI `test-reports` are short-lived debugging aids that churn on every push/PR.

This stops the storage from re-accumulating going forward. (Existing artifacts were already purged separately.)

## Notes

- Caches (~9.8 GB) are unaffected: they're not billed storage and auto-evict at the 10 GB cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)