### PR TITLE
Fix Windows legacy prefs migration from Conveyor's MSIX location

### DIFF
--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -844,12 +844,19 @@ private fun migrateLegacyWindowsPrefsDb(
     val localAppData =
         System.getenv("LOCALAPPDATA")
             ?: File(System.getProperty("user.home"), "AppData/Local").absolutePath
-    val legacyDir =
-        File(localAppData, "Packages/Warlock_ysy1438y9wgam/LocalCache/Local/WarlockFE")
-    val legacyDb = File(legacyDir, "prefs.db")
-    if (!legacyDb.exists()) {
-        return
-    }
+    // Conveyor shipped Warlock as an MSIX package, so the app ran sandboxed and its writes to
+    // %LOCALAPPDATA%\WarlockFE\warlock were virtualized into the package's per-user LocalCache mirror at
+    // %LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalCache\Local\WarlockFE\warlock. The publisher-hash
+    // suffix of the family name depends on the signing identity, so match any Warlock_* package directory;
+    // if several exist (e.g. re-signed under a new identity), migrate the most recently written database.
+    val legacyDb =
+        File(localAppData, "Packages")
+            .listFiles { file -> file.isDirectory && file.name.startsWith("Warlock_", ignoreCase = true) }
+            ?.map { File(it, "LocalCache/Local/WarlockFE/warlock/prefs.db") }
+            ?.filter { it.exists() }
+            ?.maxByOrNull { it.lastModified() }
+            ?: return
+    val legacyDir = legacyDb.parentFile
     logger.i { "Migrating legacy prefs database from ${legacyDb.absolutePath} to ${configDbFile.absolutePath}" }
     try {
         legacyDb.copyTo(configDbFile, overwrite = false)


### PR DESCRIPTION
## Summary

Desktop packaging recently moved from Conveyor (MSIX) to NSIS via Potassium (#207). `migrateLegacyWindowsPrefsDb` carries a returning Windows user's `prefs.db` forward from the old Conveyor install, but it was looking in the wrong place, so the migration silently never ran.

Conveyor packaged Warlock as an MSIX, so the app ran sandboxed and its writes to `%LOCALAPPDATA%\WarlockFE\warlock` were virtualized into the package's per-user LocalCache mirror:

```
%LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalCache\Local\WarlockFE\warlock\prefs.db
```

Two problems with the old source path:

- **Missing the `warlock` (appName) leaf.** It stopped at `...\LocalCache\Local\WarlockFE`. `appDirs.getUserConfigDir()` appends both `appAuthor` (`WarlockFE`) and `appName` (`warlock`), and the Conveyor-era code used the same two values, so the real DB sat one directory deeper. The `exists()` check always failed and returning users silently started fresh.
- **Hardcoded publisher hash.** It pinned `Warlock_ysy1438y9wgam`, but the publisher-hash suffix of an MSIX package family name depends on the signing identity.

## Fix

Scan `%LOCALAPPDATA%\Packages` for any `Warlock_*` directory (case-insensitive), append the correct `LocalCache/Local/WarlockFE/warlock/prefs.db` suffix, and if more than one matches (e.g. re-signed under a new identity) migrate the most recently written DB.

## Notes

- This migrates `prefs.db` (and its `-wal`/`-shm`). Per-character TOML config stranded in the same old sandbox folder is not carried over; out of scope here.
- Verified appdirs resolves `LOCAL_APPDATA` via the Win32 `FOLDERID_LocalAppData` known-folder API, which under MSIX returns the real `AppData\Local` while file virtualization does the LocalCache mirroring, confirming the `LocalCache\Local\WarlockFE\warlock` layout.

## Testing

`:desktopApp:compileKotlin` and `:desktopApp:ktlintMainSourceSetCheck` pass. (Behavior is Windows-only and could not be exercised on this Linux host.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)