### PR TITLE
Play desktop sounds through OpenAL instead of Java Sound

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,6 +14,18 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
+/** The LWJGL natives classifier for the machine running the build. */
+val lwjglNatives: String =
+    run {
+        val os = System.getProperty("os.name").lowercase()
+        val arm = System.getProperty("os.arch").lowercase().let { it.startsWith("aarch64") || it.startsWith("arm") }
+        when {
+            os.contains("win") -> "natives-windows"
+            os.contains("mac") || os.contains("darwin") -> if (arm) "natives-macos-arm64" else "natives-macos"
+            else -> if (arm) "natives-linux-arm64" else "natives-linux"
+        }
+    }
+
 val generateKotlinGrammarSource =
     tasks.register<AntlrKotlinTask>("generateKotlinGrammarSource") {
 
@@ -117,6 +129,13 @@ kotlin {
                 implementation(libs.antlr.kotlin.runtime)
             }
         }
+        jvmMain {
+            dependencies {
+                // Desktop audio output (DesktopSoundPlayer); the matching natives are added below.
+                implementation(libs.lwjgl.core)
+                implementation(libs.lwjgl.openal)
+            }
+        }
         jvmTest {
             dependencies {
                 implementation(kotlin("test"))
@@ -137,6 +156,13 @@ kotlin {
 }
 
 dependencies {
+    // LWJGL ships its native libraries as classifier artifacts, one per platform. The release
+    // workflow builds each platform on its own runner, so the build host's natives are the ones
+    // that belong in the package. Declared here because variantOf() is not available inside the
+    // multiplatform source set blocks.
+    add("jvmMainRuntimeOnly", variantOf(libs.lwjgl.core) { classifier(lwjglNatives) })
+    add("jvmMainRuntimeOnly", variantOf(libs.lwjgl.openal) { classifier(lwjglNatives) })
+
     // Room
     add("kspAndroid", libs.room.compiler)
     add("kspJvm", libs.room.compiler)

--- a/core/src/jvmMain/kotlin/warlockfe/warlock3/core/util/DesktopSoundPlayer.kt
+++ b/core/src/jvmMain/kotlin/warlockfe/warlock3/core/util/DesktopSoundPlayer.kt
@@ -1,15 +1,29 @@
 package warlockfe.warlock3.core.util
 
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.lwjgl.openal.AL
+import org.lwjgl.openal.AL10
+import org.lwjgl.openal.ALC
+import org.lwjgl.openal.ALC10
+import org.lwjgl.system.MemoryUtil
 import java.io.File
+import java.nio.ByteBuffer
+import java.util.concurrent.Executors
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioInputStream
 import javax.sound.sampled.AudioSystem
-import javax.sound.sampled.Clip
-import javax.sound.sampled.LineEvent
-import javax.sound.sampled.LineUnavailableException
-import javax.sound.sampled.Mixer
 
+/**
+ * Plays sounds through OpenAL (LWJGL). Java Sound is still used to *decode* a file into PCM, so the
+ * formats we read are unchanged (WAV, AIFF, AU, plus whatever an SPI on the classpath adds), but the
+ * output path is OpenAL: mixing is the driver's job there, so there is no output line to be
+ * unavailable and no need to hunt through mixers for one that will accept the clip.
+ *
+ * OpenAL calls are not thread safe, so all of them run on [audioThread], a single thread that also
+ * owns the device and context for the life of the process.
+ */
 class DesktopSoundPlayer(
     warlockDirs: WarlockDirs,
 ) : SoundPlayer {
@@ -22,38 +36,152 @@ class DesktopSoundPlayer(
             warlockDirs.homeDir,
         )
 
+    private val audioThread =
+        Executors
+            .newSingleThreadExecutor { runnable ->
+                Thread(runnable, "openal-audio").apply { isDaemon = true }
+            }.asCoroutineDispatcher()
+
+    private var device = 0L
+    private var context = 0L
+    private var initError: String? = null
+    private var initialized = false
+
+    // Sources still playing, with the buffer each one owns. Swept on every play so a long session
+    // does not exhaust OpenAL's finite source pool.
+    private val playing = mutableListOf<Pair<Int, Int>>()
+
     override suspend fun playSound(filename: String): String? =
-        withContext(Dispatchers.IO) {
+        withContext(audioThread) {
             val file =
                 File(filename).takeIf { it.exists() }
                     ?: dirs.map { File(it, filename) }.firstOrNull { it.exists() }
                     ?: return@withContext "File not found"
 
-            // null == the default clip; fall through to specific mixers if it won't open.
-            val candidates: List<Mixer.Info?> = listOf(null) + AudioSystem.getMixerInfo()
-            var lastError: Exception? = null
+            openDevice()?.let { return@withContext it }
 
-            for (mixer in candidates) {
-                var clip: Clip? = null
+            releaseFinished()
+
+            val sound =
                 try {
-                    clip = if (mixer != null) AudioSystem.getClip(mixer) else AudioSystem.getClip()
-                    clip.addLineListener { event ->
-                        if (event.type == LineEvent.Type.STOP) event.line.close()
-                    }
-                    AudioSystem.getAudioInputStream(file).use { input ->
-                        clip.open(input)
-                    }
-                    clip.start()
-                    logger.d { "playing on mixer = ${mixer?.name ?: "default"}, line = ${clip.lineInfo}" }
-                    return@withContext null
-                } catch (e: LineUnavailableException) {
-                    lastError = e
-                    clip?.close()
+                    decode(file)
                 } catch (e: Exception) {
-                    clip?.close()
-                    return@withContext e.message ?: "Error playing sound: $filename"
+                    logger.d(e) { "Could not decode $filename" }
+                    return@withContext e.message ?: "Could not read $filename"
                 }
+
+            try {
+                play(sound)
+                null
+            } catch (e: Exception) {
+                logger.d(e) { "Could not play $filename" }
+                e.message ?: "Error playing sound: $filename"
+            } finally {
+                MemoryUtil.memFree(sound.pcm)
             }
-            lastError?.message ?: "No audio device could play $filename"
         }
+
+    /** Opens the device and context on first use. Returns an error message when audio is unavailable. */
+    private fun openDevice(): String? {
+        if (initialized) return initError
+        initialized = true
+        initError =
+            try {
+                device = ALC10.alcOpenDevice(null as CharSequence?)
+                if (device == 0L) {
+                    "No audio device available"
+                } else {
+                    val capabilities = ALC.createCapabilities(device)
+                    context = ALC10.alcCreateContext(device, null as IntArray?)
+                    if (context == 0L) {
+                        "Could not create an audio context"
+                    } else {
+                        ALC10.alcMakeContextCurrent(context)
+                        AL.createCapabilities(capabilities)
+                        logger.d { "OpenAL ready: ${AL10.alGetString(AL10.AL_RENDERER)}" }
+                        null
+                    }
+                }
+            } catch (e: Throwable) {
+                // Typically a missing or mismatched native library, which would otherwise take the
+                // whole app down the first time something tried to play a sound.
+                logger.e(e) { "Could not initialize OpenAL" }
+                "Could not initialize audio: ${e.message}"
+            }
+        return initError
+    }
+
+    private class Sound(
+        val pcm: ByteBuffer,
+        val format: Int,
+        val sampleRate: Int,
+    )
+
+    /**
+     * Decodes [file] into the signed 16-bit PCM OpenAL takes, converting sample size, endianness and
+     * channel count as needed. Anything with more than two channels is asked for as stereo, since
+     * OpenAL's basic formats are mono and stereo only.
+     */
+    private fun decode(file: File): Sound =
+        AudioSystem.getAudioInputStream(file).use { encoded ->
+            val source = encoded.format
+            val channels = if (source.channels in 1..2) source.channels else 2
+            val sampleRate = if (source.sampleRate > 0) source.sampleRate else 44100f
+            val target =
+                AudioFormat(
+                    AudioFormat.Encoding.PCM_SIGNED,
+                    sampleRate,
+                    16,
+                    channels,
+                    channels * 2,
+                    sampleRate,
+                    false, // little endian, which is what alBufferData expects
+                )
+            val decoded: AudioInputStream =
+                when {
+                    AudioSystem.isConversionSupported(target, source) -> AudioSystem.getAudioInputStream(target, encoded)
+                    source.matches(target) -> encoded
+                    else -> throw UnsupportedOperationException("Unsupported audio format: $source")
+                }
+            decoded.use { stream ->
+                val bytes = stream.readBytes()
+                if (bytes.isEmpty()) throw UnsupportedOperationException("No audio data in ${file.name}")
+                val pcm = MemoryUtil.memAlloc(bytes.size)
+                pcm.put(bytes)
+                pcm.flip()
+                Sound(
+                    pcm = pcm,
+                    format = if (channels == 1) AL10.AL_FORMAT_MONO16 else AL10.AL_FORMAT_STEREO16,
+                    sampleRate = sampleRate.toInt(),
+                )
+            }
+        }
+
+    private fun play(sound: Sound) {
+        AL10.alGetError()
+        val buffer = AL10.alGenBuffers()
+        AL10.alBufferData(buffer, sound.format, sound.pcm, sound.sampleRate)
+        val source = AL10.alGenSources()
+        AL10.alSourcei(source, AL10.AL_BUFFER, buffer)
+        AL10.alSourcePlay(source)
+        val error = AL10.alGetError()
+        if (error != AL10.AL_NO_ERROR) {
+            AL10.alDeleteSources(source)
+            AL10.alDeleteBuffers(buffer)
+            throw IllegalStateException("OpenAL error: ${AL10.alGetString(error) ?: error}")
+        }
+        playing += source to buffer
+    }
+
+    /** Deletes the sources that have finished, freeing them and the buffer each one holds. */
+    private fun releaseFinished() {
+        playing.removeAll { (source, buffer) ->
+            val done = AL10.alGetSourcei(source, AL10.AL_SOURCE_STATE) != AL10.AL_PLAYING
+            if (done) {
+                AL10.alDeleteSources(source)
+                AL10.alDeleteBuffers(buffer)
+            }
+            done
+        }
+    }
 }

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/util/DesktopSoundPlayerTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/util/DesktopSoundPlayerTest.kt
@@ -1,0 +1,94 @@
+package warlockfe.warlock3.core.util
+
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import javax.sound.sampled.AudioFileFormat
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioInputStream
+import javax.sound.sampled.AudioSystem
+import kotlin.io.path.createTempDirectory
+import kotlin.math.PI
+import kotlin.math.sin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DesktopSoundPlayerTest {
+    private val dir = createTempDirectory("sound-test").toFile()
+
+    private val dirs =
+        WarlockDirs(
+            homeDir = dir.absolutePath,
+            dataDir = dir.absolutePath,
+            configDir = dir.absolutePath,
+            logDir = dir.absolutePath,
+        )
+
+    /** A short sine tone, so the test needs no audio fixture on disk. */
+    private fun writeTone(
+        name: String,
+        channels: Int = 1,
+        sampleRate: Float = 44100f,
+    ): File {
+        val frames = (sampleRate / 5).toInt() // 200ms
+        val format = AudioFormat(sampleRate, 16, channels, true, false)
+        val bytes = ByteBuffer.allocate(frames * channels * 2).order(ByteOrder.LITTLE_ENDIAN)
+        repeat(frames) { frame ->
+            val sample = (sin(2.0 * PI * 440.0 * frame / sampleRate) * Short.MAX_VALUE * 0.25).toInt().toShort()
+            repeat(channels) { bytes.putShort(sample) }
+        }
+        val file = File(dir, name)
+        AudioInputStream(bytes.array().inputStream(), format, frames.toLong()).use {
+            AudioSystem.write(it, AudioFileFormat.Type.WAVE, file)
+        }
+        return file
+    }
+
+    /**
+     * A machine with no sound card (CI, containers) can't open a device, and that is reported rather
+     * than thrown. Anything else - a missing native, a bad buffer format, an OpenAL error - fails.
+     */
+    private fun assertPlayed(result: String?) {
+        assertTrue(
+            result == null || result == "No audio device available" || result.startsWith("Could not create an audio context"),
+            "unexpected playback failure: $result",
+        )
+    }
+
+    @Test
+    fun playsAMonoWavFile() =
+        runBlocking {
+            val file = writeTone("mono.wav")
+            assertPlayed(DesktopSoundPlayer(dirs).playSound(file.absolutePath))
+        }
+
+    @Test
+    fun playsAStereoWavFile() =
+        runBlocking {
+            val file = writeTone("stereo.wav", channels = 2, sampleRate = 22050f)
+            assertPlayed(DesktopSoundPlayer(dirs).playSound(file.absolutePath))
+        }
+
+    @Test
+    fun findsSoundsRelativeToTheWarlockDirectories() =
+        runBlocking {
+            writeTone("relative.wav")
+            assertPlayed(DesktopSoundPlayer(dirs).playSound("relative.wav"))
+        }
+
+    @Test
+    fun reportsAMissingFile() =
+        runBlocking {
+            assertEquals("File not found", DesktopSoundPlayer(dirs).playSound("nope.wav"))
+        }
+
+    @Test
+    fun reportsAFileThatIsNotAudio() =
+        runBlocking {
+            File(dir, "notaudio.wav").writeText("this is not a wav file")
+            val result = DesktopSoundPlayer(dirs).playSound("notaudio.wav")
+            assertTrue(result != null, "expected an error message for a non-audio file")
+        }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,9 @@ ksp = "2.3.10"
 ktlint-gradle = "14.2.0"
 ktlint-compose-rules = "0.6.3"
 ktor = "3.5.1"
+##⬆ = "3.5.2"
 lua-kmp = "0.1.0"
+lwjgl = "3.4.2"
 potassium = "0.3.1"
 room = "3.0.1"
 sentryKotlin = "0.27.0"
@@ -118,6 +120,9 @@ ktor-utils = { module = "io.ktor:ktor-utils", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 lua-kmp = { group = "com.seanproctor", name = "lua-kmp", version.ref = "lua-kmp" }
+# Desktop audio output. The natives are added per build host (see core/build.gradle.kts).
+lwjgl-core = { module = "org.lwjgl:lwjgl", version.ref = "lwjgl" }
+lwjgl-openal = { module = "org.lwjgl:lwjgl-openal", version.ref = "lwjgl" }
 # AndroidX versions still contain stubs for desktop, so we can't migrate yet
 navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }


### PR DESCRIPTION
Java Sound made us open an output line per sound, and lines are a scarce, exclusive resource. When one was unavailable the old player walked every mixer on the system looking for one that would accept the clip, and gave up if none would. OpenAL has no equivalent problem: mixing is the driver's job, so a sound is just a buffer and a source, and playing several at once is ordinary.

**Java Sound still decodes.** `AudioSystem` is only a decoder here, never an output device, so the formats we read are unchanged (WAV, AIFF, AU, plus whatever an SPI on the classpath adds) while the unreliable half is gone. Decoding converts to the signed 16-bit little-endian PCM `alBufferData` expects, and asks for stereo when a file has more channels than OpenAL's basic formats cover. Say the word if you'd rather drop Java Sound entirely, but that means hand-rolling WAV parsing (LWJGL only decodes OGG, via stb_vorbis).

Details worth knowing:

- **Threading.** OpenAL is not thread safe, so the device, the context and every AL call live on one dedicated daemon thread.
- **Source lifetime.** Sources are a finite pool, so each play first deletes the ones that have finished, along with their buffers.
- **Failure handling.** No sound card, or a native that won't load, is caught and returned as a message instead of taking the app down at the first sound. A missing native would otherwise be an `UnsatisfiedLinkError` at class load.
- **Natives.** LWJGL ships them as classifier artifacts per platform. The release workflow builds each platform on its own runner, so the build host's classifier is what gets added, covering all five matrix targets (linux amd64/arm64, windows amd64, macos arm64/intel).

### Testing

Five new tests in `DesktopSoundPlayerTest` generate a sine tone rather than needing an audio fixture, and cover mono, stereo at a different sample rate, resolution relative to the Warlock directories, a missing file, and a non-audio file. They tolerate a machine with no sound card so CI stays green, but on a machine with audio they exercise the whole path.

Locally that path is real: the test log shows `OpenAL ready: OpenAL Soft`, so the natives loaded, a device opened, and `alSourcePlay` was accepted with no AL error.

Also verified `./gradlew check -PiosSkip=true -PlintSkip=true`, and `:desktopApp:createDistributable` followed by `bin/warlock --version` (exit 0). The packaged `lib/app/` contains `lwjgl`, `lwjgl-openal` and both `natives-linux` jars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
