### PR TITLE
Add containerized Claude Code dev environment (.devcontainer)

### DIFF
--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,2 @@
+# Generated per-machine by claude-box.sh (host user/home/repo/SDK paths).
+.env

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,116 @@
+# Containerized dev environment for running Claude Code with
+# --dangerously-skip-permissions, isolated from the host.
+#
+# Toolchain: JDK 21 (Temurin) + Android SDK (platform 36 / build-tools 36.0.0)
+# to build the full Warlock KMP project (desktop + androidApp; iOS is not
+# buildable on Linux).
+#
+# All host-specific paths are supplied as build args by claude-box.sh, so this
+# file contains no hard-coded home directory or repo location. Sensible
+# defaults let it also `docker build` standalone.
+FROM eclipse-temurin:21-jdk
+
+ARG USER_NAME=dev
+ARG USER_UID=1000
+ARG USER_GID=1000
+# Container home + Android SDK path. Mirrored to the host's values so the repo's
+# git-ignored local.properties (sdk.dir=...) resolves inside the container.
+ARG USER_HOME=/home/dev
+ARG ANDROID_SDK_DIR=/home/dev/Android/Sdk
+# Bump if a newer AGP needs a newer sdkmanager. See:
+# https://developer.android.com/studio#command-line-tools-only
+ARG CMDLINE_TOOLS_VERSION=11076708
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base tooling. ripgrep + git + less are what Claude Code leans on; the rest
+# supports the Android SDK download and general dev use.
+#
+# openssh-client: the git remote is git@github.com, so without it every fetch,
+#   pull, and push dies with "cannot run ssh: No such file or directory" —
+#   the container can read history but can never sync with the remote.
+# jq: the only JSON parser here (no python3/node), needed to work with the
+#   GitHub API and any tooling that emits JSON.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl unzip zip git ca-certificates less procps ripgrep \
+        openssh-client jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI, from GitHub's own apt repo (the documented install path).
+# Without it, PR/issue work degrades to hand-rolled curl against the REST API.
+# `gh` reuses SSH agent forwarding or GH_TOKEN, so it needs no extra secrets.
+RUN set -eux; \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg; \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends gh; \
+    rm -rf /var/lib/apt/lists/*
+
+# Pin GitHub's SSH host keys at build time so the first push isn't blocked by an
+# interactive "authenticity of host can't be established" prompt (there is no
+# TTY to answer it during an agent run). `test -s` fails the build if the scan
+# came back empty, rather than leaving that prompt to surface mid-push later.
+RUN mkdir -p /etc/ssh \
+    && ssh-keyscan -t rsa,ecdsa,ed25519 github.com > /etc/ssh/ssh_known_hosts 2>/dev/null \
+    && test -s /etc/ssh/ssh_known_hosts
+
+# Recreate the host user 1:1 so bind-mounted repo files keep correct ownership
+# and absolute paths match the host exactly. The Ubuntu base image ships a
+# default user at UID 1000, so evict it first.
+RUN set -eux; \
+    if getent passwd "${USER_UID}" >/dev/null; then \
+        userdel -rf "$(getent passwd "${USER_UID}" | cut -d: -f1)"; \
+    fi; \
+    if ! getent group "${USER_GID}" >/dev/null; then \
+        groupadd -g "${USER_GID}" "${USER_NAME}"; \
+    fi; \
+    useradd -u "${USER_UID}" -g "${USER_GID}" -d "${USER_HOME}" -m -s /bin/bash "${USER_NAME}"; \
+    mkdir -p "${USER_HOME}/.claude" "${USER_HOME}/.gradle" "${USER_HOME}/.konan"; \
+    chown -R "${USER_UID}:${USER_GID}" "${USER_HOME}"
+ENV HOME=${USER_HOME}
+
+# --- Android SDK ---------------------------------------------------------
+# Installed at the host's sdk.dir path so local.properties resolves unchanged.
+ENV ANDROID_HOME=${ANDROID_SDK_DIR}
+ENV ANDROID_SDK_ROOT=${ANDROID_SDK_DIR}
+RUN mkdir -p "${ANDROID_HOME}/cmdline-tools" \
+    && curl -fsSL -o /tmp/cmdtools.zip \
+        "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip" \
+    && unzip -q /tmp/cmdtools.zip -d "${ANDROID_HOME}/cmdline-tools" \
+    && mv "${ANDROID_HOME}/cmdline-tools/cmdline-tools" "${ANDROID_HOME}/cmdline-tools/latest" \
+    && rm /tmp/cmdtools.zip
+ENV PATH="${PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools"
+RUN yes | sdkmanager --licenses >/dev/null 2>&1 || true \
+    && sdkmanager --install "platform-tools" "platforms;android-36" "build-tools;36.0.0" >/dev/null \
+    && chown -R "${USER_UID}:${USER_GID}" "${ANDROID_HOME}"
+
+# --- Desktop GUI runtime -------------------------------------------------
+# Native libs AWT + Compose Desktop/Skiko need to render over X11, plus Mesa
+# software OpenGL (llvmpipe) so `./gradlew run` works without GPU passthrough.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgl1 libgl1-mesa-dri libglu1-mesa \
+        libx11-6 libxext6 libxrender1 libxtst6 libxi6 libxrandr2 \
+        libxcursor1 libxinerama1 libxxf86vm1 \
+        libfreetype6 libfontconfig1 fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod 755 /usr/local/bin/entrypoint.sh
+
+# --- Claude Code (native binary install, as the target user) -------------
+USER ${USER_NAME}
+ENV PATH="${USER_HOME}/.local/bin:${PATH}"
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Keep ALL of Claude Code's state (account config + credentials) in the
+# persisted ~/.claude volume. Without this, Claude reads a throwaway
+# ~/.claude.json stub the installer leaves in $HOME and shows up logged-out.
+ENV CLAUDE_CONFIG_DIR="${USER_HOME}/.claude"
+
+WORKDIR ${USER_HOME}
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+# Default: drop straight into an unconstrained Claude Code session.
+CMD ["claude", "--dangerously-skip-permissions"]

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,108 @@
+# Claude Code sandbox for Warlock
+
+A containerized dev environment for running **Claude Code with
+`--dangerously-skip-permissions`** ("unconstrained") without giving it access
+to your host. The container isolates the host filesystem and processes; only
+this repo is writable inside it.
+
+## Usage
+
+```bash
+# Unconstrained Claude Code session (builds the image on first run):
+.devcontainer/claude-box.sh
+
+# Drop into a shell in the same environment:
+.devcontainer/claude-box.sh bash
+
+# Run any command:
+.devcontainer/claude-box.sh ./gradlew jvmTest
+```
+
+## What's inside
+
+- **JDK 21** (Temurin) + **Gradle** (via the repo wrapper)
+- **Android SDK**: platform `android-36`, `build-tools;36.0.0`, `platform-tools`,
+  installed at your host's `sdk.dir` path so the git-ignored `local.properties`
+  works unchanged
+- **Claude Code** (native binary), pre-authenticated from your host login
+- **git + ssh + gh + jq + ripgrep** — enough to fetch, rebase, push, and work
+  a PR end to end without shelling out to the host
+
+## Git & GitHub access
+
+The remote is `git@github.com:sproctor/warlock3.git`, so **ssh is required** for
+anything that talks to the remote — fetch, pull, push. Two knobs, both handled
+by `claude-box.sh`:
+
+| What | How | Notes |
+|---|---|---|
+| **Push/fetch auth** | Host **ssh-agent forwarded** into the container | Private keys never enter the container; the agent only signs |
+| **Commit identity** | `user.name` / `user.email` read from your host git config, passed as `GIT_AUTHOR_*` / `GIT_COMMITTER_*` | Avoids bind-mounting `~/.gitconfig` (a mount of a missing file would create a *directory* on the host) |
+
+You need an agent running on the host before launching:
+
+```bash
+eval "$(ssh-agent -s)" && ssh-add     # then: .devcontainer/claude-box.sh
+```
+
+Without one, the container still builds and tests fine — it just can't reach the
+remote, and `claude-box.sh` warns you up front.
+
+**Why agent forwarding and not `~/.ssh`?** Mounting your keys would hand an
+unconstrained agent your credentials for *every* host they unlock, and they'd
+persist in the image layer cache. The agent socket only permits signing, and
+only while the container is running.
+
+Prefer a scoped token instead? Export `GH_TOKEN` on the host and it's passed
+through for `gh`; you can then use an HTTPS remote and skip the agent entirely.
+
+## Portable — nothing is hard-coded
+
+No home directory or repo path is baked into the committed files. On each run,
+`claude-box.sh` derives everything from your environment and writes it to a
+git-ignored `.env` that `docker-compose.yml` interpolates:
+
+| Variable | Source |
+|---|---|
+| `HOST_USER` / `HOST_UID` / `HOST_GID` | `id -un` / `id -u` / `id -g` |
+| `HOST_HOME` | `$HOME` |
+| `REPO_DIR` | parent of `.devcontainer/` |
+| `ANDROID_SDK_DIR` | `sdk.dir` from `local.properties` (else `$HOME/Android/Sdk`) |
+| `GIT_USER_NAME` / `GIT_USER_EMAIL` | `git config --get user.name` / `user.email` |
+| `HOST_SSH_AUTH_SOCK` | `$SSH_AUTH_SOCK` (else `/dev/null`) |
+
+Move the repo, run as a different user, or check this into another clone — it
+adapts. (Because these become build args, the image rebuilds when they change.)
+
+## How it's wired
+
+- Runs as your host user (matching uid/gid) so bind-mounted repo files keep
+  correct ownership and absolute paths match the host.
+- Login is **seeded read-only** from the host on first run into a persistent
+  volume — both `~/.claude/.credentials.json` (token) and `~/.claude.json`
+  (account identity, onboarding, folder trust). `CLAUDE_CONFIG_DIR` points
+  Claude at that volume so it starts logged in as you and persists across runs.
+  In-container writes never touch the host files.
+- Persistent named volumes: `claude-home` (`~/.claude`), `gradle-cache`
+  (`~/.gradle`), `konan-cache` (`~/.konan`).
+- **Open network** — Gradle reaches Maven Central / Google repos with no config.
+  The host is still protected by container isolation.
+
+## Notes & limits
+
+- **iOS targets** can't build on Linux; use desktop (`:desktopApp`) and
+  `:androidApp` / `:core` modules.
+- **Desktop GUI works out of the box.** `./gradlew run` renders on your host
+  display via X11 passthrough (`claude-box.sh` grants access with `xhost`, and
+  the image ships the X11 + software-OpenGL libs Compose Desktop needs). For
+  hardware-accelerated rendering, see the commented `devices:` block in
+  `docker-compose.yml`. On a pure-X11 host (not Wayland) it works the same.
+- **Reset auth**: `docker volume rm devcontainer_claude-home` then re-run.
+- **Rebuild image** after changing the Dockerfile:
+  `docker compose -f .devcontainer/docker-compose.yml build --no-cache`.
+- **GitHub host keys** are pinned at build time via `ssh-keyscan` (trust-on-first-use
+  at build). To verify against GitHub's published fingerprints instead, check
+  `/etc/ssh/ssh_known_hosts` against
+  <https://docs.github.com/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints>.
+- **No `python3`/`node`** in the image. `jq` covers JSON; add them to the
+  Dockerfile if a workflow needs them.

--- a/.devcontainer/claude-box.sh
+++ b/.devcontainer/claude-box.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Build (if needed) and enter the containerized Claude Code environment.
+#
+#   ./claude-box.sh          -> unconstrained Claude Code session
+#   ./claude-box.sh bash     -> interactive shell in the same container
+#   ./claude-box.sh <cmd...>  -> run an arbitrary command in the container
+#
+# Nothing here is hard-coded: the repo location, your home dir, user/uid/gid,
+# and Android SDK path are all derived from the environment and written to a
+# git-ignored .env that docker-compose.yml interpolates.
+set -euo pipefail
+
+cd "$(dirname "$0")"                 # .devcontainer
+REPO_DIR="$(cd .. && pwd)"           # repo root = parent of .devcontainer
+
+# Match the container's Android SDK to the host's local.properties (sdk.dir)
+# so that file resolves unchanged inside the container. Fall back to the
+# Android Studio default if local.properties is absent.
+sdk_dir="$(sed -n 's/^[[:space:]]*sdk\.dir[[:space:]]*=[[:space:]]*//p' \
+    "$REPO_DIR/local.properties" 2>/dev/null | head -1)"
+sdk_dir="${sdk_dir:-$HOME/Android/Sdk}"
+
+# Commit identity, copied from the host's git config so commits made in the
+# container are authored by you. Empty is fine — git just prompts instead.
+git_user_name="$(git config --get user.name 2>/dev/null || true)"
+git_user_email="$(git config --get user.email 2>/dev/null || true)"
+
+# Forward the host's ssh-agent so git can push (the remote is git@github.com)
+# without copying private keys into the container. If no agent is running we
+# point at /dev/null: the mount stays valid and ssh auth is simply unavailable.
+host_ssh_auth_sock="${SSH_AUTH_SOCK:-}"
+if [ -z "$host_ssh_auth_sock" ] || [ ! -S "$host_ssh_auth_sock" ]; then
+    host_ssh_auth_sock=/dev/null
+    echo "[claude-box] No ssh-agent detected; git push over ssh will not work." >&2
+    echo "[claude-box] Start one with: eval \"\$(ssh-agent -s)\" && ssh-add" >&2
+fi
+
+# Values docker-compose.yml interpolates. Written to .env so plain
+# `docker compose` commands (down, logs, ...) keep working too.
+cat > .env <<EOF
+HOST_USER=$(id -un)
+HOST_UID=$(id -u)
+HOST_GID=$(id -g)
+HOST_HOME=$HOME
+REPO_DIR=$REPO_DIR
+ANDROID_SDK_DIR=$sdk_dir
+GIT_USER_NAME=$git_user_name
+GIT_USER_EMAIL=$git_user_email
+HOST_SSH_AUTH_SOCK=$host_ssh_auth_sock
+EOF
+
+COMPOSE=(docker compose -f docker-compose.yml)
+
+# Let the container (same uid as host) reach the host X server for GUI apps.
+if [ -n "${DISPLAY:-}" ] && command -v xhost >/dev/null 2>&1; then
+    xhost +SI:localuser:"$(id -un)" >/dev/null 2>&1 || true
+fi
+
+"${COMPOSE[@]}" build
+exec "${COMPOSE[@]}" run --rm claude "$@"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,72 @@
+# Runs Claude Code unconstrained (--dangerously-skip-permissions) inside a
+# container. The host filesystem/processes are isolated; only the project repo
+# is writable. Network is open so Gradle can reach Maven/Google repos.
+#
+# All ${...} values are supplied by claude-box.sh via a generated .env file
+# (host user/uid/gid, home, repo root, Android SDK path) — no host paths are
+# hard-coded here. Always launch through claude-box.sh so .env is up to date.
+#
+# Usage: ./claude-box.sh            # unconstrained Claude session
+#        ./claude-box.sh bash       # shell in the same environment
+services:
+  claude:
+    build:
+      context: .
+      args:
+        USER_NAME: ${HOST_USER}
+        USER_UID: ${HOST_UID}
+        USER_GID: ${HOST_GID}
+        USER_HOME: ${HOST_HOME}
+        ANDROID_SDK_DIR: ${ANDROID_SDK_DIR}
+    image: warlock3-claudebox
+    init: true
+    stdin_open: true
+    tty: true
+    working_dir: ${REPO_DIR}
+    environment:
+      - TERM=xterm-256color
+      # X11 GUI passthrough (for `./gradlew run`). Uses the host's display;
+      # software OpenGL so it renders without GPU passthrough.
+      - DISPLAY=${DISPLAY:-:0}
+      - LIBGL_ALWAYS_SOFTWARE=1
+      # Git pushes/pulls authenticate via the host's ssh-agent (see volumes).
+      # The agent can only *sign* over this socket — the private keys never
+      # enter the container, so it can't exfiltrate them.
+      - SSH_AUTH_SOCK=/ssh-agent
+      # Commit identity, read from the host's git config by claude-box.sh.
+      # Passed as env rather than mounting ~/.gitconfig: a bind mount of a
+      # non-existent file would silently create a *directory* on the host.
+      - GIT_AUTHOR_NAME=${GIT_USER_NAME}
+      - GIT_AUTHOR_EMAIL=${GIT_USER_EMAIL}
+      - GIT_COMMITTER_NAME=${GIT_USER_NAME}
+      - GIT_COMMITTER_EMAIL=${GIT_USER_EMAIL}
+      # Optional: a GitHub token for `gh` if you'd rather not forward the agent.
+      - GH_TOKEN=${GH_TOKEN:-}
+    volumes:
+      # The project repo, mounted at the identical host path.
+      - ${REPO_DIR}:${REPO_DIR}
+      # Host login (token + account config), read-only, seeded by entrypoint.sh.
+      - ${HOST_HOME}/.claude/.credentials.json:/seed/credentials.json:ro
+      - ${HOST_HOME}/.claude.json:/seed/claude.json:ro
+      # X11 socket for GUI apps. claude-box.sh grants access via xhost.
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      # Host ssh-agent socket, so git can push without private keys in the
+      # container. Falls back to /dev/null when no agent is running, which
+      # simply makes ssh auth unavailable rather than breaking startup.
+      - ${HOST_SSH_AUTH_SOCK:-/dev/null}:/ssh-agent
+      # Persistent state / caches (survive container removal).
+      - claude-home:${HOST_HOME}/.claude
+      - gradle-cache:${HOST_HOME}/.gradle
+      - konan-cache:${HOST_HOME}/.konan
+    # Hardware-accelerated rendering (optional): remove LIBGL_ALWAYS_SOFTWARE
+    # above and uncomment below. Set the GID to your host 'render' group
+    # (run: getent group render).
+    # devices:
+    #   - /dev/dri:/dev/dri
+    # group_add:
+    #   - "109"
+
+volumes:
+  claude-home:
+  gradle-cache:
+  konan-cache:

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Seeds Claude Code credentials from the host on first run, then execs the
+# requested command. Runs as the unprivileged container user.
+set -euo pipefail
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
+mkdir -p "${CLAUDE_DIR}"
+
+# Commit identity arrives as GIT_AUTHOR_*/GIT_COMMITTER_* from the host's git
+# config. Git treats a *set but empty* ident as an error ("empty ident name not
+# allowed") rather than falling back, so drop the vars entirely when the host
+# had none — that way git gives its normal "tell me who you are" hint instead.
+for _var in GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL; do
+    if [ -z "${!_var:-}" ]; then
+        unset "${_var}"
+    fi
+done
+unset _var
+
+# One-time seed: copy the host's login into the persistent volume so the
+# container starts already authenticated *as your account*. We copy (not
+# bind-mount) so in-container writes/token-refreshes never touch host files.
+# Delete the claude-home volume to re-seed from the host.
+#
+#   .credentials.json -> OAuth token
+#   .claude.json      -> account identity (email/org), onboarding, folder trust
+if [ ! -f "${CLAUDE_DIR}/.credentials.json" ] && [ -f /seed/credentials.json ]; then
+    cp /seed/credentials.json "${CLAUDE_DIR}/.credentials.json"
+    chmod 600 "${CLAUDE_DIR}/.credentials.json"
+    echo "[entrypoint] Seeded Claude Code credentials from host."
+fi
+if [ ! -f "${CLAUDE_DIR}/.claude.json" ] && [ -f /seed/claude.json ]; then
+    cp /seed/claude.json "${CLAUDE_DIR}/.claude.json"
+    echo "[entrypoint] Seeded Claude Code account config from host."
+fi
+
+exec "$@"


### PR DESCRIPTION
A Docker-based sandbox for running Claude Code with `--dangerously-skip-permissions` isolated from the host: only the repo is writable; the host filesystem and processes are not exposed.

## What's included
- **JDK 21 + Android SDK (platform 36)** to build the desktop and Android targets
- Tooling: `git`, `ssh`, `gh`, `jq`, `ripgrep`
- `claude-box.sh` derives all host-specific paths at runtime into a git-ignored `.env`, so nothing is hard-coded and it adapts to any clone/user
- Host login seeded read-only; ssh-agent forwarded (keys never enter the container)
- X11 passthrough so `./gradlew run` renders on the host display

## Files
- `.devcontainer/Dockerfile`, `docker-compose.yml`, `entrypoint.sh`, `claude-box.sh`, `README.md`, `.gitignore`

Tooling/dev-environment only — no application code or build config is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)