### PR TITLE
Swallow lazy-layout text-selection crash; drop fixed a11y workaround

### DIFF
--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -195,7 +195,6 @@ private class WarlockCommand : CliktCommand() {
                 addAll(createInitialGameStates(appContainer, credentials, sgeSettings, logger))
             }
 
-        disableMacAccessibilityWorkaround()
         installUncaughtExceptionWorkaround()
 
         val updater = buildUpdater(clientSettings)
@@ -632,39 +631,25 @@ private class WarlockCommand : CliktCommand() {
         }
     }
 
-    // Turn off Compose Desktop's accessibility bridge on macOS. Bug 2 below (the
-    // ComposeSceneAccessibility.defaultAccessibilityFocusTarget NPE) fires in practice only on
-    // macOS, whose a11y system aggressively queries AccessibleContext and so keeps driving the
-    // crashing node-sync/focus-retarget path. installUncaughtExceptionWorkaround can swallow the
-    // resulting uncaught exception, but only after the sync is interrupted mid-way, leaving the a11y
-    // tree inconsistent so it re-throws on the next focus change. Disabling the bridge stops that
-    // path from ever running. The trade-off is no screen-reader support on macOS until the upstream
-    // fix lands, which beats a crash loop. Compose reads this system property lazily when it builds
-    // the first ComposeSceneAccessibility, so this must run before the first window opens; we leave
-    // an explicit -Dcompose.accessibility.enable=... on the command line untouched as an escape hatch.
-    private fun disableMacAccessibilityWorkaround() {
-        if (DesktopPlatform.Current == DesktopPlatform.MacOS &&
-            System.getProperty("compose.accessibility.enable") == null
-        ) {
-            System.setProperty("compose.accessibility.enable", "false")
-        }
-    }
-
     // Swallow known, unrecoverable upstream Compose Desktop crashes that surface as uncaught
     // exceptions on the AWT event thread. Each originates entirely inside Compose framework code, so
     // there is nothing for us to fix and nothing the user can do; killing the whole app over them is
-    // worse than carrying on (at worst with degraded screen-reader support).
+    // worse than carrying on (at worst a transient input glitch in the affected control).
     //   1. NoSuchElementException "Cannot find value for key": https://issuetracker.google.com/issues/399134381
-    //   2. NullPointerException in ComposeSceneAccessibility.defaultAccessibilityFocusTarget: while
-    //      retargeting accessibility focus after a node is removed it walks the Accessible tree into
-    //      an ArrayDeque, but getAccessibleChild() can return null and ArrayDeque rejects nulls.
-    //      Still unguarded in compose-multiplatform 1.11.x. disableMacAccessibilityWorkaround stops
-    //      this from ever firing on macOS; this stays as the cross-platform safety net.
-    //   3. NullPointerException from DefaultOpenContextMenu's onKeyEvent handler in
+    //   2. NullPointerException from DefaultOpenContextMenu's onKeyEvent handler in
     //      BasicContextMenuRepresentation: pressing an arrow key while the text context menu (the
     //      right-click Copy/Paste popup) is open calls FocusManager.moveFocus to step between menu
     //      items, and that traversal NPEs inside Compose's focus machinery. Not accessibility-related
     //      and not macOS-specific. No upstream issue located; still present in 1.11.x.
+    //   3. IndexOutOfBoundsException from MultiSelectionLayout.getCrossStatus (SelectionLayout.kt),
+    //      thrown while starting a text selection in a stream window. Each stream wraps a LazyColumn of
+    //      per-line selectables in a single SelectionContainer; when a drag starts, the layout indexes
+    //      infoList with a slot the SelectionRegistrar handed out for a line that has since left
+    //      composition or been trimmed from the scrollback buffer (both routine as game text streams),
+    //      so the registrar and the freshly built layout disagree on the selectable count and the
+    //      index runs off the end. Inherent to lazy layouts inside a SelectionContainer, whose text
+    //      selection is documented as undefined for items that are not currently composed; unfixed
+    //      upstream (JetBrains/compose-multiplatform#1280).
     // Matching on frame names is reliable because the desktop build never runs ProGuard
     // (it is disabled in build.gradle.kts), so class/method names are never obfuscated.
     private fun installUncaughtExceptionWorkaround() {
@@ -698,17 +683,20 @@ private class WarlockCommand : CliktCommand() {
                         cause.message?.contains("Cannot find value for key") == true
                     }
 
-                    // Workarounds: the a11y focus-target crash (bug 2,
-                    // https://youtrack.jetbrains.com/issue/CMP-10170/Crash-in-A11Y-subsystem) and the
-                    // context-menu arrow-key crash (bug 3, no upstream issue).
+                    // Workaround: the context-menu arrow-key crash (bug 2, no upstream issue).
                     is NullPointerException -> {
                         cause.stackTrace.any {
-                            it.className.endsWith("ComposeSceneAccessibility") &&
-                                it.methodName == "defaultAccessibilityFocusTarget"
-                        } ||
-                            cause.stackTrace.any {
-                                it.className.contains("BasicContextMenuRepresentation")
-                            }
+                            it.className.contains("BasicContextMenuRepresentation")
+                        }
+                    }
+
+                    // Workaround: text selection in a lazy layout (bug 3). Any out-of-bounds thrown
+                    // from inside Compose's selection package is this class of upstream bug: our own
+                    // code never runs there, so scoping to that package keeps real app bugs visible.
+                    is IndexOutOfBoundsException -> {
+                        cause.stackTrace.any {
+                            it.className.startsWith("androidx.compose.foundation.text.selection.")
+                        }
                     }
 
                     else -> {


### PR DESCRIPTION
## Summary

Two changes to `installUncaughtExceptionWorkaround` in `Main.kt`, the AWT uncaught-exception handler that absorbs known-unrecoverable upstream Compose Desktop crashes.

**Add: swallow the lazy-layout text-selection crash.** Production crash (`3.1.0-beta.22`): `IndexOutOfBoundsException: Index 33 out of bounds for length 33` at `MultiSelectionLayout.getCrossStatus` (`SelectionLayout.kt`), triggered by starting a text selection in a stream window. Each stream wraps a `LazyColumn` of per-line selectables in a single `SelectionContainer`; the `SelectionRegistrar` can hand out a slot for a line that has since left composition or been trimmed from the scrollback buffer (both routine as game text streams and the `ArrayDeque` buffer trims to `maxLines`), so the freshly built layout indexes `infoList` off the end. This is inherent to lazy layouts inside a `SelectionContainer` and is unfixed upstream ([compose-multiplatform#1280](https://github.com/JetBrains/compose-multiplatform/issues/1280)). The matcher is scoped to any `IndexOutOfBoundsException` with a frame in `androidx.compose.foundation.text.selection.*` (our code never runs there, so real app bugs stay visible). Turns a whole-app crash into, at worst, a transient failed selection.

**Remove: the accessibility-focus-target workaround**, now that the upstream fix has landed. Both halves go:
- `disableMacAccessibilityWorkaround()` (force-disabled the Compose a11y bridge on macOS) - removing it **re-enables screen-reader support on macOS**.
- The `ComposeSceneAccessibility.defaultAccessibilityFocusTarget` NPE swallow, which per its own comment re-threw on the next focus change and never actually recovered.

The unrelated context-menu arrow-key NPE swallow (`BasicContextMenuRepresentation`) is kept; remaining cases renumbered.

## Test plan

- [x] `./gradlew :desktopApp:compileKotlin` passes
- [x] `./gradlew :desktopApp:ktlintCheck` passes (also enforced by the pre-commit hook)
- [ ] Smoke-test VoiceOver on the packaged macOS app to confirm the upstream a11y fix is in `compose 1.12.0-beta02` before cutting a release (this PR reactivates the macOS a11y bridge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)