### PR TITLE
Resolve the dragged window by name when reordering a dock

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -1309,15 +1309,24 @@ class GameViewModel(
 
     fun changeWindowPositions(
         location: WindowLocation,
-        fromIndex: Int,
+        name: String,
         toIndex: Int,
     ) {
         val windowUiStates = getWindowUiStatesForLocation(location)
-        var reordered: List<WindowUiState> = emptyList()
+        var reordered: List<WindowUiState>? = null
         windowUiStates.update { states ->
+            // Reset on entry: update{} may retry.
+            reordered = null
+            // The gesture's indices are snapshots, and the dock can change under a drag (the
+            // game closing a panel mid-drag is the everyday case): resolve the dragged window
+            // by name against the current list and clamp the drop index. A stale index crashed
+            // here on a shrunken dock, and a stale-but-in-bounds one would have moved whatever
+            // window sits at it now.
+            val fromIndex = states.indexOfFirst { it.name == name }
+            if (fromIndex == -1) return@update states
             val mutableStates = states.toMutableList()
             val item = mutableStates.removeAt(fromIndex)
-            val adjustedToIndex = if (toIndex > fromIndex) toIndex - 1 else toIndex
+            val adjustedToIndex = (if (toIndex > fromIndex) toIndex - 1 else toIndex).coerceIn(0, mutableStates.size)
             mutableStates.add(adjustedToIndex, item)
             reordered = mutableStates
             mutableStates
@@ -1326,7 +1335,7 @@ class GameViewModel(
         // per-row writes from the live list could interleave with another reorder and leave
         // duplicate positions behind. A transient panel takes part in the reorder on screen but
         // records nothing.
-        val names = reordered.filter { canSaveWindow(it.name) }.map { it.name }
+        val names = reordered?.filter { canSaveWindow(it.name) }?.map { it.name } ?: return
         viewModelScope.launch {
             client.characterId.value?.let { characterId ->
                 logger.d { "Reordering $location: $names" }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -1334,8 +1334,9 @@ class GameViewModel(
         // The dock's whole order, captured before suspending and written in one transaction:
         // per-row writes from the live list could interleave with another reorder and leave
         // duplicate positions behind. A transient panel takes part in the reorder on screen but
-        // records nothing.
-        val names = reordered?.filter { canSaveWindow(it.name) }?.map { it.name } ?: return
+        // records nothing, so a dock holding only those has no saved order to rewrite.
+        val names = reordered?.filter { canSaveWindow(it.name) }?.map { it.name }
+        if (names.isNullOrEmpty()) return
         viewModelScope.launch {
             client.characterId.value?.let { characterId ->
                 logger.d { "Reordering $location: $names" }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/DragDropState.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/DragDropState.kt
@@ -16,9 +16,6 @@ class DragDropState {
         private set
     var sourceLocation: WindowLocation? by mutableStateOf(null)
         private set
-    var sourceIndex: Int by mutableIntStateOf(-1)
-        private set
-
     var dragOffset: Offset by mutableStateOf(Offset.Zero)
         private set
 
@@ -32,12 +29,10 @@ class DragDropState {
     fun startDrag(
         item: WindowUiState,
         location: WindowLocation,
-        index: Int,
         offset: Offset,
     ) {
         draggedItem = item
         sourceLocation = location
-        sourceIndex = index
         dragOffset = offset
         dropTarget = null
     }
@@ -57,7 +52,6 @@ class DragDropState {
                 DropResult(
                     name = item.name,
                     sourceLocation = source,
-                    sourceIndex = sourceIndex,
                     target = target,
                 )
             } else {
@@ -124,7 +118,6 @@ class DragDropState {
     private fun clearState() {
         draggedItem = null
         sourceLocation = null
-        sourceIndex = -1
         dragOffset = Offset.Zero
         dropTarget = null
     }
@@ -144,6 +137,5 @@ data class SectionInfo(
 data class DropResult(
     val name: String,
     val sourceLocation: WindowLocation,
-    val sourceIndex: Int,
     val target: DropTarget,
 )

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
@@ -266,7 +266,7 @@ fun DesktopGameView(
                         if (result.sourceLocation == result.target.location) {
                             viewModel.changeWindowPositions(
                                 result.sourceLocation,
-                                result.sourceIndex,
+                                result.name,
                                 result.target.insertionIndex,
                             )
                         } else {

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowsAtLocation.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowsAtLocation.kt
@@ -239,7 +239,6 @@ private fun DockableSection(
                 modifier = itemModifier,
                 uiState = uiState,
                 location = location,
-                index = index,
                 defaultStyle = defaultStyle,
                 openWindows = openWindows,
                 isLast = index == windowUiStates.lastIndex,
@@ -286,7 +285,6 @@ private fun DockableSection(
 private fun WindowViewSlot(
     uiState: WindowUiState,
     location: WindowLocation,
-    index: Int,
     defaultStyle: StyleDefinition,
     openWindows: List<String>,
     isLast: Boolean,
@@ -311,7 +309,10 @@ private fun WindowViewSlot(
     val headerModifier =
         Modifier
             .onGloballyPositioned { headerCoordinates.value = it }
-            .pointerInput(uiState.name, location, index) {
+            // Keyed on identity only. Keying on the window's index would restart this block -
+            // cancelling an in-flight drag - whenever a window ahead of it leaves the dock,
+            // which is exactly when a drag is most likely to be in flight.
+            .pointerInput(uiState.name, location) {
                 detectDragGestures(
                     onDragStart = { offset ->
                         val coords = headerCoordinates.value ?: return@detectDragGestures

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowsAtLocation.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowsAtLocation.kt
@@ -316,7 +316,7 @@ private fun WindowViewSlot(
                     onDragStart = { offset ->
                         val coords = headerCoordinates.value ?: return@detectDragGestures
                         val rootOffset = coords.localToRoot(offset)
-                        dragDropState.startDrag(uiState, location, index, rootOffset)
+                        dragDropState.startDrag(uiState, location, rootOffset)
                     },
                     onDrag = { change, _ ->
                         change.consume()

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
@@ -539,7 +539,7 @@ internal fun GameViewModel.onWindowDrop(result: DropResult) {
     if (result.sourceLocation == result.target.location) {
         changeWindowPositions(
             result.sourceLocation,
-            result.sourceIndex,
+            result.name,
             result.target.insertionIndex,
         )
     } else {

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowsAtLocation.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowsAtLocation.kt
@@ -231,7 +231,6 @@ private fun DockableSection(
                 modifier = itemModifier,
                 uiState = uiState,
                 location = location,
-                index = index,
                 defaultStyle = defaultStyle,
                 openWindows = openWindows,
                 isLast = index == windowUiStates.lastIndex,
@@ -278,7 +277,6 @@ private fun DockableSection(
 private fun WindowViewSlot(
     uiState: WindowUiState,
     location: WindowLocation,
-    index: Int,
     defaultStyle: StyleDefinition,
     openWindows: List<String>,
     isLast: Boolean,
@@ -303,7 +301,10 @@ private fun WindowViewSlot(
     val headerModifier =
         Modifier
             .onGloballyPositioned { headerCoordinates.value = it }
-            .pointerInput(uiState.name, location, index) {
+            // Keyed on identity only. Keying on the window's index would restart this block -
+            // cancelling an in-flight drag - whenever a window ahead of it leaves the dock,
+            // which is exactly when a drag is most likely to be in flight.
+            .pointerInput(uiState.name, location) {
                 detectDragGestures(
                     onDragStart = { offset ->
                         val coords = headerCoordinates.value ?: return@detectDragGestures

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowsAtLocation.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowsAtLocation.kt
@@ -308,7 +308,7 @@ private fun WindowViewSlot(
                     onDragStart = { offset ->
                         val coords = headerCoordinates.value ?: return@detectDragGestures
                         val rootOffset = coords.localToRoot(offset)
-                        dragDropState.startDrag(uiState, location, index, rootOffset)
+                        dragDropState.startDrag(uiState, location, rootOffset)
                     },
                     onDrag = { change, _ ->
                         change.consume()


### PR DESCRIPTION
## Problem

Fixes crash DESKTOP-3J (`IndexOutOfBoundsException: Index: 2, Size: 1` in `changeWindowPositions`, fatal on desktop, seen in production on 3.1.0-beta.27).

A same-dock drag crashed when the dock changed under the gesture. The drop's indices are snapshots: `sourceIndex` is frozen at drag start, and `insertionIndex` comes from item bounds cached at the dock's last recomposition - while the dock list is live. The game closing a panel mid-drag (a transient's `closeDialog`) shrinks the list, and the unguarded `removeAt`/`add` then throw inside the drag-gesture coroutine, which has no handler, taking the whole app down. The crash math matched exactly: the drag layer believed the dock had 3 items while the live list had 2.

There was also a quieter sibling: a stale-but-still-in-bounds `sourceIndex` would reorder whatever window now sat at that index instead of the one the user dragged.

## Fix

- `changeWindowPositions` takes the dragged window's **name** (which `DropResult` already carried), resolves its current index inside the `update {}` - dropping the gesture when the window is gone - and clamps the insertion index to the shrunken list, mirroring the clamp `moveWindowToPosition` already had.
- Both drop handlers (desktop and mobile) pass `result.name`.
- The stale-snapshot trap is removed from the API: `DropResult.sourceIndex`, `DragDropState.sourceIndex`, and `startDrag`'s index parameter are deleted so nothing can consume a drag-start index snapshot again.

## Testing

`./gradlew jvmTest` passes and compose compiles for Android. The crash path is gesture-timing dependent (drop landing in the same frame a window leaves the dock), so it has no unit harness; the fix is defensive resolution against the live list at the single choke point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved window drag-and-drop reordering for more reliable positioning.
  - Safely handles missing windows and prevents unnecessary layout updates.
  - Correctly adjusts destination positions when moving windows within the same location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->