### PR TITLE
Drop the redundant IntelliJ icons dependencies

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -135,9 +135,6 @@ kotlin {
             // does not pull the platform icons jar, so the SVG resources have to be added
             // explicitly or every IntelliJ-icon-keyed Icon renders as a magenta placeholder.
             implementation(libs.intellij.platform.icons)
-            implementation(libs.intellij.platform.icons.api)
-            implementation(libs.intellij.platform.icons.api.rendering)
-            implementation(libs.intellij.platform.icons.impl)
         }
         if (!skipIos) {
             iosMain.dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -115,9 +115,6 @@ ktor-utils = { module = "io.ktor:ktor-utils", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 intellij-platform-icons = { module = "com.jetbrains.intellij.platform:icons", version.ref = "intellij" }
-intellij-platform-icons-api = { module = "com.jetbrains.intellij.platform:icons-api", version.ref = "intellij" }
-intellij-platform-icons-api-rendering = { module = "com.jetbrains.intellij.platform:icons-api-rendering", version.ref = "intellij" }
-intellij-platform-icons-impl = { module = "com.jetbrains.intellij.platform:icons-impl", version.ref = "intellij" }
 jewel-standalone = { module = "org.jetbrains.jewel:jewel-int-ui-standalone", version.ref = "jewel" }
 jewel-decorated-window = { module = "org.jetbrains.jewel:jewel-int-ui-decorated-window", version.ref = "jewel" }
 lua-kmp = { group = "com.seanproctor", name = "lua-kmp", version.ref = "lua-kmp" }


### PR DESCRIPTION
Removes `icons-api`, `icons-api-rendering` and `icons-impl`. They are not needed: the resource-only `:icons` jar is the one that keeps Jewel's `AllIconsKeys` lookups working, and it stays.

These rode into master by accident on #251. That branch was cut from a local master which still carried an `add intellij icons dependencies` commit, so the squash merge brought the deps along with the lab tool. Sorry about that.

### How I picked what to keep

Ran the desktop app with each combination and watched both the window and Jewel's resource loader:

| Dependencies | Result |
| --- | --- |
| `:icons` only | dashboard renders every icon, no icon errors in the log |
| none of them | Jewel logs `Resource 'expui/general/drag.svg' ... not found` for the connection-list drag handles |

So `:icons` is still doing real work under Jewel 0.39.1 and the other three are dead weight. `./gradlew check -PiosSkip=true -PlintSkip=true` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
