### PR TITLE
Finalize xmlutil 1.0.0 and fix deprecation warnings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,7 +74,7 @@ sentryKotlin = "0.27.0"
 slf4j = "2.0.18"
 slf4jAndroid = "2.0.17-0"
 uri = "0.0.21"
-xmlutil = "1.0.0-rc3"
+xmlutil = "1.0.0"
 
 compileSdk = "36"
 minSdk = "26"

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/ScriptManagerImpl.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/ScriptManagerImpl.kt
@@ -102,7 +102,7 @@ class ScriptManagerImpl(
             argumentString = argString ?: "",
             onStop = {
                 externalScope.launch {
-                    _runningScripts.update { it.remove(instance.id) }
+                    _runningScripts.update { it.removing(instance.id) }
                     client.print(StyledString("Script has finished: ${instance.name}", style = WarlockStyle.Echo))
                 }
             },

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/settings/WraythImporter.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/settings/WraythImporter.kt
@@ -175,8 +175,8 @@ class WraythImporter(
 
     internal fun importString(text: String): WraythSettings {
         val parser =
-            XML {
-                defaultPolicy {
+            XML.v1 {
+                policy {
                     pedantic = false
                     ignoreUnknownChildren()
                 }


### PR DESCRIPTION
## Summary

Finalizes the xmlutil upgrade to the stable **1.0.0** release (from `1.0.0-rc3`) and clears the two deprecation warnings that remained in the build.

## Changes

- **Wrayth settings importer** (`WraythImporter`): migrate from the deprecated `XML {}` constructor to `XML.v1 { policy { ... } }`. xmlutil 1.0.0 deprecates the old constructor as well as the `XML.compat` property/function, steering all usage to the versioned `XML.v1` object. Within `v1`, `defaultPolicy {}` is itself deprecated in favor of `policy {}`.
- **Scripting** (`ScriptManagerImpl`): replace the deprecated `PersistentMap.remove(key)` with `removing()` (kotlinx.collections.immutable renamed it to avoid clashing with `MutableMap.remove`).

## Behavior

`XML.v1` uses a stricter base policy than the old constructor, which matters here because `WraythSettings` has unannotated primitive fields whose attribute-vs-element decoding depends on policy defaults. The existing `WraythSettingsTests.testSettings` — which decodes a representative StormFront/Wrayth settings file and asserts on parsed colors and macro counts — still passes, and the lenient flags (`pedantic = false`, `ignoreUnknownChildren()`) are preserved.

A full-project compile (JVM + metadata + desktop/compose/android) reports zero deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)