### PR TITLE
Fix startup crash from duplicate coroutines jars on the packaged classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,24 @@ subprojects {
 
     dependencies {
         add("ktlintRuleset", rootProject.libs.ktlint.compose.rules)
+
+        // The IntelliJ platform icons artifacts (see compose/build.gradle.kts) depend on
+        // JetBrains' fork of coroutines, which sits under a different Maven group and so
+        // never conflict-resolves against the stock kotlinx-coroutines-core we ask for.
+        // Both jars carry kotlinx/coroutines/*, so both used to land in the packaged lib
+        // dir and whichever won the classpath decided which implementation the app got.
+        // The fork lags upstream (1.10.2 vs 1.11.0) and lacks APIs the Kotlin compiler now
+        // emits calls to -- Kotlin 2.4 compiles `runBlocking` down to BuildersKt.runBlockingK,
+        // which exists only in 1.11.0, so a fork-first classpath crashed at startup with
+        // NoSuchMethodError. Collapse the two onto the stock artifact.
+        modules {
+            module("org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm") {
+                replacedBy(
+                    "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
+                    "Duplicate coroutines on the classpath; the fork lags upstream",
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

`v3.1.0-beta.21` crashes at launch for every user, before any window opens:

```
NoSuchMethodError: 'java.lang.Object kotlinx.coroutines.BuildersKt.runBlockingK$default(...)'
  at WarlockCommand.run (Main.kt:170)
```

Reported via Sentry as `DESKTOP-3G` on `desktop@3.1.0-beta.21`.

## Root cause

Two changes in beta.21 combined. Either alone was harmless, which is why beta.20 was fine.

**#234** added `com.jetbrains.intellij.platform:icons-impl` (to fix the IconManager crash). It transitively pulls `org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm:1.10.2-intellij-1`, JetBrains' fork of coroutines. That fork sits under a **different Maven group**, so Gradle never conflict-resolved it against the stock `org.jetbrains.kotlinx` 1.11.0 we ask for. Both jars carry `kotlinx/coroutines/*`, so both shipped in the packaged lib dir:

```
kotlinx-coroutines-core-jvm-1.11.0-....jar
kotlinx-coroutines-core-jvm-1.10.2-intellij-1-....jar   <- fork, wins the classpath
```

**#235** bumped Kotlin 2.3.21 -> 2.4.10. Kotlin 2.4 compiles `runBlocking` down to `BuildersKt.runBlockingK`, which exists only in coroutines 1.11.0. Confirmed at both ends:

- `javap` on our `WarlockCommand.class` emits `BuildersKt.runBlockingK$default`
- `javap` on the two jars: `runBlockingK` present in 1.11.0, absent in 1.10.2

So the first `runBlocking` in `WarlockCommand.run` resolves against the fork and dies.

## Fix

A `replacedBy` module rule collapsing the fork onto the stock artifact.

## Verification

- fork now redirects to `kotlinx-coroutines-core-jvm:1.11.0` in the runtime graph
- distributable ships a single coroutines jar
- packaged binary starts, loads prefs, opens the DB, stays up with no exceptions (this also re-exercises the IconManager path `icons-impl` was added for)
- `ktlintCheck` passes

## Follow-up worth considering

**CI could not have caught this.** `check` resolves through Gradle's classpath, where 1.11.0 wins within-group, so tests pass. The duplicate only exists physically in the packaged lib dir. A smoke test that launches the packaged app would close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)