### PR TITLE
Follow the system default output device when playing sounds

### DIFF
--- a/core/src/jvmMain/kotlin/warlockfe/warlock3/core/util/DesktopSoundPlayer.kt
+++ b/core/src/jvmMain/kotlin/warlockfe/warlock3/core/util/DesktopSoundPlayer.kt
@@ -7,6 +7,8 @@ import org.lwjgl.openal.AL
 import org.lwjgl.openal.AL10
 import org.lwjgl.openal.ALC
 import org.lwjgl.openal.ALC10
+import org.lwjgl.openal.EnumerateAllExt
+import org.lwjgl.openal.SOFTReopenDevice
 import org.lwjgl.system.MemoryUtil
 import java.io.File
 import java.nio.ByteBuffer
@@ -46,6 +48,7 @@ class DesktopSoundPlayer(
     private var context = 0L
     private var initError: String? = null
     private var initialized = false
+    private var canReopen = false
 
     // Sources still playing, with the buffer each one owns. Swept on every play so a long session
     // does not exhaust OpenAL's finite source pool.
@@ -60,6 +63,7 @@ class DesktopSoundPlayer(
 
             openDevice()?.let { return@withContext it }
 
+            followDefaultDevice()
             releaseFinished()
 
             val sound =
@@ -98,6 +102,7 @@ class DesktopSoundPlayer(
                     } else {
                         ALC10.alcMakeContextCurrent(context)
                         AL.createCapabilities(capabilities)
+                        canReopen = ALC10.alcIsExtensionPresent(device, "ALC_SOFT_reopen_device")
                         logger.d { "OpenAL ready: ${AL10.alGetString(AL10.AL_RENDERER)}" }
                         null
                     }
@@ -109,6 +114,22 @@ class DesktopSoundPlayer(
                 "Could not initialize audio: ${e.message}"
             }
         return initError
+    }
+
+    /**
+     * Moves the device to the system default output when the default has changed since the device
+     * was opened. openal-soft's CoreAudio backend resolves the default to a concrete device at open
+     * time and stays pinned to it, so on a Mac a long-lived device keeps playing through the old
+     * output after the user switches. WASAPI and PulseAudio migrate on their own, so the names never
+     * differ there and this is a no-op.
+     */
+    private fun followDefaultDevice() {
+        if (!canReopen) return
+        val default = ALC10.alcGetString(0, EnumerateAllExt.ALC_DEFAULT_ALL_DEVICES_SPECIFIER) ?: return
+        if (default == ALC10.alcGetString(device, EnumerateAllExt.ALC_ALL_DEVICES_SPECIFIER)) return
+        if (!SOFTReopenDevice.alcReopenDeviceSOFT(device, null as ByteBuffer?, null as IntArray?)) {
+            logger.d { "Could not move playback to the new default audio device" }
+        }
     }
 
     private class Sound(

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/util/DesktopSoundPlayerTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/util/DesktopSoundPlayerTest.kt
@@ -71,6 +71,16 @@ class DesktopSoundPlayerTest {
             assertPlayed(DesktopSoundPlayer(dirs).playSound(file.absolutePath))
         }
 
+    /** The player holds its device across plays, re-checking the default output each time. */
+    @Test
+    fun playsRepeatedlyThroughOnePlayer() =
+        runBlocking {
+            val player = DesktopSoundPlayer(dirs)
+            val file = writeTone("repeat.wav")
+            assertPlayed(player.playSound(file.absolutePath))
+            assertPlayed(player.playSound(file.absolutePath))
+        }
+
     @Test
     fun findsSoundsRelativeToTheWarlockDirectories() =
         runBlocking {


### PR DESCRIPTION
## Problem

On macOS, sounds kept playing through the built-in speakers after the user switched output to AirPods (or AirPods connected after launch).

Since #256, `DesktopSoundPlayer` opens the OpenAL device once on first play and holds it for the life of the process. openal-soft's CoreAudio backend (1.25.2, bundled by LWJGL 3.4.2) resolves `alcOpenDevice(NULL)` to a concrete `AudioDeviceID` at open time and stays pinned to it - it never follows the OS default afterward. Automatic migration on default-device change only exists in the WASAPI and PulseAudio backends, which is why Windows and Linux were unaffected. The old Java Sound path opened a fresh output line per play, so this never showed up before.

## Fix

Before each play, compare the system default output (`ALC_DEFAULT_ALL_DEVICES_SPECIFIER`) with the device we are actually on (`ALC_ALL_DEVICES_SPECIFIER`); when they differ, `alcReopenDeviceSOFT(device, NULL, NULL)` re-resolves the default in place, keeping the context, sources, and buffers valid. Guarded on the `ALC_SOFT_reopen_device` extension. A failed reopen is logged and the sound still plays on the old output.

A sound already in flight when the user switches finishes on the old device; the next sound moves. On Windows/Linux the names never differ, so this is a no-op there.

## Testing

- New `playsRepeatedlyThroughOnePlayer` test plays twice through one long-lived player, exercising the re-check on an already-open device.
- `:core:jvmTest` passes locally with a real device open (PipeWire), so the new path ran for real; the macOS behavior itself needs a manual check: play a sound, switch output to AirPods, play again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)