### PR TITLE
Add global font color and per-messagetype size

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
@@ -79,6 +79,7 @@ import warlockfe.warlock3.core.client.WarlockMenuData
 import warlockfe.warlock3.core.macro.ScrollEvent
 import warlockfe.warlock3.core.text.FontConfig
 import warlockfe.warlock3.core.text.StyleDefinition
+import warlockfe.warlock3.core.text.isSpecified
 import warlockfe.warlock3.core.window.ClientBackgroundImage
 import warlockfe.warlock3.core.window.WindowLocation
 
@@ -254,9 +255,14 @@ private fun WindowViewContent(
     modifier: Modifier = Modifier,
 ) {
     val backgroundColor = style.backgroundColor.toColor()
-    val textColor = style.textColor.toColor()
     // The window's base (normal) font: its per-window override if set, otherwise the character default.
     val effectiveFont = font ?: LocalDefaultFont.current
+    val textColor =
+        if (effectiveFont?.textColor?.isSpecified() == true) {
+            effectiveFont.textColor.toColor()
+        } else {
+            style.textColor.toColor()
+        }
     val fontFamily = effectiveFont?.family?.let { createFontFamily(it) }
     val fontSize = effectiveFont?.size?.sp ?: defaultFontSize
     val fontWeight = effectiveFont?.weight?.let { FontWeight(it) }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/StyledStringHelpers.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/StyledStringHelpers.kt
@@ -19,6 +19,7 @@ import warlockfe.warlock3.core.text.StyledStringSubstring
 import warlockfe.warlock3.core.text.StyledStringVariable
 import warlockfe.warlock3.core.text.WarlockStyle
 import warlockfe.warlock3.core.text.flattenStyles
+import warlockfe.warlock3.core.text.isSpecified
 
 fun StyledString.toAnnotatedString(
     variables: Map<String, StyledString>,
@@ -37,7 +38,12 @@ fun StyledString.toAnnotatedString(
  */
 fun StyleDefinition.toSpanStyle(monoFont: FontConfig?): SpanStyle =
     SpanStyle(
-        color = textColor.toColor(),
+        color =
+            when {
+                textColor.isSpecified() -> textColor.toColor()
+                monospace -> monoFont?.textColor?.toColor() ?: textColor.toColor()
+                else -> textColor.toColor()
+            },
         background = backgroundColor.toColor(),
         fontFamily = if (monospace) monoFont?.family?.let { createFontFamily(it) } ?: FontFamily.Monospace else null,
         textDecoration = if (underline) TextDecoration.Underline else null,
@@ -48,7 +54,7 @@ fun StyleDefinition.toSpanStyle(monoFont: FontConfig?): SpanStyle =
                 else -> null
             },
         fontStyle = if (italic) FontStyle.Italic else null,
-        fontSize = if (monospace) monoFont?.size?.sp ?: TextUnit.Unspecified else TextUnit.Unspecified,
+        fontSize = fontSize?.sp ?: if (monospace) monoFont?.size?.sp ?: TextUnit.Unspecified else TextUnit.Unspecified,
     )
 
 fun WarlockStyle.toStyleDefinition(styleMap: Map<String, StyleDefinition>): StyleDefinition = (styleMap[name] ?: StyleDefinition())

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopAppearanceView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopAppearanceView.kt
@@ -13,18 +13,23 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
 import org.jetbrains.jewel.ui.component.Text
@@ -33,9 +38,10 @@ import warlockfe.warlock3.compose.components.toFontConfig
 import warlockfe.warlock3.compose.desktop.components.DesktopColorPickerButton
 import warlockfe.warlock3.compose.desktop.components.DesktopColorPickerDialog
 import warlockfe.warlock3.compose.desktop.components.DesktopFontPickerDialog
-import warlockfe.warlock3.compose.desktop.shim.WarlockCheckboxRow
+import warlockfe.warlock3.compose.desktop.shim.WarlockButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
+import warlockfe.warlock3.compose.desktop.shim.WarlockTextField
 import warlockfe.warlock3.compose.ui.window.StreamTextLine
 import warlockfe.warlock3.compose.util.LocalDarkTheme
 import warlockfe.warlock3.compose.util.LocalSkin
@@ -51,6 +57,7 @@ import warlockfe.warlock3.core.text.StyleDefinition
 import warlockfe.warlock3.core.text.StyledString
 import warlockfe.warlock3.core.text.WarlockColor
 import warlockfe.warlock3.core.text.WarlockStyle
+import warlockfe.warlock3.core.text.isSpecified
 
 @Composable
 fun DesktopAppearanceView(
@@ -104,7 +111,12 @@ fun DesktopAppearanceView(
 
         val defaultStyle = presets["default"]
         val previewBackground = defaultStyle?.backgroundColor?.toColor() ?: Color.Unspecified
-        val previewContentColor = defaultStyle?.textColor?.toColor() ?: LocalContentColor.current
+        val previewContentColor =
+            if (defaultFont?.textColor?.isSpecified() == true) {
+                defaultFont?.textColor.toColor()
+            } else {
+                defaultStyle?.textColor?.toColor() ?: LocalContentColor.current
+            }
         CompositionLocalProvider(LocalContentColor provides previewContentColor) {
             WarlockScrollableColumn(
                 modifier =
@@ -153,6 +165,7 @@ private fun DefaultFontSettings(
 ) {
     // Which selector's picker is open, plus whether to restrict it to monospace families.
     var editFont by remember { mutableStateOf<Pair<FontConfig?, Boolean>?>(null) }
+    var editColor by remember { mutableStateOf<Pair<WarlockColor, (WarlockColor) -> Unit>?>(null) }
 
     editFont?.let { (current, monospaceOnly) ->
         DesktopFontPickerDialog(
@@ -160,8 +173,19 @@ private fun DefaultFontSettings(
             monospaceOnly = monospaceOnly,
             onCloseRequest = { editFont = null },
             onSaveClick = { update ->
-                if (monospaceOnly) onSaveMonoFont(update.toFontConfig()) else onSaveDefaultFont(update.toFontConfig())
+                val fontUpdate = update.toFontConfig().withTextColorFrom(current)
+                if (monospaceOnly) onSaveMonoFont(fontUpdate) else onSaveDefaultFont(fontUpdate)
                 editFont = null
+            },
+        )
+    }
+    editColor?.let { (initialColor, onPick) ->
+        DesktopColorPickerDialog(
+            initialColor = initialColor.toColor(),
+            onCloseRequest = { editColor = null },
+            onColorSelect = { color ->
+                onPick(color)
+                editColor = null
             },
         )
     }
@@ -176,6 +200,16 @@ private fun DefaultFontSettings(
                 onClick = { editFont = defaultFont to false },
                 text = defaultFont.fontLabel(),
             )
+            DesktopColorPickerButton(
+                text = "Color",
+                color = defaultFont?.textColor.toColor(),
+                onClick = {
+                    editColor =
+                        Pair(defaultFont?.textColor ?: WarlockColor.Unspecified) { color ->
+                            onSaveDefaultFont(defaultFont.withTextColor(color))
+                        }
+                },
+            )
         }
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             Text(
@@ -186,9 +220,30 @@ private fun DefaultFontSettings(
                 onClick = { editFont = monoFont to true },
                 text = monoFont.fontLabel(),
             )
+            DesktopColorPickerButton(
+                text = "Color",
+                color = monoFont?.textColor.toColor(),
+                onClick = {
+                    editColor =
+                        Pair(monoFont?.textColor ?: WarlockColor.Unspecified) { color ->
+                            onSaveMonoFont(monoFont.withTextColor(color))
+                        }
+                },
+            )
         }
     }
 }
+
+private fun FontConfig?.withTextColorFrom(current: FontConfig?): FontConfig? {
+    val textColor = current?.textColor ?: WarlockColor.Unspecified
+    return (this ?: FontConfig()).copy(textColor = textColor).takeUnless { it.isEmpty() }
+}
+
+private fun FontConfig?.withTextColor(color: WarlockColor): FontConfig? =
+    (this ?: FontConfig()).copy(textColor = color).takeUnless { it.isEmpty() }
+
+private const val MIN_PRESET_FONT_SIZE = 6f
+private const val MAX_PRESET_FONT_SIZE = 72f
 
 @Composable
 private fun ColumnScope.PresetSettings(
@@ -217,12 +272,13 @@ private fun ColumnScope.PresetSettings(
         WarlockStyle.presets.forEach { warlockStyle ->
             val preset = warlockStyle.name.ifBlank { "default" }
             val style = styleMap[preset] ?: StyleDefinition()
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 Text(
-                    modifier =
-                        Modifier
-                            .width(120.dp)
-                            .align(Alignment.CenterVertically),
+                    modifier = Modifier.width(120.dp),
                     text = preset.replaceFirstChar { it.uppercase() },
                 )
                 DesktopColorPickerButton(
@@ -245,28 +301,96 @@ private fun ColumnScope.PresetSettings(
                             }
                     },
                 )
-                WarlockCheckboxRow(
-                    checked = style.bold,
-                    onCheckedChange = { saveStyle(preset, style.copy(bold = it)) },
-                    text = "Bold",
-                    modifier = Modifier.align(Alignment.CenterVertically),
+                FontSizeSetting(
+                    fontSize = style.fontSize,
+                    onFontSizeChange = { saveStyle(preset, style.copy(fontSize = it)) },
                 )
-                WarlockCheckboxRow(
-                    checked = style.italic,
-                    onCheckedChange = { saveStyle(preset, style.copy(italic = it)) },
-                    text = "Italic",
-                    modifier = Modifier.align(Alignment.CenterVertically),
+                StyleToggleButton(
+                    selected = style.bold,
+                    onSelectedChange = { saveStyle(preset, style.copy(bold = it)) },
+                    label = "B",
                 )
-                WarlockCheckboxRow(
-                    checked = style.underline,
-                    onCheckedChange = { saveStyle(preset, style.copy(underline = it)) },
-                    text = "Underline",
-                    modifier = Modifier.align(Alignment.CenterVertically),
+                StyleToggleButton(
+                    selected = style.italic,
+                    onSelectedChange = { saveStyle(preset, style.copy(italic = it)) },
+                    label = "I",
+                )
+                StyleToggleButton(
+                    selected = style.underline,
+                    onSelectedChange = { saveStyle(preset, style.copy(underline = it)) },
+                    label = "U",
                 )
             }
         }
     }
 }
+
+@Composable
+private fun StyleToggleButton(
+    selected: Boolean,
+    onSelectedChange: (Boolean) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    val buttonModifier = modifier.width(40.dp)
+    if (selected) {
+        WarlockButton(
+            onClick = { onSelectedChange(false) },
+            modifier = buttonModifier,
+            text = label,
+        )
+    } else {
+        WarlockOutlinedButton(
+            onClick = { onSelectedChange(true) },
+            modifier = buttonModifier,
+            text = label,
+        )
+    }
+}
+
+@Composable
+private fun FontSizeSetting(
+    fontSize: Float?,
+    onFontSizeChange: (Float?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sizeState = rememberTextFieldState(fontSize?.toFontSizeText().orEmpty())
+
+    LaunchedEffect(fontSize) {
+        val text = fontSize?.toFontSizeText().orEmpty()
+        if (sizeState.text.toString() != text) {
+            sizeState.setTextAndPlaceCursorAtEnd(text)
+        }
+    }
+    LaunchedEffect(sizeState, fontSize) {
+        snapshotFlow { sizeState.text.toString() }
+            .collectLatest { text ->
+                val next =
+                    when {
+                        text.isBlank() -> null
+                        else -> text.toFloatOrNull()?.coerceIn(MIN_PRESET_FONT_SIZE, MAX_PRESET_FONT_SIZE)
+                    }
+                if (next != null || text.isBlank()) {
+                    if (next != fontSize) onFontSizeChange(next)
+                }
+            }
+    }
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Size")
+        WarlockTextField(
+            state = sizeState,
+            modifier = Modifier.width(72.dp),
+            placeholder = "Default",
+        )
+    }
+}
+
+private fun Float.toFontSizeText(): String = if (this == toInt().toFloat()) toInt().toString() else toString().trimEnd('0').trimEnd('.')
 
 private fun buildPreviewLines(
     presets: Map<String, StyleDefinition>,

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/AppearanceView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/AppearanceView.kt
@@ -13,26 +13,35 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import io.github.oikvpqya.compose.fastscroller.ThumbStyle
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import warlockfe.warlock3.compose.components.CheckboxRow
 import warlockfe.warlock3.compose.components.ColorPickerButton
 import warlockfe.warlock3.compose.components.ColorPickerDialog
 import warlockfe.warlock3.compose.components.FontPickerDialog
@@ -55,6 +64,7 @@ import warlockfe.warlock3.core.text.StyleDefinition
 import warlockfe.warlock3.core.text.StyledString
 import warlockfe.warlock3.core.text.WarlockColor
 import warlockfe.warlock3.core.text.WarlockStyle
+import warlockfe.warlock3.core.text.isSpecified
 
 @Composable
 fun AppearanceView(
@@ -217,7 +227,14 @@ fun AppearanceView(
         Spacer(Modifier.height(16.dp))
         val barColor = presets["default"]?.textColor?.toColor() ?: MaterialTheme.colorScheme.onSurface
         CompositionLocalProvider(
-            LocalContentColor provides (presets["default"]?.textColor?.toColor() ?: LocalContentColor.current),
+            LocalContentColor provides
+                (
+                    if (defaultFont?.textColor?.isSpecified() == true) {
+                        defaultFont?.textColor.toColor()
+                    } else {
+                        presets["default"]?.textColor?.toColor() ?: LocalContentColor.current
+                    }
+                ),
         ) {
             ScrollableColumn(
                 Modifier
@@ -274,6 +291,7 @@ private fun DefaultFontSettings(
 ) {
     // (current font, monospaceOnly).
     var editFont by remember { mutableStateOf<Pair<FontConfig?, Boolean>?>(null) }
+    var editColor by remember { mutableStateOf<Pair<WarlockColor, (WarlockColor) -> Unit>?>(null) }
 
     editFont?.let { (current, monospaceOnly) ->
         FontPickerDialog(
@@ -281,8 +299,19 @@ private fun DefaultFontSettings(
             monospaceOnly = monospaceOnly,
             onCloseRequest = { editFont = null },
             onSaveClick = { update ->
-                if (monospaceOnly) onSaveMonoFont(update.toFontConfig()) else onSaveDefaultFont(update.toFontConfig())
+                val fontUpdate = update.toFontConfig().withTextColorFrom(current)
+                if (monospaceOnly) onSaveMonoFont(fontUpdate) else onSaveDefaultFont(fontUpdate)
                 editFont = null
+            },
+        )
+    }
+    editColor?.let { (initialColor, onPick) ->
+        ColorPickerDialog(
+            initialColor = initialColor.toColor(),
+            onCloseRequest = { editColor = null },
+            onColorSelect = { color ->
+                onPick(color)
+                editColor = null
             },
         )
     }
@@ -296,6 +325,16 @@ private fun DefaultFontSettings(
             OutlinedButton(onClick = { editFont = defaultFont to false }) {
                 Text(defaultFont.fontLabel(), maxLines = 1)
             }
+            ColorPickerButton(
+                text = "Color",
+                color = defaultFont?.textColor.toColor(),
+                onClick = {
+                    editColor =
+                        Pair(defaultFont?.textColor ?: WarlockColor.Unspecified) { color ->
+                            onSaveDefaultFont(defaultFont.withTextColor(color))
+                        }
+                },
+            )
         }
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             Text(
@@ -305,9 +344,30 @@ private fun DefaultFontSettings(
             OutlinedButton(onClick = { editFont = monoFont to true }) {
                 Text(monoFont.fontLabel(), maxLines = 1)
             }
+            ColorPickerButton(
+                text = "Color",
+                color = monoFont?.textColor.toColor(),
+                onClick = {
+                    editColor =
+                        Pair(monoFont?.textColor ?: WarlockColor.Unspecified) { color ->
+                            onSaveMonoFont(monoFont.withTextColor(color))
+                        }
+                },
+            )
         }
     }
 }
+
+private fun FontConfig?.withTextColorFrom(current: FontConfig?): FontConfig? {
+    val textColor = current?.textColor ?: WarlockColor.Unspecified
+    return (this ?: FontConfig()).copy(textColor = textColor).takeUnless { it.isEmpty() }
+}
+
+private fun FontConfig?.withTextColor(color: WarlockColor): FontConfig? =
+    (this ?: FontConfig()).copy(textColor = color).takeUnless { it.isEmpty() }
+
+private const val MIN_PRESET_FONT_SIZE = 6f
+private const val MAX_PRESET_FONT_SIZE = 72f
 
 @Composable
 fun ColumnScope.PresetSettings(
@@ -335,10 +395,12 @@ fun ColumnScope.PresetSettings(
             val preset = warlockStyle.name.ifBlank { "default" }
             val style = styleMap[preset] ?: StyleDefinition()
             Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    modifier = Modifier.width(120.dp).align(Alignment.CenterVertically),
+                    modifier = Modifier.width(120.dp),
                     text = preset.replaceFirstChar { it.uppercase() },
                 )
                 ColorPickerButton(
@@ -368,26 +430,113 @@ fun ColumnScope.PresetSettings(
                             }
                     },
                 )
-
-                CheckboxRow(
-                    checked = style.bold,
-                    onCheckedChange = { saveStyle(preset, style.copy(bold = it)) },
-                    text = "Bold",
-                    modifier = Modifier.align(Alignment.CenterVertically),
+                FontSizeSetting(
+                    fontSize = style.fontSize,
+                    onFontSizeChange = { saveStyle(preset, style.copy(fontSize = it)) },
                 )
-                CheckboxRow(
-                    checked = style.italic,
-                    onCheckedChange = { saveStyle(preset, style.copy(italic = it)) },
-                    text = "Italic",
-                    modifier = Modifier.align(Alignment.CenterVertically),
+                StyleToggleButton(
+                    selected = style.bold,
+                    onSelectedChange = { saveStyle(preset, style.copy(bold = it)) },
+                    label = "B",
+                    fontWeight = FontWeight.Bold,
                 )
-                CheckboxRow(
-                    checked = style.underline,
-                    onCheckedChange = { saveStyle(preset, style.copy(underline = it)) },
-                    text = "Underline",
-                    modifier = Modifier.align(Alignment.CenterVertically),
+                StyleToggleButton(
+                    selected = style.italic,
+                    onSelectedChange = { saveStyle(preset, style.copy(italic = it)) },
+                    label = "I",
+                    fontStyle = FontStyle.Italic,
+                )
+                StyleToggleButton(
+                    selected = style.underline,
+                    onSelectedChange = { saveStyle(preset, style.copy(underline = it)) },
+                    label = "U",
+                    textDecoration = TextDecoration.Underline,
                 )
             }
         }
     }
 }
+
+@Composable
+private fun StyleToggleButton(
+    selected: Boolean,
+    onSelectedChange: (Boolean) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    fontWeight: FontWeight? = null,
+    fontStyle: FontStyle? = null,
+    textDecoration: TextDecoration? = null,
+) {
+    val content: @Composable () -> Unit = {
+        Text(
+            text = label,
+            fontWeight = fontWeight,
+            fontStyle = fontStyle,
+            textDecoration = textDecoration,
+        )
+    }
+    val buttonModifier = modifier.width(40.dp)
+    val contentPadding = PaddingValues(horizontal = 0.dp)
+    if (selected) {
+        Button(
+            onClick = { onSelectedChange(false) },
+            modifier = buttonModifier,
+            contentPadding = contentPadding,
+        ) {
+            content()
+        }
+    } else {
+        OutlinedButton(
+            onClick = { onSelectedChange(true) },
+            modifier = buttonModifier,
+            contentPadding = contentPadding,
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun FontSizeSetting(
+    fontSize: Float?,
+    onFontSizeChange: (Float?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sizeState = rememberTextFieldState(fontSize?.toFontSizeText().orEmpty())
+
+    LaunchedEffect(fontSize) {
+        val text = fontSize?.toFontSizeText().orEmpty()
+        if (sizeState.text.toString() != text) {
+            sizeState.setTextAndPlaceCursorAtEnd(text)
+        }
+    }
+    LaunchedEffect(sizeState, fontSize) {
+        snapshotFlow { sizeState.text.toString() }
+            .collectLatest { text ->
+                val next =
+                    when {
+                        text.isBlank() -> null
+                        else -> text.toFloatOrNull()?.coerceIn(MIN_PRESET_FONT_SIZE, MAX_PRESET_FONT_SIZE)
+                    }
+                if (next != null || text.isBlank()) {
+                    if (next != fontSize) onFontSizeChange(next)
+                }
+            }
+    }
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Size")
+        OutlinedTextField(
+            state = sizeState,
+            modifier = Modifier.width(72.dp),
+            placeholder = { Text("Default") },
+            singleLine = true,
+        )
+    }
+}
+
+private fun Float.toFontSizeText(): String = if (this == toInt().toFloat()) toInt().toString() else toString().trimEnd('0').trimEnd('.')

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigMappers.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigMappers.kt
@@ -63,6 +63,7 @@ internal fun HighlightStyleConfig.toStyleDefinition(): StyleDefinition =
         italic = italic,
         underline = underline,
         monospace = monospace,
+        fontSize = fontSize,
     )
 
 internal fun StyleDefinition.toStyleConfig(group: Int): HighlightStyleConfig =
@@ -75,6 +76,7 @@ internal fun StyleDefinition.toStyleConfig(group: Int): HighlightStyleConfig =
         italic = italic,
         underline = underline,
         monospace = monospace,
+        fontSize = fontSize,
     )
 
 internal fun NameEntity.toConfig(): NameConfig =
@@ -136,6 +138,7 @@ internal fun PresetStyleConfig.toStyleDefinition(): StyleDefinition =
         italic = italic,
         underline = underline,
         monospace = monospace,
+        fontSize = fontSize,
     )
 
 internal fun StyleDefinition.toPresetStyleConfig(): PresetStyleConfig =
@@ -147,6 +150,7 @@ internal fun StyleDefinition.toPresetStyleConfig(): PresetStyleConfig =
         italic = italic,
         underline = underline,
         monospace = monospace,
+        fontSize = fontSize,
     )
 
 internal fun ProgressBarSettingEntity.toConfig(): ProgressBarConfig =

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigMigration.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigMigration.kt
@@ -92,6 +92,7 @@ class ConfigMigration(
                         bold = entity.bold,
                         italic = entity.italic,
                         underline = entity.underline,
+                        fontSize = entity.fontSize,
                     )
             }
         val progressBars = progressBarSettingDao.getByCharacter(id).associate { it.id to it.toConfig() }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigSchema.kt
@@ -123,6 +123,7 @@ data class PresetStyleConfig(
     val italic: Boolean = false,
     val underline: Boolean = false,
     val monospace: Boolean = false,
+    val fontSize: Float? = null,
 )
 
 @Serializable
@@ -248,6 +249,7 @@ data class HighlightStyleConfig(
     val italic: Boolean = false,
     val underline: Boolean = false,
     val monospace: Boolean = false,
+    val fontSize: Float? = null,
 )
 
 @Serializable

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/export/StyleExport.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/export/StyleExport.kt
@@ -12,4 +12,5 @@ data class StyleExport(
     val italic: Boolean,
     val underline: Boolean,
     val monospace: Boolean,
+    val fontSize: Float? = null,
 )

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/mappers/HighlightMappers.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/mappers/HighlightMappers.kt
@@ -26,4 +26,5 @@ fun HighlightStyleEntity.toStyleDefinition(): StyleDefinition =
         bold = bold,
         italic = italic,
         underline = underline,
+        fontSize = fontSize,
     )

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ExportRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ExportRepository.kt
@@ -164,6 +164,7 @@ class ExportRepository(
                                         italic = style.italic,
                                         underline = style.underline,
                                         monospace = style.monospace,
+                                        fontSize = style.fontSize,
                                     )
                             },
                     )
@@ -199,6 +200,7 @@ class ExportRepository(
                                 underline = preset.underline,
                                 monospace = preset.monospace,
                                 entireLine = preset.entireLine,
+                                fontSize = preset.fontSize,
                             ),
                     )
                 },
@@ -403,6 +405,7 @@ class ExportRepository(
                         italic = preset.style.italic,
                         underline = preset.style.underline,
                         monospace = preset.style.monospace,
+                        fontSize = preset.style.fontSize,
                     )
             }
         val importedWindowStyles =

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/FontConfig.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/FontConfig.kt
@@ -14,7 +14,9 @@ data class FontConfig(
     val family: String? = null,
     val size: Float? = null,
     val weight: Int? = null,
+    @Serializable(WarlockColorAsHexSerializer::class)
+    val textColor: WarlockColor = WarlockColor.Unspecified,
 ) {
     /** True when nothing is set, i.e. this override contributes nothing and can be dropped. */
-    fun isEmpty(): Boolean = family == null && size == null && weight == null
+    fun isEmpty(): Boolean = family == null && size == null && weight == null && textColor.isUnspecified()
 }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/StyleDefinition.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/StyleDefinition.kt
@@ -8,6 +8,7 @@ data class StyleDefinition(
     val italic: Boolean = false,
     val underline: Boolean = false,
     val monospace: Boolean = false,
+    val fontSize: Float? = null,
 ) {
     fun mergeWith(other: StyleDefinition): StyleDefinition =
         StyleDefinition(
@@ -18,6 +19,7 @@ data class StyleDefinition(
             italic = italic || other.italic,
             underline = underline || other.underline,
             monospace = monospace || other.monospace,
+            fontSize = fontSize ?: other.fontSize,
         )
 }
 

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/WarlockColor.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/text/WarlockColor.kt
@@ -1,6 +1,12 @@
 package warlockfe.warlock3.core.text
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import warlockfe.warlock3.core.util.toWarlockColor
 
 @Serializable
@@ -35,4 +41,25 @@ fun WarlockColor.ifUnspecified(defaultColor: WarlockColor): WarlockColor {
 fun WarlockColor.toHexString(): String? {
     if (isUnspecified()) return null
     return "#" + argb.toString(16)
+}
+
+object WarlockColorAsHexSerializer : KSerializer<WarlockColor> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("WarlockColor", PrimitiveKind.STRING)
+
+    override fun serialize(
+        encoder: Encoder,
+        value: WarlockColor,
+    ) {
+        encoder.encodeString(value.toHexString() ?: "default")
+    }
+
+    override fun deserialize(decoder: Decoder): WarlockColor {
+        val text = decoder.decodeString()
+        return if (text.isBlank() || text == "default") {
+            WarlockColor.Unspecified
+        } else {
+            text.toWarlockColor() ?: WarlockColor.Unspecified
+        }
+    }
 }


### PR DESCRIPTION
I scribbled together a fix to restore font color and per-message sizing functionality lost in the last font settings overhaul. This PR is just to demonstrate what I have in mind. The color for the default font is a bit redundant with the "Default" message type further down on the Appearance tab; it can probably be removed. Also swapped Bold/Italic/Underline checkboxes with buttons to make room for size box.