### PR TITLE
Restrict the IntelliJ repository to com.jetbrains.intellij.* groups

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,20 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven("https://www.jetbrains.com/intellij-repository/releases")
+        // This repository serves IntelliJ monorepo build output rather than curated
+        // releases, so treat it as a narrow escape hatch: it is only here because
+        // com.jetbrains.intellij.platform (we need :icons, a resource-only SVG jar for
+        // Jewel's AllIconsKeys lookups) is not published to Maven Central at all.
+        //
+        // The content filter keeps anything else from silently resolving from here.
+        // That matters because artifacts published only to this repo carry real hazards:
+        // incomplete POMs, and versions whose API changes without the version changing.
+        // v3.1.0-beta.21 shipped a startup crash that started exactly this way, with
+        // Jewel drifting from a Maven Central release onto an IJ-repo-only 0.38 build.
+        // With this filter that bump fails at dependency resolution instead of at launch.
+        maven("https://www.jetbrains.com/intellij-repository/releases") {
+            content { includeGroupByRegex("com\\.jetbrains\\.intellij\\..*") }
+        }
         // mavenLocal()
     }
 }


### PR DESCRIPTION
## Why

The IntelliJ platform repository serves IJ monorepo build output rather than curated releases. It's only in the build because `com.jetbrains.intellij.platform` is not published to Maven Central at all, and we need `:icons`, the resource-only SVG jar backing Jewel's `AllIconsKeys` lookups.

Declared unfiltered, it is also free to serve anything else missing from Central. That's how `v3.1.0-beta.21` broke:

1. Jewel drifted from a Maven Central release onto `0.38.0-262.8665.258`, published only in this repo
2. its incomplete POM forced adding `icons-impl` by hand to get past theme composition
3. `icons-impl` dragged JetBrains' coroutines fork onto the packaged classpath next to stock `kotlinx-coroutines`
4. every user crashed at startup on `NoSuchMethodError: BuildersKt.runBlockingK`

Step 1 is the one worth blocking, and a content filter blocks it.

## Verified both directions

**Still resolves.** `:desktopApp:createDistributable --refresh-dependencies` succeeds and ships the same `icons-261.26222.65` jar; `check -PiosSkip=true -PlintSkip=true` passes.

**Now catches the drift.** Re-pointing `jewel` at `0.38.0-262.8665.258` fails at dependency resolution:

```
> Could not resolve all files for configuration ':compose:jvmCompileClasspath'.
   > Could not find org.jetbrains.jewel:jewel-int-ui-standalone:0.38.0-262.8665.258.
     Required by:
         project ':compose'
```

Before this change that same bump resolved quietly and failed at launch instead.

## What it does not cover

The coroutines fork itself, `org.jetbrains.intellij.deps.kotlinx`, **is** on Maven Central (verified: 200). So this filter would not have blocked the fork on its own, only the Jewel drift that pulled it in. It's a guard on the root cause, not on the duplicate-jar mechanism.

Minor side benefit: Gradle no longer probes this repo for unrelated modules during resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)