### PR TITLE
Add WslValue.toText() for script-facing string conversion

### DIFF
--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslCommands.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslCommands.kt
@@ -348,7 +348,7 @@ private suspend fun shiftCommand(
         }
         i++
     }
-    val allArgs = context.lookupVariable("0").toString()
+    val allArgs = context.lookupVariable("0")?.toText() ?: ""
     val breakIndex = findArgumentBreak(allArgs)
     context.setScriptVariable(
         name = "0",

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslComponents.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslComponents.kt
@@ -5,6 +5,8 @@ import warlockfe.warlock3.core.client.WarlockClient
 class WslComponents(
     private val client: WarlockClient,
 ) : WslValue {
+    override fun toText(): String = client.getComponents().toString()
+
     override fun toString(): String = client.getComponents().toString()
 
     override fun toBoolean(): Boolean = false

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslNumeric.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslNumeric.kt
@@ -1,5 +1,7 @@
 package warlockfe.warlock3.scripting.wsl
 
+import kotlin.math.floor
+
 abstract class WslNumeric : WslValue {
     override fun toBoolean(): Boolean = throw WslRuntimeException("Attempted to use number as a boolean")
 
@@ -10,21 +12,23 @@ abstract class WslNumeric : WslValue {
         value: WslValue,
     ) {}
 
-    override fun toString(): String {
+    override fun toText(): String {
         val n = toNumber()
-        return if (n == kotlin.math.floor(n) && !n.isInfinite()) {
+        return if (n == floor(n) && !n.isInfinite()) {
             n.toLong().toString()
         } else {
             n.toString()
         }
     }
 
+    override fun toString(): String = toText()
+
     override fun equals(other: Any?): Boolean =
         when {
             other !is WslValue -> false
             other.isBoolean() -> toBoolean() == other.toBoolean()
             other.isNumeric() -> toNumber() == other.toNumber()
-            else -> toString().equals(other = other.toString(), ignoreCase = true)
+            else -> toText().equals(other = other.toText(), ignoreCase = true)
         }
 
     override fun hashCode(): Int = toNumber().hashCode()

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslScript.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslScript.kt
@@ -364,13 +364,13 @@ sealed class WslCommandContent {
     data class Variable(
         val name: String,
     ) : WslCommandContent() {
-        override fun getValue(context: WslContext): String = context.lookupVariable(name)?.toString() ?: ""
+        override fun getValue(context: WslContext): String = context.lookupVariable(name)?.toText() ?: ""
     }
 
     data class Expression(
         val expression: WslExpression,
     ) : WslCommandContent() {
-        override fun getValue(context: WslContext): String = expression.getValue(context).toString()
+        override fun getValue(context: WslContext): String = expression.getValue(context).toText()
     }
 
     abstract fun getValue(context: WslContext): String
@@ -466,17 +466,17 @@ enum class WslInfixOperator {
             value2: WslValue,
         ): WslValue {
             if (value1.isMap()) {
-                val property = value1.getProperty(value2.toString())
+                val property = value1.getProperty(value2.toText())
                 return WslBoolean(!property.isNull())
             }
-            return WslBoolean(value1.toString().contains(value2.toString()))
+            return WslBoolean(value1.toText().contains(value2.toText()))
         }
     },
     CONTAINSRE {
         override fun getValue(
             value1: WslValue,
             value2: WslValue,
-        ): WslValue = WslBoolean(value1.toString().contains(value2.toString().toRegex()))
+        ): WslValue = WslBoolean(value1.toText().contains(value2.toText().toRegex()))
     }, ;
 
     abstract fun getValue(
@@ -507,7 +507,7 @@ enum class WslAdditiveOperator {
             if (value1.isNumeric() && value2.isNumeric()) {
                 WslNumber(value1.toNumber() + value2.toNumber())
             } else {
-                WslString(value1.toString() + value2.toString())
+                WslString(value1.toText() + value2.toText())
             }
     },
     SUB {
@@ -548,7 +548,7 @@ enum class WslMultiplicativeOperator {
             return if (value1.isNumeric()) {
                 WslNumber(value1.toNumber() * value2.toNumber())
             } else {
-                WslString(value1.toString().repeat(value2.toNumber().toInt()))
+                WslString(value1.toText().repeat(value2.toNumber().toInt()))
             }
         }
     },
@@ -611,7 +611,7 @@ data class WslPostfixUnaryExpression(
     fun getValue(context: WslContext): WslValue {
         var acc = primaryExpression.getValue(context)
         indexingSuffixes.forEach {
-            val key = it.getValue(context).toString()
+            val key = it.getValue(context).toText()
             acc = acc.getProperty(key)
         }
         return acc
@@ -678,7 +678,7 @@ sealed class WslStringContent {
     data class Variable(
         val name: String,
     ) : WslStringContent() {
-        override fun getValue(context: WslContext): String = context.lookupVariable(name).toString()
+        override fun getValue(context: WslContext): String = context.lookupVariable(name)?.toText() ?: ""
     }
 
     abstract fun getValue(context: WslContext): String

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslValue.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslValue.kt
@@ -5,6 +5,13 @@ interface WslValue {
 
     fun toNumber(): Double
 
+    /**
+     * The script-facing string representation of this value. Use this (not [toString]) wherever a
+     * script observes a value as text - variable substitution, concatenation, comparison, etc.
+     * [toString] is reserved for debugging/logging.
+     */
+    fun toText(): String
+
     fun isNumeric(): Boolean
 
     fun isBoolean(): Boolean
@@ -27,7 +34,7 @@ interface WslValue {
         if (isNumeric() && other.isNumeric()) {
             return compare(operator, toNumber(), other.toNumber())
         }
-        return compare(operator, toString(), other.toString())
+        return compare(operator, toText(), other.toText())
     }
 }
 
@@ -47,7 +54,9 @@ class WslBoolean(
         value: WslValue,
     ) { }
 
-    override fun toString(): String = if (value) "true" else "false"
+    override fun toText(): String = if (value) "true" else "false"
+
+    override fun toString(): String = toText()
 
     override fun equals(other: Any?): Boolean =
         when (other) {
@@ -80,6 +89,8 @@ class WslString(
             ?: throw WslRuntimeException("String \"$value\" cannot be converted to a number.")
     }
 
+    override fun toText(): String = value
+
     override fun toString(): String = value
 
     override fun getProperty(key: String): WslValue {
@@ -102,7 +113,7 @@ class WslString(
                 other !is WslValue -> false
                 other.isBoolean() -> toBoolean() == other.toBoolean()
                 other.isNumeric() -> toNumber() == other.toNumber()
-                else -> value.equals(other = other.toString(), ignoreCase = true)
+                else -> value.equals(other = other.toText(), ignoreCase = true)
             }
         } catch (_: WslRuntimeException) {
             false
@@ -125,6 +136,8 @@ object WslNull : WslValue {
     override fun equals(other: Any?): Boolean = other === WslNull
 
     override fun hashCode(): Int = 0
+
+    override fun toText(): String = ""
 
     override fun toString(): String = ""
 
@@ -169,6 +182,8 @@ class WslMap(
     ) {
         values[key] = value
     }
+
+    override fun toText(): String = values.toString()
 
     override fun toString(): String = values.toString()
 

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslVariable.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslVariable.kt
@@ -14,8 +14,12 @@ class WslVariable(
             is Int -> value.toDouble()
             is Long -> value.toDouble()
             is Float -> value.toDouble()
-            else -> toString().toDoubleOrNull() ?: 0.0
+            else -> value?.toString()?.toDoubleOrNull() ?: 0.0
         }
+
+    override fun toText(): String = getter()?.toString() ?: ""
+
+    override fun toString(): String = toText()
 
     override fun isNumeric(): Boolean = getter() is Number
 
@@ -38,7 +42,7 @@ class WslVariable(
         val map =
             getter()
                 ?.takeIf { it is MutableMap<*, *> } as? MutableMap<String, String>
-        map?.set(key, value.toString())
+        map?.set(key, value.toText())
     }
 
     override fun isMap(): Boolean = getter() is Map<*, *>

--- a/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslVariables.kt
+++ b/scripting/src/commonMain/kotlin/warlockfe/warlock3/scripting/wsl/WslVariables.kt
@@ -3,6 +3,8 @@ package warlockfe.warlock3.scripting.wsl
 class WslVariables(
     private val context: WslContext,
 ) : WslValue {
+    override fun toText(): String = ""
+
     override fun toString(): String = ""
 
     override fun toBoolean(): Boolean = false

--- a/scripting/src/commonTest/kotlin/wsl/TestWslContext.kt
+++ b/scripting/src/commonTest/kotlin/wsl/TestWslContext.kt
@@ -1,13 +1,43 @@
 package warlockfe.warlock3.scripting.wsl
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.SystemTemporaryDirectory
+import kotlinx.io.writeString
 import warlockfe.warlock3.core.prefs.config.CharacterConfigStore
 import warlockfe.warlock3.core.prefs.repositories.VariableRepository
+import warlockfe.warlock3.core.script.ScriptStatus
 
 private var testStoreSeq = 0
+
+/** Parses [content] into script lines via a throwaway temp file, then deletes the file. */
+fun parseScript(content: String): List<WslLine> {
+    val path = Path(SystemTemporaryDirectory, "wsl-script-${testStoreSeq++}.wsl")
+    SystemFileSystem.sink(path).buffered().use { it.writeString(content) }
+    try {
+        return WslScript("test", path, SystemFileSystem).parse()
+    } finally {
+        SystemFileSystem.delete(path)
+    }
+}
+
+/**
+ * Drives the context through its script line-by-line the same way [WslScriptInstance] does,
+ * stopping when the script runs off the end or a command (e.g. `exit`) stops it. [maxStatements]
+ * guards against a runaway loop in a buggy test script.
+ */
+suspend fun WslContext.runToCompletion(maxStatements: Int = 10_000) {
+    var executed = 0
+    while (scriptInstance.status != ScriptStatus.Stopped) {
+        val line = getNextLine() ?: break
+        line.statement.execute(this)
+        if (++executed > maxStatements) {
+            throw AssertionError("Script exceeded $maxStatements statements without terminating")
+        }
+    }
+}
 
 /** A [CharacterConfigStore] over a throwaway temp directory; backs a real [VariableRepository] in tests. */
 fun newTestConfigStore(): CharacterConfigStore =

--- a/scripting/src/commonTest/kotlin/wsl/WslScriptTest.kt
+++ b/scripting/src/commonTest/kotlin/wsl/WslScriptTest.kt
@@ -1,0 +1,165 @@
+package warlockfe.warlock3.scripting.wsl
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * End-to-end coverage of whole scripts: each test parses a small example script, runs it through
+ * the interpreter the way [WslScriptInstance] would, and asserts on the values it computes (script
+ * variables and echoed output).
+ */
+class WslScriptTest {
+    private suspend fun CoroutineScope.runScript(
+        script: String,
+        client: FakeWarlockClient = FakeWarlockClient(),
+    ): WslContext {
+        val context = buildTestContext(this, lines = parseScript(script), client = client)
+        context.runToCompletion()
+        return context
+    }
+
+    // --- arithmetic via the counter command ---
+
+    @Test
+    fun counterArithmeticChainsCorrectly() =
+        runTest {
+            // (10 + 5) * 2 - 6 = 24
+            val ctx =
+                backgroundScope.runScript(
+                    """
+                    counter set 10
+                    counter add 5
+                    counter multiply 2
+                    counter subtract 6
+                    """.trimIndent(),
+                )
+            assertEquals("24", ctx.lookupVariable("c")?.toText())
+        }
+
+    @Test
+    fun divisionProducesDecimalResult() =
+        runTest {
+            val ctx = backgroundScope.runScript("var half %{10 / 4}")
+            assertEquals("2.5", ctx.lookupVariable("half")?.toText())
+        }
+
+    // --- expression evaluation into variables ---
+
+    @Test
+    fun expressionRespectsOperatorPrecedence() =
+        runTest {
+            val ctx = backgroundScope.runScript("var result %{2 + 3 * 4}")
+            assertEquals("14", ctx.lookupVariable("result")?.toText())
+        }
+
+    @Test
+    fun parenthesesOverridePrecedence() =
+        runTest {
+            val ctx = backgroundScope.runScript("var result %{(2 + 3) * 4}")
+            assertEquals("20", ctx.lookupVariable("result")?.toText())
+        }
+
+    @Test
+    fun booleanLogicEvaluates() =
+        runTest {
+            val ctx = backgroundScope.runScript("var ok %{2 > 1 and 3 >= 3}")
+            assertEquals("true", ctx.lookupVariable("ok")?.toText())
+        }
+
+    // --- strings ---
+
+    @Test
+    fun stringConcatenationAndRepeat() =
+        runTest {
+            val ctx =
+                backgroundScope.runScript(
+                    """
+                    var greeting %{"hello, " + "world"}
+                    var bar %{"ab" * 3}
+                    """.trimIndent(),
+                )
+            assertEquals("hello, world", ctx.lookupVariable("greeting")?.toText())
+            assertEquals("ababab", ctx.lookupVariable("bar")?.toText())
+        }
+
+    // --- control flow ---
+
+    @Test
+    fun ifThenElseTakesTheTrueBranch() =
+        runTest {
+            val ctx =
+                backgroundScope.runScript(
+                    """
+                    var n 7
+                    if n > 5 then var size big
+                    else var size small
+                    """.trimIndent(),
+                )
+            assertEquals("big", ctx.lookupVariable("size")?.toText())
+        }
+
+    @Test
+    fun ifThenElseTakesTheFalseBranch() =
+        runTest {
+            val ctx =
+                backgroundScope.runScript(
+                    """
+                    var n 3
+                    if n > 5 then var size big
+                    else var size small
+                    """.trimIndent(),
+                )
+            assertEquals("small", ctx.lookupVariable("size")?.toText())
+        }
+
+    @Test
+    fun loopSumsWithGotoAndConditional() =
+        runTest {
+            // Sums 1 + 2 + 3 + 4 + 5 = 15
+            val ctx =
+                backgroundScope.runScript(
+                    """
+                    counter set 0
+                    var i 1
+                    sum: counter add %i
+                    var i %{i + 1}
+                    if i <= 5 then goto sum
+                    """.trimIndent(),
+                )
+            assertEquals("15", ctx.lookupVariable("c")?.toText())
+        }
+
+    @Test
+    fun exitStopsExecutionEarly() =
+        runTest {
+            val ctx =
+                backgroundScope.runScript(
+                    """
+                    var a 1
+                    exit
+                    var a 2
+                    """.trimIndent(),
+                )
+            // The line after `exit` never runs, so `a` keeps its first value.
+            assertEquals("1", ctx.lookupVariable("a")?.toText())
+        }
+
+    // --- end-to-end output ---
+
+    @Test
+    fun echoOutputsComputedValue() =
+        runTest {
+            val client = FakeWarlockClient()
+            backgroundScope.runScript(
+                """
+                counter set 3
+                counter multiply 7
+                echo result is %c
+                """.trimIndent(),
+                client = client,
+            )
+            assertEquals(listOf("result is 21"), client.printed.map { it.toText() })
+        }
+}

--- a/scripting/src/commonTest/kotlin/wsl/WslVariableTest.kt
+++ b/scripting/src/commonTest/kotlin/wsl/WslVariableTest.kt
@@ -15,6 +15,19 @@ class WslVariableTest {
     }
 
     @Test
+    fun toTextReturnsWrappedValue() {
+        assertEquals("Excalibur", WslVariable { "Excalibur" }.toText())
+        assertEquals("42", WslVariable { 42 }.toText())
+        assertEquals("", WslVariable { null }.toText())
+    }
+
+    @Test
+    fun numericStringBackedVariableConvertsToNumber() {
+        assertEquals(5.0, WslVariable { "5" }.toNumber())
+        assertEquals(0.0, WslVariable { "notanumber" }.toNumber())
+    }
+
+    @Test
     fun wrapsDouble() {
         val v = WslVariable { 3.5 }
         assertTrue(v.isNumeric())


### PR DESCRIPTION
## Summary

Introduces an explicit `fun toText(): String` on `WslValue` (parallel to `toNumber()`/`toBoolean()`) as the canonical way scripts read a value as text — variable substitution, concatenation, `contains`, indexing keys, and comparisons. `toString()` now delegates to it and is reserved for debugging/logging, so script semantics no longer ride on `toString()`.

Fixes two latent `WslVariable` bugs surfaced by the change (both pre-existing on `master`):
- `toText()`/`toString()` returned the identity string (`WslVariable@<hash>`), so built-in variables like `%right` and `%character` substituted to garbage.
- `toNumber()` called `this.toString()` instead of the wrapped value, so a string-backed variable always converted to `0.0`.

Also tightens two nullable `lookupVariable(...).toString()` sites that silently produced `"null"` to the null-safe `?.toText() ?: ""` pattern.

## Tests

- New `WslScriptTest` — parses and runs whole example scripts end-to-end (counter arithmetic, expression precedence, string ops, if/then/else, a `goto` loop, `exit`, echo output) and asserts on the values they compute.
- Shared `parseScript` / `runToCompletion` helpers in `TestWslContext`.
- `WslVariableTest` regression cases for the two bug fixes.

`:scripting:jvmTest` and `:scripting:ktlintCheck` pass.

## Note

Stacked on #219 (`agp9-kmp-android-plugin`) because this builds on the `BigDecimal`→`Double` change there; base will retarget to `master` once #219 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)