### PR TITLE
Build the Intel macOS package on the macos-26-intel runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
             arch: amd64
           - os: macos-latest
             arch: arm64
-          - os: macos-15-intel
+          - os: macos-26-intel
             arch: amd64
 
     env:


### PR DESCRIPTION
Updates the Intel (amd64) macOS build job from `macos-15-intel` to `macos-26-intel`. GitHub's `macos-15-intel` image is aging out; `macos-26-intel` is the current Intel macOS 26 runner.

Note: `macos-26-latest` is not a valid runner label - the versioned Intel image is `macos-26-intel` (Apple Silicon is `macos-26`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)