### PR TITLE
Harden Compose Desktop crash workarounds (macOS a11y + context-menu NPE)

### DIFF
--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -193,6 +193,7 @@ private class WarlockCommand : CliktCommand() {
                 addAll(createInitialGameStates(appContainer, credentials, sgeSettings, logger))
             }
 
+        disableMacAccessibilityWorkaround()
         installUncaughtExceptionWorkaround()
 
         val updater = buildUpdater(clientSettings)
@@ -625,6 +626,24 @@ private class WarlockCommand : CliktCommand() {
         }
     }
 
+    // Turn off Compose Desktop's accessibility bridge on macOS. Bug 2 below (the
+    // ComposeSceneAccessibility.defaultAccessibilityFocusTarget NPE) fires in practice only on
+    // macOS, whose a11y system aggressively queries AccessibleContext and so keeps driving the
+    // crashing node-sync/focus-retarget path. installUncaughtExceptionWorkaround can swallow the
+    // resulting uncaught exception, but only after the sync is interrupted mid-way, leaving the a11y
+    // tree inconsistent so it re-throws on the next focus change. Disabling the bridge stops that
+    // path from ever running. The trade-off is no screen-reader support on macOS until the upstream
+    // fix lands, which beats a crash loop. Compose reads this system property lazily when it builds
+    // the first ComposeSceneAccessibility, so this must run before the first window opens; we leave
+    // an explicit -Dcompose.accessibility.enable=... on the command line untouched as an escape hatch.
+    private fun disableMacAccessibilityWorkaround() {
+        if (DesktopPlatform.Current == DesktopPlatform.MacOS &&
+            System.getProperty("compose.accessibility.enable") == null
+        ) {
+            System.setProperty("compose.accessibility.enable", "false")
+        }
+    }
+
     // Swallow known, unrecoverable upstream Compose Desktop accessibility crashes that surface as
     // uncaught exceptions on the AWT event thread. Both originate entirely inside Compose's a11y
     // tree-sync code, so there is nothing for us to fix and nothing the user can do; killing the
@@ -633,7 +652,8 @@ private class WarlockCommand : CliktCommand() {
     //   2. NullPointerException in ComposeSceneAccessibility.defaultAccessibilityFocusTarget: while
     //      retargeting accessibility focus after a node is removed it walks the Accessible tree into
     //      an ArrayDeque, but getAccessibleChild() can return null and ArrayDeque rejects nulls.
-    //      Still unguarded in compose-multiplatform 1.11.x.
+    //      Still unguarded in compose-multiplatform 1.11.x. disableMacAccessibilityWorkaround stops
+    //      this from ever firing on macOS; this stays as the cross-platform safety net.
     // Matching on frame names is reliable because the desktop build never runs ProGuard
     // (it is disabled in build.gradle.kts), so class/method names are never obfuscated.
     private fun installUncaughtExceptionWorkaround() {

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -644,16 +644,21 @@ private class WarlockCommand : CliktCommand() {
         }
     }
 
-    // Swallow known, unrecoverable upstream Compose Desktop accessibility crashes that surface as
-    // uncaught exceptions on the AWT event thread. Both originate entirely inside Compose's a11y
-    // tree-sync code, so there is nothing for us to fix and nothing the user can do; killing the
-    // whole app over them is worse than carrying on with (at worst) degraded screen-reader support.
+    // Swallow known, unrecoverable upstream Compose Desktop crashes that surface as uncaught
+    // exceptions on the AWT event thread. Each originates entirely inside Compose framework code, so
+    // there is nothing for us to fix and nothing the user can do; killing the whole app over them is
+    // worse than carrying on (at worst with degraded screen-reader support).
     //   1. NoSuchElementException "Cannot find value for key": https://issuetracker.google.com/issues/399134381
     //   2. NullPointerException in ComposeSceneAccessibility.defaultAccessibilityFocusTarget: while
     //      retargeting accessibility focus after a node is removed it walks the Accessible tree into
     //      an ArrayDeque, but getAccessibleChild() can return null and ArrayDeque rejects nulls.
     //      Still unguarded in compose-multiplatform 1.11.x. disableMacAccessibilityWorkaround stops
     //      this from ever firing on macOS; this stays as the cross-platform safety net.
+    //   3. NullPointerException from DefaultOpenContextMenu's onKeyEvent handler in
+    //      BasicContextMenuRepresentation: pressing an arrow key while the text context menu (the
+    //      right-click Copy/Paste popup) is open calls FocusManager.moveFocus to step between menu
+    //      items, and that traversal NPEs inside Compose's focus machinery. Not accessibility-related
+    //      and not macOS-specific. No upstream issue located; still present in 1.11.x.
     // Matching on frame names is reliable because the desktop build never runs ProGuard
     // (it is disabled in build.gradle.kts), so class/method names are never obfuscated.
     private fun installUncaughtExceptionWorkaround() {
@@ -687,12 +692,17 @@ private class WarlockCommand : CliktCommand() {
                         cause.message?.contains("Cannot find value for key") == true
                     }
 
-                    // Workaround https://youtrack.jetbrains.com/issue/CMP-10170/Crash-in-A11Y-subsystem
+                    // Workarounds: the a11y focus-target crash (bug 2,
+                    // https://youtrack.jetbrains.com/issue/CMP-10170/Crash-in-A11Y-subsystem) and the
+                    // context-menu arrow-key crash (bug 3, no upstream issue).
                     is NullPointerException -> {
                         cause.stackTrace.any {
                             it.className.endsWith("ComposeSceneAccessibility") &&
                                 it.methodName == "defaultAccessibilityFocusTarget"
-                        }
+                        } ||
+                            cause.stackTrace.any {
+                                it.className.contains("BasicContextMenuRepresentation")
+                            }
                     }
 
                     else -> {


### PR DESCRIPTION
Two independent, unrecoverable upstream Compose Desktop crashes that reach production Sentry as fatal uncaught exceptions on the AWT event thread. Both are framework bugs with nothing for us to fix; the app should not die over them.

## 1. macOS a11y focus-target NPE (CMP-10170)

Reported on macOS (`macbookair`):

```
addFirst in unknown file
defaultAccessibilityFocusTarget in ComposeSceneAccessibility.kt [Line 169]
onAccessibleReceivedFocus in ComposeSceneAccessibility.kt [Line 86]
...
syncNodes in SemanticsOwnerAccessibility.kt
```

While retargeting a11y focus after a node is removed, `defaultAccessibilityFocusTarget()` walks the `Accessible` tree into an `ArrayDeque`, but `getAccessibleChild()` can return null and `ArrayDeque` rejects nulls (`ComposeSceneAccessibility.kt:168-169`). Still unguarded in compose-multiplatform 1.11.x.

We already swallow this in `installUncaughtExceptionWorkaround`, but the swallow is reactive: it only prevents process death. The crash happens mid `syncNodes`, so the a11y tree is left inconsistent and re-throws on the next focus change. It fires in practice only on macOS, whose a11y system aggressively queries `AccessibleContext`.

**Fix:** disable the Compose Desktop accessibility bridge on macOS by setting `-Dcompose.accessibility.enable=false` before the first window opens (Compose reads that system property lazily when it constructs the first `ComposeSceneAccessibility`). With the bridge off, `accessibleContextProvider` is null and the crashing focus-retarget path never runs.

- macOS only; Windows/Linux keep working screen-reader support and don't hit this in practice.
- An explicit `-Dcompose.accessibility.enable=...` on the command line is left untouched as an escape hatch.
- The existing uncaught-exception swallow stays as the cross-platform safety net.

**Trade-off:** no VoiceOver support on macOS until the upstream fix lands, which beats a crash loop.

## 2. Context-menu arrow-key NPE

Reported separately (not macOS-specific):

```
invoke-ZmokQxo in BasicContextMenuRepresentation.skiko.kt [Line 89]
invoke in BasicContextMenuRepresentation.skiko.kt [Line 80]
onKeyEvent-ZmokQxo in CanvasLayersComposeScene.skiko.kt [Line 586]
...
keyPressed in ComposeSceneMediator.desktop.kt
```

Pressing an arrow key while the text context menu (right-click Copy/Paste popup) is open runs `DefaultOpenContextMenu`'s `onKeyEvent` handler, which calls `FocusManager.moveFocus` to step between menu items; that traversal NPEs inside Compose's focus machinery. The crashing frame is `BasicContextMenuRepresentation_skikoKt$DefaultOpenContextMenu$2$1` (the `Function1<KeyEvent, Boolean>` key handler). Not accessibility-related; still unguarded in 1.11.x.

**Fix:** extend `isKnownComposeBug` to also swallow `NullPointerException`s whose stack contains a `BasicContextMenuRepresentation` frame, alongside the existing a11y focus-target guard. (Frame-name matching is reliable because the desktop build never runs ProGuard.)

## Testing

- `./gradlew :desktopApp:ktlintCheck :desktopApp:compileKotlin` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)