### PR TITLE
Tolerate legacy string-form UUIDs when reading the prefs DB

### DIFF
--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/adapters/DatabaseConverters.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/adapters/DatabaseConverters.kt
@@ -13,7 +13,16 @@ class DatabaseConverters {
     fun fromWindowLocation(value: WindowLocation): String = value.value
 
     @TypeConverter
-    fun toUuid(databaseValue: ByteArray): Uuid = Uuid.fromByteArray(databaseValue)
+    fun toUuid(databaseValue: ByteArray): Uuid =
+        // New rows store the UUID as 16 raw bytes. Legacy rows (written by old app versions and
+        // carried forward unconverted by MIGRATION_14_16's INSERT..SELECT) hold the 36-char string
+        // form instead, which SQLite's dynamic typing returns as its UTF-8 bytes. Parse whichever we
+        // get so reading these now-retired tables for the one-time DB->TOML migration can't crash.
+        if (databaseValue.size == 16) {
+            Uuid.fromByteArray(databaseValue)
+        } else {
+            Uuid.parse(databaseValue.decodeToString())
+        }
 
     @TypeConverter
     fun fromUUID(value: Uuid): ByteArray = value.toByteArray()

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/adapters/DatabaseConvertersTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/adapters/DatabaseConvertersTest.kt
@@ -1,0 +1,27 @@
+package warlockfe.warlock3.core.prefs.adapters
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+class DatabaseConvertersTest {
+    private val converters = DatabaseConverters()
+
+    @Test
+    fun `round-trips a uuid stored as 16 binary bytes`() {
+        val uuid = Uuid.parse("48856eb8-99a1-48a6-ab7f-0f6692a10000")
+        val stored = converters.fromUUID(uuid)
+        assertEquals(16, stored.size)
+        assertEquals(uuid, converters.toUuid(stored))
+    }
+
+    @Test
+    fun `reads a legacy uuid stored as its 36-char string`() {
+        // Old rows kept the UUID in textual form; SQLite hands those back as their UTF-8 bytes,
+        // which is what crashed production before toUuid learned to parse the string form.
+        val text = "48856eb8-99a1-48a6-ab7f-0f6692a10000"
+        val stored = text.encodeToByteArray()
+        assertEquals(36, stored.size)
+        assertEquals(Uuid.parse(text), converters.toUuid(stored))
+    }
+}


### PR DESCRIPTION
Fixes a fatal `IllegalArgumentException: Expected exactly 16 bytes, but was [...] of size 36` reported from production (`desktop@3.0.166`), thrown while reading the `Highlight` and `Name` tables during the one-time DB->TOML migration at startup.

## Root cause

The failing value is the `id` primary key (the only `Uuid`-typed column in these rows; `characterId` is a plain `String`). The 36 bytes decode to a UUID *string* like `48856eb8-99a1-48a6-ab7f-0f6692a1...`.

- New rows write `id` as 16 raw bytes (`fromUUID` -> `toByteArray()`).
- Legacy rows from old app versions stored `id` as the 36-char UUID string. `MIGRATION_14_16` recreated the tables as `id BLOB` but copied the old values forward with a plain `INSERT..SELECT`, never converting them. SQLite's dynamic typing keeps them as TEXT.
- `toUuid` assumed 16 bytes, so `Uuid.fromByteArray` got the 36-byte UTF-8 text and threw, crashing `ConfigMigration` on the `DefaultDispatcher` worker (uncaught -> fatal).

## Fix

Make the shared `toUuid` converter parse whichever form it gets:

```kotlin
fun toUuid(databaseValue: ByteArray): Uuid =
    if (databaseValue.size == 16) {
        Uuid.fromByteArray(databaseValue)
    } else {
        Uuid.parse(databaseValue.decodeToString())
    }
```

`toUuid` is the single converter for every `Uuid` column (Highlight/Name/Alias/Alteration `id`, `HighlightStyle.highlightId`), so this covers all of them at once. The sizes are unambiguous: a binary UUID is always 16 bytes, the string form is 36. No schema-version bump, since a data migration would be heavy and pointless for tables that are being retired into TOML.

Added `DatabaseConvertersTest` covering both the binary and legacy-string paths.

## Verification

`:core:compileKotlinJvm`, ktlint (main + test), and `:core:jvmTest --tests DatabaseConvertersTest` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)