### PR TITLE
Group settings pages into sections with icons

### DIFF
--- a/compose/src/commonMain/composeResources/drawable/group.xml
+++ b/compose/src/commonMain/composeResources/drawable/group.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="#000000"
+      android:pathData="M215,360 a115,115 0 1,0 230,0 a115,115 0 1,0 -230,0 Z"/>
+  <path
+      android:fillColor="#000000"
+      android:pathData="M515,360 a115,115 0 1,0 230,0 a115,115 0 1,0 -230,0 Z"/>
+  <path
+      android:fillColor="#000000"
+      android:pathData="M255,460 L405,460 Q485,460 485,540 L485,700 Q485,780 405,780 L255,780 Q175,780 175,700 L175,540 Q175,460 255,460 Z"/>
+  <path
+      android:fillColor="#000000"
+      android:pathData="M555,460 L705,460 Q785,460 785,540 L785,700 Q785,780 705,780 L555,780 Q475,780 475,700 L475,540 Q475,460 555,460 Z"/>
+</vector>

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsPage.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsPage.kt
@@ -1,17 +1,44 @@
 package warlockfe.warlock3.compose.ui.settings
 
-enum class SettingsPage(
+import org.jetbrains.compose.resources.DrawableResource
+import warlockfe.warlock3.compose.generated.resources.Res
+import warlockfe.warlock3.compose.generated.resources.arrow_right_alt
+import warlockfe.warlock3.compose.generated.resources.circle_filled
+import warlockfe.warlock3.compose.generated.resources.edit
+import warlockfe.warlock3.compose.generated.resources.front_hand
+import warlockfe.warlock3.compose.generated.resources.group
+import warlockfe.warlock3.compose.generated.resources.login
+import warlockfe.warlock3.compose.generated.resources.palette
+import warlockfe.warlock3.compose.generated.resources.settings_filled
+import warlockfe.warlock3.compose.generated.resources.space_dashboard
+import warlockfe.warlock3.compose.generated.resources.star_shine
+import warlockfe.warlock3.compose.generated.resources.visibility_filled
+
+// Sections the settings pages are grouped under in the nav. General has a blank title so it renders
+// on its own with no section header.
+enum class SettingsGroup(
     val title: String,
 ) {
-    General("General"),
+    General(""),
     Appearance("Appearance"),
-    Variables("Variables"),
-    Macros("Macros"),
-    Highlights("Highlights"),
-    Names("Names"),
-    Aliases("Aliases"),
-    Alterations("Alterations"),
-    Actions("Actions"),
-    Accounts("Accounts"),
-    Characters("Characters"),
+    Game("Game"),
+    Account("Account"),
+}
+
+enum class SettingsPage(
+    val title: String,
+    val group: SettingsGroup,
+    val icon: DrawableResource,
+) {
+    General("General", SettingsGroup.General, Res.drawable.settings_filled),
+    Appearance("Appearance", SettingsGroup.Appearance, Res.drawable.palette),
+    Highlights("Highlights", SettingsGroup.Appearance, Res.drawable.star_shine),
+    Names("Names", SettingsGroup.Appearance, Res.drawable.visibility_filled),
+    Alterations("Alterations", SettingsGroup.Appearance, Res.drawable.edit),
+    Actions("Actions", SettingsGroup.Game, Res.drawable.front_hand),
+    Macros("Macros", SettingsGroup.Game, Res.drawable.space_dashboard),
+    Aliases("Aliases", SettingsGroup.Game, Res.drawable.arrow_right_alt),
+    Variables("Variables", SettingsGroup.Game, Res.drawable.circle_filled),
+    Accounts("Accounts", SettingsGroup.Account, Res.drawable.login),
+    Characters("Characters", SettingsGroup.Account, Res.drawable.group),
 }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsDialog.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsDialog.kt
@@ -1,29 +1,38 @@
 package warlockfe.warlock3.compose.desktop.ui.settings
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.rememberDialogState
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.Orientation
 import org.jetbrains.jewel.ui.component.Divider
 import org.jetbrains.jewel.ui.component.Text
+import warlockfe.warlock3.compose.ui.settings.SettingsGroup
 import warlockfe.warlock3.compose.ui.settings.SettingsPage
 import warlockfe.warlock3.core.client.GameCharacter
 import warlockfe.warlock3.core.prefs.repositories.AccountRepository
@@ -76,16 +85,27 @@ fun DesktopSettingsDialog(
                 Column(
                     modifier =
                         Modifier
-                            .width(220.dp)
+                            // 180 fits the longest label plus its leading icon
+                            .width(180.dp)
                             .fillMaxHeight()
                             .padding(vertical = 8.dp),
                 ) {
-                    SettingsPage.entries.forEach { entry ->
-                        SettingsNavItem(
-                            label = entry.title,
-                            selected = page == entry,
-                            onClick = { page = entry },
-                        )
+                    SettingsGroup.entries.forEach { group ->
+                        if (group.title.isNotEmpty()) {
+                            Text(
+                                text = group.title,
+                                style = JewelTheme.defaultTextStyle.copy(fontWeight = FontWeight.Bold),
+                                modifier = Modifier.padding(start = 8.dp, top = 12.dp, bottom = 2.dp),
+                            )
+                        }
+                        SettingsPage.entries.filter { it.group == group }.forEach { entry ->
+                            SettingsNavItem(
+                                label = entry.title,
+                                icon = entry.icon,
+                                selected = page == entry,
+                                onClick = { page = entry },
+                            )
+                        }
                     }
                 }
                 Divider(orientation = Orientation.Vertical, modifier = Modifier.fillMaxHeight())
@@ -121,6 +141,7 @@ fun DesktopSettingsDialog(
 @Composable
 private fun SettingsNavItem(
     label: String,
+    icon: DrawableResource,
     selected: Boolean,
     onClick: () -> Unit,
 ) {
@@ -131,7 +152,8 @@ private fun SettingsNavItem(
         } else {
             Color.Transparent
         }
-    Box(
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
         modifier =
             Modifier
                 .fillMaxWidth()
@@ -139,6 +161,13 @@ private fun SettingsNavItem(
                 .background(background)
                 .padding(horizontal = 12.dp, vertical = 8.dp),
     ) {
+        Image(
+            painter = painterResource(icon),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(JewelTheme.globalColors.text.normal),
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(8.dp))
         Text(label)
     }
 }

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsScreen.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/settings/SettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -18,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.painterResource
 import warlockfe.warlock3.compose.AppContainer
 import warlockfe.warlock3.compose.components.ScrollableColumn
@@ -63,17 +65,33 @@ fun SettingsScreen(
             val selected = page
             if (selected == null) {
                 ScrollableColumn {
-                    SettingsPage.entries.forEach { entry ->
-                        ListItem(
-                            modifier = Modifier.clickable { page = entry },
-                            headlineContent = { Text(entry.title) },
-                            trailingContent = {
-                                Icon(
-                                    painter = painterResource(Res.drawable.arrow_right),
-                                    contentDescription = null,
-                                )
-                            },
-                        )
+                    SettingsGroup.entries.forEach { group ->
+                        if (group.title.isNotEmpty()) {
+                            Text(
+                                text = group.title,
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp),
+                            )
+                        }
+                        SettingsPage.entries.filter { it.group == group }.forEach { entry ->
+                            ListItem(
+                                modifier = Modifier.clickable { page = entry },
+                                headlineContent = { Text(entry.title) },
+                                leadingContent = {
+                                    Icon(
+                                        painter = painterResource(entry.icon),
+                                        contentDescription = null,
+                                    )
+                                },
+                                trailingContent = {
+                                    Icon(
+                                        painter = painterResource(Res.drawable.arrow_right),
+                                        contentDescription = null,
+                                    )
+                                },
+                            )
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
## What

Reorganizes the settings navigation:

- **Grouped into sections** via a new `SettingsGroup` — **General** (no header, stands alone), then **Appearance** (Appearance, Highlights, Names, Alterations), **Game** (Actions, Macros, Aliases, Variables), and **Account** (Accounts, Characters).
- **A leading icon for every page** (`SettingsPage.icon`), rendered by both the mobile (Material3 `ListItem` `leadingContent`) and desktop (Jewel `Image` + `ColorFilter.tint`) navs.
- Adds a hand-authored **`group.xml`** (two-person) drawable for the Characters page, since the existing Material Symbols set had no multi-person glyph.

## Icons

Mostly existing Material Symbols. Three were the closest available stand-ins where the set lacks a dedicated glyph: **Macros** → `space_dashboard`, **Variables** → `circle_filled` (no keyboard/data icon). Easy to swap later if better ones are added.

## Note

Stacked on #229 (base = `remove-gradle-daemon-jvm`) so the diff stays limited to the settings changes; will retarget to `master` once #229 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)