### PR TITLE
Rework the font picker: search, live preview, compact two-tier dialog

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/components/FontInfo.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/components/FontInfo.kt
@@ -1,6 +1,7 @@
 package warlockfe.warlock3.compose.components
 
 import androidx.compose.ui.text.font.FontFamily
+import kotlin.math.roundToInt
 
 internal data class FontFamilyInfo(
     val familyName: String,
@@ -32,5 +33,37 @@ val fontWeightOptions =
         FontWeightInfo("Extra Bold", 800),
         FontWeightInfo("Black", 900),
     )
+
+internal val genericFontFamilies =
+    listOf(
+        FontFamilyInfo("Default", FontFamily.Default),
+        FontFamilyInfo("Serif", FontFamily.Serif),
+        FontFamilyInfo("SansSerif", FontFamily.SansSerif),
+        FontFamilyInfo("Monospace", FontFamily.Monospace),
+        FontFamilyInfo("Cursive", FontFamily.Cursive),
+    )
+
+// Sample text for the font preview. ASCII only; includes digits and symbols because game text is
+// full of stat numbers.
+internal const val FONT_PICKER_SAMPLE_TEXT = "The quick brown fox 0123456789 +-/%"
+
+internal const val MIN_FONT_SIZE = 6f
+internal const val MAX_FONT_SIZE = 72f
+internal const val FONT_SIZE_STEP = 1f
+
+internal fun filterFontFamilies(
+    families: List<FontFamilyInfo>,
+    query: String,
+): List<FontFamilyInfo> {
+    val trimmed = query.trim()
+    if (trimmed.isEmpty()) return families
+    return families.filter { it.familyName.contains(trimmed, ignoreCase = true) }
+}
+
+/** A compact size readout: "14" for whole numbers, otherwise one decimal ("13.5"). */
+internal fun formatFontSize(size: Float): String {
+    val rounded = (size * 10f).roundToInt() / 10f
+    return if (rounded % 1f == 0f) rounded.toInt().toString() else rounded.toString()
+}
 
 internal expect suspend fun loadSystemFonts(): List<FontFamilyInfo>

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/components/FontPickerState.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/components/FontPickerState.kt
@@ -1,0 +1,80 @@
+package warlockfe.warlock3.compose.components
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.text.font.FontFamily
+import warlockfe.warlock3.compose.util.createFontFamily
+import warlockfe.warlock3.core.text.StyleDefinition
+
+/**
+ * Shared state for the font picker dialogs (desktop Jewel + mobile Material3). Owns the selected
+ * family/size/weight, the family-search query, and the asynchronously loaded font list, and derives
+ * the filtered list plus a combined preview style. Both platform dialogs are thin views over this.
+ */
+internal class FontPickerState(
+    initialFamily: String,
+    private val seedSize: Float,
+    initialWeight: Int?,
+) {
+    val sizeFieldState = TextFieldState(formatFontSize(seedSize.coerceIn(MIN_FONT_SIZE, MAX_FONT_SIZE)))
+    val queryState = TextFieldState()
+
+    var selectedFamily by mutableStateOf(initialFamily)
+    var weight by mutableStateOf(initialWeight)
+    var familyPickerOpen by mutableStateOf(false)
+
+    // Seeded with the generic families so the list is never empty during the async system-font load;
+    // fontsLoaded is a real flag (not list-size derived) so the loading hint clears even on mobile,
+    // where loadSystemFonts() legitimately returns an empty list.
+    var allFamilies by mutableStateOf(genericFontFamilies)
+    var fontsLoaded by mutableStateOf(false)
+
+    /** The parsed, clamped size; invalid/empty input falls back to the seed so it is never null. */
+    val effectiveSize: Float by derivedStateOf {
+        sizeFieldState.text
+            .toString()
+            .toFloatOrNull()
+            ?.coerceIn(MIN_FONT_SIZE, MAX_FONT_SIZE) ?: seedSize
+    }
+
+    val filteredFamilies: List<FontFamilyInfo> by derivedStateOf {
+        filterFontFamilies(allFamilies, queryState.text.toString())
+    }
+
+    /** The selected family resolved to a Compose FontFamily, for the live preview. */
+    val previewFontFamily: FontFamily by derivedStateOf { createFontFamily(selectedFamily) }
+
+    fun stepSize(delta: Float) {
+        val next = (effectiveSize + delta).coerceIn(MIN_FONT_SIZE, MAX_FONT_SIZE)
+        sizeFieldState.setTextAndPlaceCursorAtEnd(formatFontSize(next))
+    }
+
+    fun toFontUpdate(): FontUpdate = FontUpdate(size = effectiveSize, fontFamily = selectedFamily, weight = weight)
+}
+
+@Composable
+internal fun rememberFontPickerState(
+    currentStyle: StyleDefinition,
+    defaultSize: Float,
+): FontPickerState {
+    val state =
+        remember(currentStyle) {
+            FontPickerState(
+                initialFamily = currentStyle.fontFamily ?: "Default",
+                seedSize = currentStyle.fontSize ?: defaultSize,
+                initialWeight = currentStyle.fontWeight,
+            )
+        }
+    LaunchedEffect(state) {
+        state.allFamilies = genericFontFamilies + loadSystemFonts()
+        state.fontsLoaded = true
+    }
+    return state
+}

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/components/DesktopFontPickerDialog.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/components/DesktopFontPickerDialog.kt
@@ -4,38 +4,37 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.VerticallyScrollableContainer
-import warlockfe.warlock3.compose.components.FontFamilyInfo
+import warlockfe.warlock3.compose.components.FONT_PICKER_SAMPLE_TEXT
+import warlockfe.warlock3.compose.components.FONT_SIZE_STEP
+import warlockfe.warlock3.compose.components.FontPickerState
 import warlockfe.warlock3.compose.components.FontUpdate
 import warlockfe.warlock3.compose.components.fontWeightOptions
-import warlockfe.warlock3.compose.components.loadSystemFonts
+import warlockfe.warlock3.compose.components.rememberFontPickerState
 import warlockfe.warlock3.compose.desktop.shim.WarlockButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockDialog
 import warlockfe.warlock3.compose.desktop.shim.WarlockDropdownSelect
@@ -50,26 +49,96 @@ fun DesktopFontPickerDialog(
     onCloseRequest: () -> Unit,
     onSaveClick: (FontUpdate) -> Unit,
 ) {
-    val initialFontSize = currentStyle.fontSize ?: JewelTheme.defaultTextStyle.fontSize.value
-    val size = rememberTextFieldState(initialFontSize.toString())
-    var newFontFamily by remember(currentStyle.fontFamily) {
-        mutableStateOf(currentStyle.fontFamily ?: "Default")
-    }
-    var newWeight by remember(currentStyle.fontWeight) {
-        mutableStateOf(currentStyle.fontWeight)
-    }
-    var systemFontFamilies by remember { mutableStateOf(emptyList<FontFamilyInfo>()) }
-
-    LaunchedEffect(Unit) {
-        systemFontFamilies = loadSystemFonts()
-    }
-
-    val families = remember(systemFontFamilies) { genericFontFamilies + systemFontFamilies }
-    val listState = rememberLazyListState()
+    val state = rememberFontPickerState(currentStyle, JewelTheme.defaultTextStyle.fontSize.value)
 
     WarlockDialog(
         title = "Choose a font",
         onCloseRequest = onCloseRequest,
+        width = 460.dp,
+        height = 320.dp,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Single live preview of the combined family + size + weight.
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(64.dp)
+                        .border(Dp.Hairline, JewelTheme.globalColors.borders.normal, RoundedCornerShape(6.dp))
+                        .padding(horizontal = 12.dp),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                Text(
+                    text = FONT_PICKER_SAMPLE_TEXT,
+                    fontFamily = state.previewFontFamily,
+                    fontSize = state.effectiveSize.sp,
+                    fontWeight = state.weight?.let { FontWeight(it) },
+                    maxLines = 2,
+                )
+            }
+
+            // The font family list lives in its own sub-dialog to keep this one uncluttered.
+            WarlockOutlinedButton(
+                onClick = { state.familyPickerOpen = true },
+                text = "Family: ${state.selectedFamily}",
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text("Weight", modifier = Modifier.width(48.dp))
+                WarlockDropdownSelect(
+                    items = fontWeightOptions,
+                    selected = fontWeightOptions.firstOrNull { it.weight == state.weight } ?: fontWeightOptions.first(),
+                    onSelect = { state.weight = it.weight },
+                    itemLabelBuilder = { it.label },
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text("Size", modifier = Modifier.width(48.dp))
+                WarlockOutlinedButton(onClick = { state.stepSize(-FONT_SIZE_STEP) }, text = "-")
+                WarlockTextField(state = state.sizeFieldState, modifier = Modifier.width(72.dp))
+                WarlockOutlinedButton(onClick = { state.stepSize(FONT_SIZE_STEP) }, text = "+")
+            }
+
+            Spacer(Modifier.weight(1f))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                WarlockOutlinedButton(
+                    onClick = { onSaveClick(FontUpdate(null, null)) },
+                    text = "Reset to defaults",
+                )
+                Spacer(Modifier.weight(1f))
+                WarlockOutlinedButton(onClick = onCloseRequest, text = "Cancel")
+                WarlockButton(onClick = { onSaveClick(state.toFontUpdate()) }, text = "Save")
+            }
+        }
+    }
+
+    if (state.familyPickerOpen) {
+        DesktopFontFamilyPickerDialog(state = state)
+    }
+}
+
+@Composable
+private fun DesktopFontFamilyPickerDialog(state: FontPickerState) {
+    val listState = rememberLazyListState()
+    WarlockDialog(
+        title = "Choose a font family",
+        onCloseRequest = { state.familyPickerOpen = false },
         width = 500.dp,
         height = 540.dp,
     ) {
@@ -77,22 +146,14 @@ fun DesktopFontPickerDialog(
             modifier = Modifier.fillMaxSize().padding(8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text("Size")
-            WarlockTextField(state = size, modifier = Modifier.fillMaxWidth())
-
-            Text("Weight")
-            WarlockDropdownSelect(
-                items = fontWeightOptions,
-                selected = fontWeightOptions.firstOrNull { it.weight == newWeight } ?: fontWeightOptions.first(),
-                onSelect = { newWeight = it.weight },
+            WarlockTextField(
+                state = state.queryState,
                 modifier = Modifier.fillMaxWidth(),
-                itemLabelBuilder = { it.label },
+                placeholder = "Search fonts",
             )
-
-            if (systemFontFamilies.isEmpty()) {
-                Text("Loading system fonts…")
+            if (!state.fontsLoaded) {
+                Text("Loading system fonts...")
             }
-
             VerticallyScrollableContainer(
                 scrollState = listState,
                 modifier =
@@ -106,8 +167,8 @@ fun DesktopFontPickerDialog(
                         .weight(1f),
             ) {
                 LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-                    items(families, key = { it.familyName }) { family ->
-                        val isSelected = family.familyName == newFontFamily
+                    items(state.filteredFamilies, key = { it.familyName }) { family ->
+                        val isSelected = family.familyName == state.selectedFamily
                         val rowBackground =
                             if (isSelected) {
                                 JewelTheme.globalColors.borders.normal
@@ -119,8 +180,10 @@ fun DesktopFontPickerDialog(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable { newFontFamily = family.familyName }
-                                    .background(rowBackground)
+                                    .clickable {
+                                        state.selectedFamily = family.familyName
+                                        state.familyPickerOpen = false
+                                    }.background(rowBackground)
                                     .padding(horizontal = 8.dp, vertical = 8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
@@ -136,38 +199,6 @@ fun DesktopFontPickerDialog(
                     }
                 }
             }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
-            ) {
-                WarlockOutlinedButton(
-                    onClick = { onSaveClick(FontUpdate(null, null)) },
-                    text = "Reset to defaults",
-                )
-                Spacer(Modifier.weight(1f))
-                WarlockOutlinedButton(onClick = onCloseRequest, text = "Cancel")
-                WarlockButton(
-                    onClick = {
-                        onSaveClick(
-                            FontUpdate(
-                                size = size.text.toString().toFloatOrNull(),
-                                fontFamily = newFontFamily,
-                                weight = newWeight,
-                            ),
-                        )
-                    },
-                    text = "Save",
-                )
-            }
         }
     }
 }
-
-private val genericFontFamilies =
-    listOf(
-        FontFamilyInfo("Default", FontFamily.Default),
-        FontFamilyInfo("Serif", FontFamily.Serif),
-        FontFamilyInfo("SansSerif", FontFamily.SansSerif),
-        FontFamilyInfo("Monospace", FontFamily.Monospace),
-        FontFamilyInfo("Cursive", FontFamily.Cursive),
-    )

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/components/FontPickerDialog.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/components/FontPickerDialog.kt
@@ -3,11 +3,14 @@ package warlockfe.warlock3.compose.components
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
@@ -20,16 +23,17 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import warlockfe.warlock3.core.text.StyleDefinition
 
 @Composable
@@ -38,50 +42,51 @@ fun FontPickerDialog(
     onCloseRequest: () -> Unit,
     onSaveClick: (FontUpdate) -> Unit,
 ) {
-    val initialFontSize = currentStyle.fontSize ?: MaterialTheme.typography.bodyMedium.fontSize.value
-    val size = rememberTextFieldState(initialFontSize.toString())
-    var newFontFamily by remember(currentStyle.fontFamily) {
-        mutableStateOf(currentStyle.fontFamily ?: "Default")
-    }
-    var newWeight by remember(currentStyle.fontWeight) {
-        mutableStateOf(currentStyle.fontWeight)
-    }
-    var weightMenuExpanded by remember { mutableStateOf(false) }
-    var systemFontFamilies by remember { mutableStateOf(emptyList<FontFamilyInfo>()) }
+    val state = rememberFontPickerState(currentStyle, MaterialTheme.typography.bodyMedium.fontSize.value)
 
-    LaunchedEffect(Unit) {
-        systemFontFamilies = loadSystemFonts()
-    }
     AlertDialog(
         onDismissRequest = onCloseRequest,
         title = { Text("Choose a font") },
-        confirmButton = {
-            Button(onClick = {
-                onSaveClick(
-                    FontUpdate(
-                        size = size.text.toString().toFloatOrNull(),
-                        fontFamily = newFontFamily,
-                        weight = newWeight,
-                    ),
-                )
-            }) {
-                Text("Save")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onCloseRequest) {
-                Text("Cancel")
-            }
-        },
+        confirmButton = { Button(onClick = { onSaveClick(state.toFontUpdate()) }) { Text("Save") } },
+        dismissButton = { TextButton(onClick = onCloseRequest) { Text("Cancel") } },
         text = {
             Column(
-                modifier = Modifier.padding(16.dp).fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                OutlinedTextField(state = size)
+                // Single live preview of the combined family + size + weight.
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(56.dp)
+                            .border(
+                                Dp.Hairline,
+                                MaterialTheme.colorScheme.outline,
+                                MaterialTheme.shapes.medium,
+                            ).padding(horizontal = 12.dp),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    Text(
+                        text = FONT_PICKER_SAMPLE_TEXT,
+                        fontFamily = state.previewFontFamily,
+                        fontSize = state.effectiveSize.sp,
+                        fontWeight = state.weight?.let { FontWeight(it) },
+                        maxLines = 2,
+                    )
+                }
 
-                val weightLabel = fontWeightOptions.firstOrNull { it.weight == newWeight }?.label ?: "Default"
-                Column {
+                // The font family list lives in its own sub-dialog to keep this one uncluttered.
+                OutlinedButton(
+                    onClick = { state.familyPickerOpen = true },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Family: ${state.selectedFamily}")
+                }
+
+                var weightMenuExpanded by remember { mutableStateOf(false) }
+                val weightLabel = fontWeightOptions.firstOrNull { it.weight == state.weight }?.label ?: "Default"
+                Box {
                     OutlinedButton(onClick = { weightMenuExpanded = true }) {
                         Text("Weight: $weightLabel")
                     }
@@ -93,7 +98,7 @@ fun FontPickerDialog(
                             DropdownMenuItem(
                                 text = { Text(option.label) },
                                 onClick = {
-                                    newWeight = option.weight
+                                    state.weight = option.weight
                                     weightMenuExpanded = false
                                 },
                             )
@@ -101,6 +106,49 @@ fun FontPickerDialog(
                     }
                 }
 
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text("Size")
+                    OutlinedButton(onClick = { state.stepSize(-FONT_SIZE_STEP) }) { Text("-") }
+                    OutlinedTextField(state = state.sizeFieldState, modifier = Modifier.width(96.dp))
+                    OutlinedButton(onClick = { state.stepSize(FONT_SIZE_STEP) }) { Text("+") }
+                }
+
+                TextButton(onClick = { onSaveClick(FontUpdate(null, null)) }) {
+                    Text("Reset to defaults")
+                }
+            }
+        },
+    )
+
+    if (state.familyPickerOpen) {
+        FontFamilyPickerDialog(state = state)
+    }
+}
+
+@Composable
+private fun FontFamilyPickerDialog(state: FontPickerState) {
+    AlertDialog(
+        onDismissRequest = { state.familyPickerOpen = false },
+        title = { Text("Choose a font family") },
+        confirmButton = {
+            TextButton(onClick = { state.familyPickerOpen = false }) { Text("Close") }
+        },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                OutlinedTextField(
+                    state = state.queryState,
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = { Text("Search fonts") },
+                )
+                if (!state.fontsLoaded) {
+                    Text("Loading system fonts...")
+                }
                 ScrollableColumn(
                     modifier =
                         Modifier
@@ -109,17 +157,18 @@ fun FontPickerDialog(
                                 color = MaterialTheme.colorScheme.outline,
                                 shape = MaterialTheme.shapes.medium,
                             ).clip(MaterialTheme.shapes.medium)
-                            .fillMaxWidth(),
+                            .fillMaxWidth()
+                            .heightIn(max = 280.dp),
                 ) {
-                    (genericFontFamilies + systemFontFamilies).forEach { fontFamily ->
+                    state.filteredFamilies.forEach { family ->
                         ListItem(
                             modifier =
-                                Modifier
-                                    .clickable {
-                                        newFontFamily = fontFamily.familyName
-                                    },
+                                Modifier.clickable {
+                                    state.selectedFamily = family.familyName
+                                    state.familyPickerOpen = false
+                                },
                             colors =
-                                if (fontFamily.familyName == newFontFamily) {
+                                if (family.familyName == state.selectedFamily) {
                                     ListItemDefaults.colors(
                                         containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.2f),
                                     )
@@ -129,27 +178,15 @@ fun FontPickerDialog(
                             headlineContent = {
                                 Text(
                                     text = "The quick brown fox jumps over the lazy dog",
-                                    fontFamily = fontFamily.fontFamily,
+                                    fontFamily = family.fontFamily,
                                     maxLines = 1,
                                 )
                             },
-                            supportingContent = { Text(text = fontFamily.familyName) },
+                            supportingContent = { Text(text = family.familyName) },
                         )
                     }
-                }
-                Button(onClick = { onSaveClick(FontUpdate(null, null)) }) {
-                    Text("Reset to defaults")
                 }
             }
         },
     )
 }
-
-private val genericFontFamilies =
-    listOf(
-        FontFamilyInfo("Default", FontFamily.Default),
-        FontFamilyInfo("Serif", FontFamily.Serif),
-        FontFamilyInfo("SansSerif", FontFamily.SansSerif),
-        FontFamilyInfo("Monospace", FontFamily.Monospace),
-        FontFamilyInfo("Cursive", FontFamily.Cursive),
-    )


### PR DESCRIPTION
## Why

The font picker (`DesktopFontPickerDialog` / `FontPickerDialog`) was hard to use: a raw size field with no validation, no search over the 100+ system fonts, no preview of the combined choice, and a cluttered single dialog dominated by the family list.

## What

Keeps the exact `(currentStyle, onCloseRequest, onSaveClick) -> FontUpdate` contract; all 6 call sites (progress-bar context menu, appearance presets, window settings - desktop + mobile) are untouched.

**Compact main dialog:**
- A single **live preview** of the selected family + size + weight.
- A **`Family: <name>` button** that opens the family list in its own **sub-dialog** (the declutter).
- The **weight** dropdown (unchanged).
- A **size** number field with `-`/`+` steppers, parsed and clamped to `[6, 72]` (fixes the silent-null-on-bad-input bug).
- Reset / Cancel / Save.

**Family sub-dialog:** a **search box** filtering the family list + the scrollable list (each row rendered in its own font).

**Shared logic:** a new `commonMain` `FontPickerState` + `rememberFontPickerState` own selection/search/filtering/derived preview and the async font load; `FontInfo.kt` now hosts the previously-duplicated `genericFontFamilies` plus `filterFontFamilies` / `formatFontSize` / sample text / size bounds. Each platform dialog is a thin view over it.

## Test plan

- [x] `:compose:compileKotlinJvm`, `:compose:compileAndroidMain`, `:compose:compileKotlinMetadata`
- [x] `:compose:ktlintCheck`
- [ ] Manual: open via the 3 desktop entry points (progress-bar font menu, Settings > Appearance preset font, window settings font) - search filters the list, the number field + `-`/`+` clamp, the live preview reflects family + size + weight, Save round-trips, Reset restores defaults; repeat on Android (family list is the 5 generics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
