### PR TITLE
Center a lone indicator icon at full size in its slot

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/IndicatorView.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/IndicatorView.kt
@@ -8,8 +8,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -28,9 +30,6 @@ import warlockfe.warlock3.compose.model.SkinImage
 import warlockfe.warlock3.compose.model.SkinObject
 import warlockfe.warlock3.compose.util.LocalSkin
 import warlockfe.warlock3.compose.util.indicatorDrawable
-import warlockfe.warlock3.compose.util.indicatorEntry
-import warlockfe.warlock3.compose.util.indicatorIconModifier
-import warlockfe.warlock3.compose.util.indicatorReference
 import kotlin.math.ceil
 import kotlin.math.sqrt
 
@@ -65,8 +64,8 @@ private val DEFAULT_SLOT_SIZE = 40.dp
 
 /**
  * The grouped status slots of the control bar, laid out as a 3-column, 2-row grid (the six status
- * groups). A lone active status fills its box (or sits at its skin-defined position); when several
- * statuses are co-active in one slot they are shrunk and offset into a packed grid so all are visible
+ * groups). A lone active status fills its box, centered at full size; when several statuses are
+ * co-active in one slot they are shrunk and offset into a packed grid so all are visible
  * instead of stacking on top of each other. The slot's highest-priority active status colors the box
  * (a "lit" accent for posture/concealment, a danger accent for health) and each icon keeps its own
  * accent tint; an inactive slot is an empty bordered box. Colors come from [palette].
@@ -92,7 +91,6 @@ fun IndicatorView(
         )
 
     val skin = LocalSkin.current
-    val reference = skin.indicatorReference()
     val spacing = 4.dp
     val columns = 3
     val rows = groups.chunked(columns)
@@ -114,7 +112,6 @@ fun IndicatorView(
                             indicators = indicators,
                             palette = palette,
                             skin = skin,
-                            reference = reference,
                             indicatorSize = slotSize,
                             shape = shape,
                         )
@@ -132,7 +129,6 @@ private fun IndicatorSlot(
     indicators: Set<String>,
     palette: IndicatorPalette,
     skin: Map<String, SkinObject>,
-    reference: Int,
     indicatorSize: Dp,
     shape: Shape,
     modifier: Modifier = Modifier,
@@ -150,16 +146,15 @@ private fun IndicatorSlot(
         // Pre-resolve to the statuses that actually have an icon so the packed grid has no gaps.
         val icons =
             active.mapNotNull { status ->
-                val entry = skin.indicatorEntry(status) ?: return@mapNotNull null
-                val drawable = entry.indicatorDrawable() ?: return@mapNotNull null
-                Triple(status, entry, drawable)
+                val drawable = skin.indicatorDrawable(status) ?: return@mapNotNull null
+                status to drawable
             }
-        icons.forEachIndexed { index, (status, entry, drawable) ->
+        icons.forEachIndexed { index, (status, drawable) ->
             Image(
                 modifier =
                     if (icons.size == 1) {
-                        // A lone status keeps its skin placement (fills the box, or its skin offset).
-                        indicatorIconModifier(entry, indicatorSize, reference)
+                        // A lone status is centered at full size, filling the slot.
+                        Modifier.fillMaxSize().padding(indicatorSize / 6f)
                     } else {
                         // Co-active statuses are shrunk and offset into a grid so none is hidden.
                         packedIconModifier(index, icons.size, indicatorSize)
@@ -268,8 +263,44 @@ private fun indicatorAccent(
 
 @Preview
 @Composable
-private fun IndicatorPreview() {
+private fun IndicatorPreviewFull() {
     val previewStatuses = listOf("standing", "joined", "bleeding", "webbed", "stunned", "hidden", "diseased", "poisoned")
+    val skin =
+        mapOf(
+            "indicator" to
+                SkinObject(
+                    children = previewStatuses.associateWith { SkinObject(image = SkinImage(name = it)) },
+                ),
+        )
+    val palette =
+        IndicatorPalette(
+            inactiveBackground = Color(0xFF2B2B30),
+            inactiveBorder = Color(0xFF3C3C42),
+            litBackground = Color(0xFF4A3B12),
+            litBorder = Color(0xFFB58A2E),
+            litIcon = Color(0xFFF0C24B),
+            dangerBackground = Color(0xFF4A1416),
+            dangerBorder = Color(0xFFB5403F),
+            dangerIcon = Color(0xFFF26461),
+            deadIcon = Color(0xFFECECEC),
+            joinedBackground = Color(0x383B5BCC),
+            joinedBorder = Color(0xFF5B6BCC),
+            joinedIcon = Color(0xFFAAB4F0),
+        )
+    CompositionLocalProvider(LocalSkin provides skin) {
+        IndicatorView(
+            indicators = previewStatuses.toSet(),
+            palette = palette,
+            shape = RoundedCornerShape(5.dp),
+            modifier = Modifier.height(88.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun IndicatorPreview() {
+    val previewStatuses = listOf("standing", "bleeding", "hidden", "diseased", "poisoned")
     val skin =
         mapOf(
             "indicator" to

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/IndicatorImages.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/IndicatorImages.kt
@@ -1,12 +1,5 @@
 package warlockfe.warlock3.compose.util
 
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.DrawableResource
 import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.generated.resources.allDrawableResources
@@ -16,33 +9,8 @@ import warlockfe.warlock3.core.util.getIgnoringCase
 /** The skin's "indicator" entry for a status (its image + optional position), or null. */
 fun Map<String, SkinObject>.indicatorEntry(status: String): SkinObject? = getIgnoringCase("indicator")?.children?.getIgnoringCase(status)
 
-/** The reference box size the indicator offsets are authored against (the skin's panel size; 24 by default). */
-fun Map<String, SkinObject>.indicatorReference(): Int {
-    val panel = getIgnoringCase("indicator")
-    return panel?.width ?: panel?.height ?: 24
-}
-
 /** The drawable a skin "indicator" entry points at via its image `name`, or null. */
 fun SkinObject?.indicatorDrawable(): DrawableResource? = this?.image?.name?.let { Res.allDrawableResources[it] }
 
 /** Convenience: the drawable for a status, resolved through the skin's "indicator" section. */
 fun Map<String, SkinObject>.indicatorDrawable(status: String): DrawableResource? = indicatorEntry(status).indicatorDrawable()
-
-/**
- * Places one status icon inside its indicator box. Skin offsets ([SkinObject.top]/[left][SkinObject.left]/
- * [width][SkinObject.width]/[height][SkinObject.height]) are authored against a [reference]-unit box
- * and scaled to the actual [boxSize], so several active statuses can sit side by side. An entry with
- * no offsets fills the box (the single-status case).
- */
-fun indicatorIconModifier(
-    entry: SkinObject,
-    boxSize: Dp,
-    reference: Int,
-): Modifier {
-    val positioned = entry.top != null || entry.left != null || entry.width != null || entry.height != null
-    if (!positioned) return Modifier.fillMaxSize().padding(boxSize / 6f)
-    val scale = boxSize / reference.dp
-    return Modifier
-        .offset(x = ((entry.left ?: 0) * scale).dp, y = ((entry.top ?: 0) * scale).dp)
-        .size(width = ((entry.width ?: reference) * scale).dp, height = ((entry.height ?: reference) * scale).dp)
-}


### PR DESCRIPTION
## What

When a status group's slot in the `IndicatorView` holds exactly one icon, draw it filling the slot (centered) instead of honoring the skin's offset/size placement. Slots with two or more co-active statuses keep the packed grid unchanged.

## Why

A lone status icon could be drawn small and off-center when the skin defined an offset for it. The common case (e.g. a single posture) now reads clearly as one large, centered icon.

## Notes

- The skin-offset path (`indicatorIconModifier` / `indicatorReference` in `IndicatorImages.kt`) was reachable only from this single-icon case, so it's now dead code and removed along with its unused imports. Multi-icon slots already use `packedIconModifier`, so nothing visible relied on the offset path.
- This removes the skin's ability to position indicator icons at custom offsets. That capability was already unreachable for multi-icon slots; flagging it in case custom single-icon placement is wanted again later.
- Added an `IndicatorPreview` exercising the single-icon-per-slot layout (the existing all-groups preview is renamed `IndicatorPreviewFull`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)