### PR TITLE
Use AGP's withAndroid() in the source set hierarchy

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -1,8 +1,6 @@
 @file:OptIn(ExperimentalKotlinGradlePluginApi::class)
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidCompilation
-import org.gradle.api.tasks.bundling.Zip
-import org.gradle.api.tasks.bundling.ZipEntryCompression
+import com.android.build.api.withAndroid
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
@@ -60,14 +58,12 @@ kotlin {
         common {
             group("commonJvmAndroid") {
                 withJvm()
-                withAndroidTarget()
-                // Following line can be removed when https://issuetracker.google.com/issues/442950553 is fixed
-                withCompilations { it is KotlinMultiplatformAndroidCompilation }
+                @Suppress("UnstableApiUsage")
+                withAndroid()
             }
             group("mobile") {
-                withAndroidTarget()
-                // Following line can be removed when https://issuetracker.google.com/issues/442950553 is fixed
-                withCompilations { it is KotlinMultiplatformAndroidCompilation }
+                @Suppress("UnstableApiUsage")
+                withAndroid()
                 // Keep the ios subgroup declared even when iOS targets are skipped so
                 // the mobileMain source set is still created for androidMain.
                 group("ios") {
@@ -217,6 +213,7 @@ tasks.register<JavaExec>("streamNetworkBenchmark") {
 // churn between builds. The zip readers on every platform (java.util.zip on JVM/Android, kompress on
 // iOS) handle DEFLATE, so the archive is compressed.
 val packageDefaultSkin by tasks.registering(Zip::class) {
+    description = "Creates skin zip from skin files"
     from(layout.projectDirectory.dir("skin"))
     archiveFileName.set("skin.zip")
     destinationDirectory.set(layout.buildDirectory.dir("generated/skin/files"))

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalKotlinGradlePluginApi::class)
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidCompilation
+import com.android.build.api.withAndroid
 import com.strumenta.antlrkotlin.gradle.AntlrKotlinTask
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
@@ -16,6 +16,7 @@ plugins {
 
 val generateKotlinGrammarSource =
     tasks.register<AntlrKotlinTask>("generateKotlinGrammarSource") {
+
         dependsOn("cleanGenerateKotlinGrammarSource")
 
         // ANTLR .g4 files are under {example-project}/antlr
@@ -79,9 +80,8 @@ kotlin {
         common {
             group("commonJvmAndroid") {
                 withJvm()
-                withAndroidTarget()
-                // Following line can be removed when https://issuetracker.google.com/issues/442950553 is fixed
-                withCompilations { it is KotlinMultiplatformAndroidCompilation }
+                @Suppress("UnstableApiUsage")
+                withAndroid()
             }
         }
     }

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -70,6 +70,7 @@ val releaseVersion: String = resolvedReleaseVersion ?: "0.0.0-dev"
 val jbrRuntime =
     javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(25)
+        @Suppress("UnstableApiUsage")
         vendor = JvmVendorSpec.JETBRAINS
     }
 

--- a/scripting/build.gradle.kts
+++ b/scripting/build.gradle.kts
@@ -1,8 +1,4 @@
-@file:OptIn(ExperimentalKotlinGradlePluginApi::class)
-
-import com.android.build.api.dsl.KotlinMultiplatformAndroidCompilation
 import com.strumenta.antlrkotlin.gradle.AntlrKotlinTask
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
     alias(libs.plugins.android.kmp.library)
@@ -12,6 +8,7 @@ plugins {
 
 val generateKotlinGrammarSource =
     tasks.register<AntlrKotlinTask>("generateKotlinGrammarSource") {
+        description = "Generate ANTLR grammars."
         dependsOn("cleanGenerateKotlinGrammarSource")
 
         // ANTLR .g4 files are under {example-project}/antlr

--- a/wrayth/build.gradle.kts
+++ b/wrayth/build.gradle.kts
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalKotlinGradlePluginApi::class)
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidCompilation
+import com.android.build.api.withAndroid
 import com.strumenta.antlrkotlin.gradle.AntlrKotlinTask
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
@@ -21,6 +21,7 @@ allOpen {
 
 val generateKotlinGrammarSource =
     tasks.register<AntlrKotlinTask>("generateKotlinGrammarSource") {
+        description = "Generate ANTLR grammars."
         dependsOn("cleanGenerateKotlinGrammarSource")
 
         // ANTLR .g4 files are under {example-project}/antlr
@@ -93,9 +94,8 @@ kotlin {
         common {
             group("commonJvmAndroid") {
                 withJvm()
-                withAndroidTarget()
-                // Following line can be removed when https://issuetracker.google.com/issues/442950553 is fixed
-                withCompilations { it is KotlinMultiplatformAndroidCompilation }
+                @Suppress("UnstableApiUsage")
+                withAndroid()
             }
         }
     }


### PR DESCRIPTION
The `commonJvmAndroid` and `mobile` groups paired `withAndroidTarget()` with a `withCompilations { it is KotlinMultiplatformAndroidCompilation }` workaround for [b/442950553](https://issuetracker.google.com/issues/442950553). `withAndroid()` covers both, so the workaround goes, along with its `KotlinMultiplatformAndroidCompilation` import and the `ExperimentalKotlinGradlePluginApi` opt-in that `scripting` no longer needs.

Two small things ride along: `UnstableApiUsage` is suppressed on the JBR vendor selection in `desktopApp`, and the skin zip task gets a description.

`./gradlew check -PiosSkip=true -PlintSkip=true` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
