### PR TITLE
Derive release versions from tag history; correct the docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,13 @@ Warlock is a multi-platform front-end client for the Simutronics Game Engine (SG
 
 ```bash
 # Run the desktop app
-./gradlew run
+./gradlew :desktopApp:run
 
 # Build everything
 ./gradlew build
+
+# What CI runs (Android Lint and iOS targets are skipped there)
+./gradlew check -PiosSkip=true -PlintSkip=true
 
 # Run all tests
 ./gradlew allTests
@@ -24,11 +27,14 @@ Warlock is a multi-platform front-end client for the Simutronics Game Engine (SG
 # Run a single test class (JVM)
 ./gradlew jvmTest --tests "com.example.MyTest"
 
-# Full release pipeline
-./release.sh
+# Build the packaged desktop app locally (output under
+# desktopApp/build/potassium/binaries/main/app/)
+./gradlew :desktopApp:createDistributable
 ```
 
-Requires Java 21 JVM toolchain.
+Compilation uses a Java 21 toolchain. The desktop app *runs* and is *packaged*
+under JBR 25, configured via `javaHome` in `desktopApp/build.gradle.kts`, so
+`:desktopApp:run` and the packaging tasks use a different JVM than the build.
 
 ## Module Architecture
 
@@ -59,4 +65,29 @@ The project is organized into 6 Gradle modules:
 
 ## Distribution
 
-Desktop packages are built with [Conveyor](https://www.hydraulic.software/). The `conveyor.conf` file configures macOS DMG, Windows MSI, and Linux Deb packaging with code signing and auto-update via GitHub Pages.
+Releases are cut by pushing a git tag; `.github/workflows/release.yaml` does the
+rest. Use `./release.sh` rather than tagging by hand: it derives the next
+version from the tag history (`-v` prints it without tagging, `-p` cuts a
+production release, `-m` starts a new minor).
+
+**The tag is the only source of versioning.** No version string is committed
+anywhere. `release.yaml` passes the tag through as `RELEASE_VERSION`, and
+`desktopApp/build.gradle.kts` routes a tag containing `beta`/`alpha` to the
+matching update channel and marks the GitHub release a prerelease.
+
+Packaging is handled by [Potassium](https://github.com/sproctor/potassium)
+(`potassium { }` in `desktopApp/build.gradle.kts`), which produces NSIS for
+Windows, DMG + Zip for macOS, and Deb/AppImage/Tar for Linux, with Azure Trusted
+Signing on Windows and Developer ID signing + notarization on macOS. The
+workflow builds a matrix of Linux amd64/arm64, Windows amd64, and macOS
+arm64/intel, then publishes them as a GitHub release. An Android job builds an
+AAB and uploads to the Play internal track, gated on the `PUBLISH_ANDROID` repo
+variable.
+
+**Verify the packaged app, not just CI.** `check` compiles and tests against
+Gradle's resolved classpath, which is not the classpath the shipped app runs on:
+the packaged `lib/` directory can contain jars Gradle deduplicated away. A
+release has shipped that passed CI and crashed on launch for every user
+(`v3.1.0-beta.21`, a duplicate `kotlinx-coroutines` from a transitive IntelliJ
+dependency). Before tagging, run `:desktopApp:createDistributable` and launch
+`desktopApp/build/potassium/binaries/main/app/warlock/bin/warlock`.

--- a/release.sh
+++ b/release.sh
@@ -1,31 +1,155 @@
 #!/usr/bin/bash
 
-# Release pipeline: tag the current commit and push the tag.
-# The GitHub Actions release workflow (.github/workflows/release.yaml) builds
-# and publishes the multi-platform desktop packages on tag push.
+# Tag the current commit so the GitHub Actions release workflow
+# (.github/workflows/release.yaml) picks it up and publishes.
 #
-# Usage: ./release.sh <version>
+# Version is auto-derived from the latest git tag. Beta is the default; use
+# -p to cut a production release.
+#
+#   - default   -> next beta of the in-progress version, or beta.1 on the
+#                  next patch if no beta line is open
+#                  (v3.0.166 -> v3.0.167-beta.1, or .N+1 if betas exist)
+#   - -m        -> bump minor and start beta.1 on the new minor
+#                  (with 3.1.0 betas open -> v3.2.0-beta.1)
+#   - -p        -> production tag. Finalizes the in-progress beta version if
+#                  one exists, otherwise bumps patch.
+#                  (with 3.1.0 betas open -> v3.1.0)
+#   - -m -p     -> bump minor, reset patch, no beta suffix
+#   - -v        -> print the next tag and exit (no tag, no push)
+#
+# The tag is what sets the version: release.yaml passes it through as
+# RELEASE_VERSION, and desktopApp/build.gradle.kts routes a tag containing
+# "beta"/"alpha" to the matching update channel. There is no version string
+# committed anywhere, so the tag is the single source of truth.
+#
 # Examples:
-#   ./release.sh 3.0.165
-#   ./release.sh 3.0.165-beta.1
+#   release.sh        # v3.1.0-beta.22 -> v3.1.0-beta.23
+#   release.sh -p     # v3.1.0-beta.22 -> v3.1.0
+#   release.sh -m     # v3.1.0-beta.22 -> v3.2.0-beta.1
+#   release.sh -v     # print next tag and exit
 
-set -e
+set -o errexit -o pipefail -o noclobber
 
-if [[ -z "$1" ]]; then
-  echo "Usage: $0 <version>" >&2
-  echo "Example: $0 3.0.165" >&2
-  echo "         $0 3.0.165-beta.1" >&2
+PROD=0
+MINOR=0
+PRINT_ONLY=0
+DEBUG=0
+
+RED='\033[0;31m'
+NC='\033[0m'
+
+usage() {
+  echo "Usage: release.sh [-dhmpv]"
+  echo "  -d   enable debug mode"
+  echo "  -h   show this help"
+  echo "  -m   bump minor (reset patch to 0)"
+  echo "  -p   production release (no beta suffix)"
+  echo "  -v   print next tag and exit (no tag, no push)"
+}
+
+while getopts "dhmpv" arg; do
+  case $arg in
+    d) DEBUG=1 ;;
+    m) MINOR=1 ;;
+    p) PROD=1 ;;
+    v) PRINT_ONLY=1 ;;
+    h) usage; exit 0 ;;
+    *) usage; exit 1 ;;
+  esac
+done
+
+if [[ "$DEBUG" == "1" ]]; then
+  set -xv
+fi
+
+TAG_GLOB='v[0-9]*.[0-9]*.[0-9]*'
+
+# Bare version strings (3.1.0 or 3.1.0-beta.22) from the release tags.
+# The '[-]' bracket form matters: ugrep, which is what `grep` resolves to on
+# some setups here, rejects a bare '-' pattern as a missing argument.
+all_versions() { git tag --list "$TAG_GLOB" | sed -E 's/^v//'; }
+
+# Highest stable version (no pre-release suffix), as a bare X.Y.Z.
+STABLE_VERSION=$(all_versions | grep -vE '[-]' | sort -V | tail -1 || true)
+
+if [[ -z "$STABLE_VERSION" ]]; then
+  echo -e "${RED}No prior stable tag found (looked for v*.*.* without a suffix).${NC}"
+  echo "Create an initial tag manually, then re-run."
   exit 1
 fi
 
-VERSION="$1"
+IFS='.' read -r MAJOR MIN PATCH <<<"$STABLE_VERSION"
 
-echo "Releasing v${VERSION}..."
+# Highest X.Y.Z across every tag, ignoring any -beta suffix. This is ahead of
+# STABLE_VERSION whenever a beta line is open (as 3.1.0 has been since 3.0.166).
+LATEST_ANY_BASE=$(all_versions | sed -E 's/-.*//' | sort -V | tail -1 || true)
+HIGHER=$(printf '%s\n%s\n' "$LATEST_ANY_BASE" "$STABLE_VERSION" | sort -V | tail -1)
+BETA_LINE_OPEN=0
+if [[ "$LATEST_ANY_BASE" != "$STABLE_VERSION" && "$HIGHER" == "$LATEST_ANY_BASE" ]]; then
+  BETA_LINE_OPEN=1
+fi
 
-read -p "Press enter to tag v${VERSION} and push"
+# Decide the target VERSION (the MAJOR.MINOR.PATCH portion of the next tag).
+if [[ "$MINOR" == "1" ]]; then
+  # Bump minor from whichever line is furthest along. Basing this on the latest
+  # stable instead would hand back the already-open beta version: with stable
+  # 3.0.166 and 3.1.0 betas in flight, "start a new minor" means 3.2.0, not 3.1.0.
+  IFS='.' read -r BUMP_MAJOR BUMP_MIN _ <<<"$HIGHER"
+  VERSION="${BUMP_MAJOR}.$((BUMP_MIN + 1)).0"
+elif [[ "$BETA_LINE_OPEN" == "1" ]]; then
+  # Default (beta) and -p both target the in-progress version: default bumps the
+  # beta number, -p finalizes that version as stable.
+  VERSION="$LATEST_ANY_BASE"
+else
+  VERSION="${MAJOR}.${MIN}.$((PATCH + 1))"
+fi
 
-git tag "v${VERSION}"
-git push origin "v${VERSION}"
+if [[ "$PROD" == "1" ]]; then
+  TAG="v${VERSION}"
+else
+  NEXT=1
+  while git rev-parse "v${VERSION}-beta.${NEXT}" >/dev/null 2>&1; do
+    NEXT=$((NEXT + 1))
+  done
+  TAG="v${VERSION}-beta.${NEXT}"
+fi
 
-echo "Tag pushed. CI will build and publish the release at:"
-echo "  https://github.com/sproctor/warlock3/actions"
+if [[ "$PRINT_ONLY" == "1" ]]; then
+  echo "$TAG"
+  exit 0
+fi
+
+echo "Latest stable: v${STABLE_VERSION}"
+if [[ "$BETA_LINE_OPEN" == "1" ]]; then
+  echo "Beta line open: v${LATEST_ANY_BASE}"
+fi
+echo "Next tag:      ${TAG}"
+
+if [[ -n $(git status --porcelain) ]]; then
+  echo -e "${RED}There are uncommitted changes${NC}"
+  exit 1
+fi
+
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+  echo -e "${RED}Tag $TAG already exists${NC}"
+  exit 1
+fi
+
+echo "Tagging $TAG and pushing"
+read -p "Press enter to continue, or ctrl-c to abort"
+
+git tag "$TAG"
+git push origin "$TAG"
+
+if [[ "$PROD" == "1" ]]; then
+  channel="production"
+else
+  channel="beta"
+fi
+
+echo "Pushed $TAG."
+echo "  Desktop: build and publish the ${channel} Linux (amd64/arm64), Windows,"
+echo "           and macOS (arm64/intel) packages as a GitHub release."
+echo "  Android: build an AAB and upload it to the Play internal track"
+echo "           (skipped unless the PUBLISH_ANDROID repo variable is true)."
+echo "Watch: https://github.com/sproctor/warlock3/actions"


### PR DESCRIPTION
## release.sh

Took the version as an argument, so the next beta number had to be hand-computed every time with no feedback if it was wrong. Version derivation is now adapted from `ScrapReceipts/ReceiptsApp/release.sh`.

Verified against the real tag history (stable `v3.0.166`, open beta line `3.1.0`):

| Command | Result |
|---|---|
| `./release.sh -v` | `v3.1.0-beta.23` |
| `./release.sh -p -v` | `v3.1.0` |
| `./release.sh -m -v` | `v3.2.0-beta.1` |
| `./release.sh -m -p -v` | `v3.2.0` |

Guards carried over: refuses a dirty tree, refuses to overwrite an existing tag, still confirms before pushing. Checked that the dirty-tree guard fires before the prompt.

### Departures from the script this was adapted from

- **No `-t TARGET`.** That script's platform-prefixed tags (`desktop-v...`, `windows-v...`) key off tag filters its workflows declare. `release.yaml` here filters on `tags: ['v*']` only, so a prefixed tag would push and trigger nothing at all. That fails more quietly than not having the flag.
- **No `releaseNotes/` check, no Android promote guards.** There's no `releaseNotes/` convention here, and the Android job always builds a fresh AAB to the internal track rather than promoting an existing one, so there is nothing to guard.
- **`-m` bumps from whichever line is furthest along**, not from latest stable. Stable is `v3.0.166` while the `3.1.0` beta line has been open for 22 betas, so bumping from stable would have returned `3.1.0`, the line already in flight.

Small thing worth knowing: uses grep's `'[-]'` bracket form rather than a bare `'-'` pattern. ugrep, which is what `grep` resolves to on some setups here, rejects the bare form as a missing argument. Commented in the script so it doesn't look like a pointless edit later.

## CLAUDE.md

The Distribution section documented [Conveyor](https://www.hydraulic.software/) and a `conveyor.conf` that no longer exists in the repo. Packaging has moved to [Potassium](https://github.com/sproctor/potassium), driven by `release.yaml` on tag push. Rewritten to describe the actual pipeline, including that the tag is the only source of versioning (no version string is committed anywhere).

Also in Build & Development Commands:
- `./gradlew run` corrected to `:desktopApp:run`
- added the CI invocation (`check -PiosSkip=true -PlintSkip=true`) and `createDistributable`
- noted that compilation uses a Java 21 toolchain while the app runs and packages under JBR 25, which is easy to trip over

🤖 Generated with [Claude Code](https://claude.com/claude-code)