### PR TITLE
Pin Jewel to the last Maven Central build, dropping icons-impl

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -135,11 +135,6 @@ kotlin {
             // does not pull the platform icons jar, so the SVG resources have to be added
             // explicitly or every IntelliJ-icon-keyed Icon renders as a magenta placeholder.
             implementation(libs.intellij.platform.icons)
-            // Jewel 0.38's IntUiTheme activates a com.intellij.platform.icons.IconManager
-            // (via StandaloneIconManager). Those runtime classes ship in icons-impl (which
-            // pulls icons-api transitively), not in the resource-only icons jar above; without
-            // them the app crashes at theme composition with NoClassDefFoundError: IconManager.
-            implementation(libs.intellij.platform.icons.impl)
         }
         if (!skipIos) {
             iosMain.dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,10 +37,24 @@ compose-material3 = "1.12.0-alpha03"
 colorpicker = "1.2.0"
 fastscroller = "0.3.2"
 filekit = "0.14.2"
-intellij = "262.8665.258"
-##    ⬆ = "262.8665.262"
-##    ⬆ = "262.8665.270"
-jewel = "0.38.0-262.8665.258"
+# Treat the Jewel/platform pair as one pinned unit, and prefer builds published to
+# Maven Central. Two traps here, both hit in v3.1.0-beta.21:
+#
+#  1. 0.38.x exists ONLY in the IntelliJ platform repository. Those artifacts are a
+#     byproduct of the IJ monorepo build, not published releases: 0.38's standalone
+#     POM omits the icons-api/icons-impl its own bytecode requires, and pulling those
+#     in drags JetBrains' coroutines fork onto the packaged classpath alongside stock
+#     kotlinx-coroutines. That duplicate crashed the app at startup.
+#  2. The trailing platform build is part of the API, not just metadata. 0.37.0-262.4852.51
+#     dropped the rememberSelectableLazyListState(selectionMode=) overload that
+#     0.37.0-261.26222.65 has and WarlockDropdownSelect depends on, despite both
+#     calling themselves 0.37.0.
+#
+# So: bump these two together, and verify the packaged app launches, not just that it
+# compiles. `icons` is resource-only (SVGs, no classes, empty POM) and comes from the
+# IntelliJ repo since that group is not on Maven Central.
+intellij = "261.26222.65"
+jewel = "0.37.0-261.26222.65"
 kermit = "2.1.0"
 kotlin = "2.4.10"
 kotlinx-benchmark = "0.4.17"
@@ -112,7 +126,6 @@ ktor-utils = { module = "io.ktor:ktor-utils", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 intellij-platform-icons = { module = "com.jetbrains.intellij.platform:icons", version.ref = "intellij" }
-intellij-platform-icons-impl = { module = "com.jetbrains.intellij.platform:icons-impl", version.ref = "intellij" }
 jewel-standalone = { module = "org.jetbrains.jewel:jewel-int-ui-standalone", version.ref = "jewel" }
 jewel-decorated-window = { module = "org.jetbrains.jewel:jewel-int-ui-decorated-window", version.ref = "jewel" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,22 +37,7 @@ compose-material3 = "1.12.0-alpha03"
 colorpicker = "1.2.0"
 fastscroller = "0.3.2"
 filekit = "0.14.2"
-# Treat the Jewel/platform pair as one pinned unit, and prefer builds published to
-# Maven Central. Two traps here, both hit in v3.1.0-beta.21:
-#
-#  1. 0.38.x exists ONLY in the IntelliJ platform repository. Those artifacts are a
-#     byproduct of the IJ monorepo build, not published releases: 0.38's standalone
-#     POM omits the icons-api/icons-impl its own bytecode requires, and pulling those
-#     in drags JetBrains' coroutines fork onto the packaged classpath alongside stock
-#     kotlinx-coroutines. That duplicate crashed the app at startup.
-#  2. The trailing platform build is part of the API, not just metadata. 0.37.0-262.4852.51
-#     dropped the rememberSelectableLazyListState(selectionMode=) overload that
-#     0.37.0-261.26222.65 has and WarlockDropdownSelect depends on, despite both
-#     calling themselves 0.37.0.
-#
-# So: bump these two together, and verify the packaged app launches, not just that it
-# compiles. `icons` is resource-only (SVGs, no classes, empty POM) and comes from the
-# IntelliJ repo since that group is not on Maven Central.
+# Jewel 0.38 is not officially released. check maven central before updating. IJ repo gets pre-released versions
 intellij = "261.26222.65"
 jewel = "0.37.0-261.26222.65"
 kermit = "2.1.0"


### PR DESCRIPTION
Supersedes #236, which patched the symptom. This removes the cause.

## What broke

`v3.1.0-beta.21` crashed at startup for every user with `NoSuchMethodError` on `BuildersKt.runBlockingK` (Sentry `DESKTOP-3G`).

## Why

**Jewel 0.38 is not published to Maven Central.** Central's Jewel line stops at `0.37.0-262.4852.51`. `0.38.0-262.8665.258` exists only in the IntelliJ platform repository, where artifacts are a byproduct of the IJ monorepo build rather than curated releases. That has two consequences we hit:

1. **Its POM is incomplete.** `jewel-int-ui-standalone` 0.38 declares only `jewel-ui` and `jna-platform`, yet its `StandaloneIconManager` hard-references `DefaultIconManager` and `IntUiThemeKt` references `IconManager`. That is why #234 had to add `icons-impl` by hand to get past theme composition. Verified against the published POM, not just the local cache.
2. **`icons-api`/`icons-impl` depend on JetBrains' coroutines fork** (`org.jetbrains.intellij.deps.kotlinx`). Different Maven group, so it never conflict-resolves against stock `org.jetbrains.kotlinx`. Both jars shipped in the packaged lib dir; the fork (1.10.2) won the classpath and lacks the `runBlockingK` that Kotlin 2.4 (from #235) now emits for `runBlocking`.

The resource-only `icons` jar we've had since before beta.20 declares zero dependencies, which is why this never bit until #234.

## The fix

Back to `0.37.0-261.26222.65`, the pair beta.20 shipped. That drops `icons-impl`, `icons-api`, and the coroutines fork together, with no `replacedBy` workaround needed.

**`0.37.0-262.4852.51` is not a substitute** even though it's newer and on Maven Central: it dropped the `rememberSelectableLazyListState(selectionMode = ...)` overload that `WarlockDropdownSelect` uses. Same `0.37.0` marketing version, different API. The trailing platform build is part of the API surface, so the two versions are now pinned and commented as one unit.

## Verified

- distributable ships a single `kotlinx-coroutines-core-jvm` (1.11.0) and only the resource-only icons jar
- packaged app launches, stays up, zero icon-resolution errors in the log
- `./gradlew check -PiosSkip=true -PlintSkip=true` passes

## Also investigated: can we drop the IntelliJ repo entirely?

No. Checked and rejected. `com.jetbrains.intellij.platform` is not on Maven Central at all (the whole group 404s), so the `icons` jar can only come from there. Jewel bundles only its checkbox/radio and window-decoration SVGs; everything else resolves through `AllIconsKeys` against that jar.

Building without it does compile and launch, but Jewel internals for components we use would degrade to magenta placeholders:

| Jewel class | Icons needed | We use |
|---|---|---|
| `TextContextMenu` | `Actions.Copy`, `MenuCut`, `MenuPaste` | TextField right-click (x4) |
| `LinkKt` / `IntUiLinkStylingKt` | `Nodes.PpWeb`, `Ide.External`, `Actions.Copy` | Link (x6) |
| `IntUiComboBoxStylingKt` | `General.ChevronDown` | `WarlockDropdownSelect` |
| `IntUiMenuStylingKt` | `General.ChevronRight` | Menu |

A dashboard-only launch shows just one failure (`expui/general/drag.svg`, our own `AllIconsKeys.General.Drag`) because the rest aren't on screen at startup. So the runtime check alone would have been misleading here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)