### PR TITLE
Make the update channel setting cumulative

### DIFF
--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopWarlockEntry.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopWarlockEntry.kt
@@ -22,10 +22,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,7 +40,6 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlinx.coroutines.delay
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.Text
 import warlockfe.warlock3.compose.desktop.ui.settings.DesktopWindowSettingsDialog
@@ -61,10 +58,6 @@ import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.core.text.StyleDefinition
 import warlockfe.warlock3.core.text.isSpecified
 import kotlin.math.min
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.Instant
 
 @Suppress("ktlint:compose:vm-forwarding-check")
 @Composable

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopGeneralSettingsView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopGeneralSettingsView.kt
@@ -314,7 +314,7 @@ fun DesktopGeneralSettingsView(
                         onClick = {
                             scope.launch { clientSettingRepository.putReleaseChannel(entry) }
                         },
-                        text = entry.name.lowercase(),
+                        text = entry.label(),
                     )
                 }
             }
@@ -402,3 +402,16 @@ fun DesktopGeneralSettingsView(
         }
     }
 }
+
+/**
+ * Each channel also picks up everything more stable than itself, so a beta build still moves to the
+ * stable release that supersedes it. The labels spell that out - "beta" alone reads like it would
+ * strand you on prereleases.
+ */
+private fun ReleaseChannelSetting.label(): String =
+    when (this) {
+        ReleaseChannelSetting.CURRENT -> "Current - stay on the channel this build came from"
+        ReleaseChannelSetting.STABLE -> "Stable - stable releases only"
+        ReleaseChannelSetting.BETA -> "Beta - betas and stable releases"
+        ReleaseChannelSetting.ALPHA -> "Alpha - the newest release of any kind"
+    }

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
 
     // In-app updates
     implementation(libs.potassium.updater)
+
+    testImplementation(kotlin("test"))
 }
 
 kotlin {

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -79,6 +79,8 @@ import org.jetbrains.jewel.window.styling.LocalTitleBarStyle
 import org.jetbrains.jewel.window.utils.DesktopPlatform
 import org.slf4j.simple.SimpleLogger.DEFAULT_LOG_LEVEL_KEY
 import warlockfe.warlock3.app.di.JvmAppContainer
+import warlockfe.warlock3.app.updater.ChannelUpdater
+import warlockfe.warlock3.app.updater.channelsToCheck
 import warlockfe.warlock3.compose.desktop.shim.WarlockButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
 import warlockfe.warlock3.compose.desktop.theme.WarlockDesktopTheme
@@ -92,7 +94,6 @@ import warlockfe.warlock3.compose.util.LocalSkin
 import warlockfe.warlock3.compose.util.LocalWindowComponent
 import warlockfe.warlock3.core.client.WarlockSocket
 import warlockfe.warlock3.core.prefs.PrefsDatabase
-import warlockfe.warlock3.core.prefs.ReleaseChannelSetting
 import warlockfe.warlock3.core.prefs.ThemeSetting
 import warlockfe.warlock3.core.prefs.repositories.ClientSettingRepository
 import warlockfe.warlock3.core.prefs.repositories.MainWindowBounds
@@ -606,27 +607,18 @@ private class WarlockCommand : CliktCommand() {
             }
         }
 
-    private fun buildUpdater(clientSettings: ClientSettingRepository): PotassiumUpdater {
+    private fun buildUpdater(clientSettings: ClientSettingRepository): ChannelUpdater {
         val resolvedVersion = version ?: "0.0.0"
-        val versionChannel =
-            when {
-                resolvedVersion.contains("beta") -> "beta"
-                resolvedVersion.contains("alpha") -> "alpha"
-                else -> "latest"
-            }
         val channelSetting = runBlocking { clientSettings.getReleaseChannel() }
-        val selectedChannel =
-            when (channelSetting) {
-                ReleaseChannelSetting.CURRENT -> versionChannel
-                ReleaseChannelSetting.STABLE -> "latest"
-                ReleaseChannelSetting.BETA -> "beta"
-                ReleaseChannelSetting.ALPHA -> "alpha"
-            }
-        return PotassiumUpdater {
-            provider = GitHubProvider(owner = "sproctor", repo = "warlock3")
-            channel = selectedChannel
-            currentVersion = resolvedVersion
-        }
+        return ChannelUpdater(
+            channelSetting.channelsToCheck(resolvedVersion).map { channelName ->
+                PotassiumUpdater {
+                    provider = GitHubProvider(owner = "sproctor", repo = "warlock3")
+                    channel = channelName
+                    currentVersion = resolvedVersion
+                }
+            },
+        )
     }
 }
 
@@ -642,7 +634,7 @@ fun main(args: Array<String>) =
 
 @Composable
 private fun UpdateDialog(
-    updater: PotassiumUpdater,
+    updater: ChannelUpdater,
     updateSupported: Boolean,
     availableUpdate: UpdateInfo?,
     clientSettings: ClientSettingRepository,

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/updater/ChannelUpdater.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/updater/ChannelUpdater.kt
@@ -1,0 +1,93 @@
+package warlockfe.warlock3.app.updater
+
+import com.seanproctor.potassium.updater.DownloadProgress
+import com.seanproctor.potassium.updater.PotassiumUpdater
+import com.seanproctor.potassium.updater.UpdateInfo
+import com.seanproctor.potassium.updater.UpdateResult
+import com.seanproctor.potassium.updater.Version
+import kotlinx.coroutines.flow.Flow
+import warlockfe.warlock3.core.prefs.ReleaseChannelSetting
+import java.io.File
+
+/** Potassium/electron-updater channel names. Stable is spelled "latest" in the manifest files. */
+internal const val ALPHA_CHANNEL = "alpha"
+internal const val BETA_CHANNEL = "beta"
+internal const val STABLE_CHANNEL = "latest"
+
+/**
+ * The channel a version string belongs to: its first semver pre-release identifier, which is how
+ * both potassium and electron-updater classify a tag (`3.1.0-beta.8` -> `beta`). Anything we don't
+ * publish under counts as stable.
+ */
+internal fun channelOfVersion(version: String): String =
+    when (version.substringAfter('-', missingDelimiterValue = "").substringBefore('.')) {
+        ALPHA_CHANNEL -> ALPHA_CHANNEL
+        BETA_CHANNEL -> BETA_CHANNEL
+        else -> STABLE_CHANNEL
+    }
+
+/**
+ * The channels an update check covers. Each channel includes everything more stable than itself:
+ * alpha takes the highest version published anywhere, beta takes the higher of the newest beta and
+ * the newest stable, and stable only ever sees stable releases. Without that, a beta build would
+ * sit on the beta line forever, never picking up the stable release that supersedes it.
+ */
+internal fun ReleaseChannelSetting.channelsToCheck(currentVersion: String): List<String> =
+    when (this) {
+        ReleaseChannelSetting.CURRENT -> channelsUpFrom(channelOfVersion(currentVersion))
+        ReleaseChannelSetting.ALPHA -> channelsUpFrom(ALPHA_CHANNEL)
+        ReleaseChannelSetting.BETA -> channelsUpFrom(BETA_CHANNEL)
+        ReleaseChannelSetting.STABLE -> channelsUpFrom(STABLE_CHANNEL)
+    }
+
+private fun channelsUpFrom(channel: String): List<String> =
+    when (channel) {
+        ALPHA_CHANNEL -> listOf(ALPHA_CHANNEL, BETA_CHANNEL, STABLE_CHANNEL)
+        BETA_CHANNEL -> listOf(BETA_CHANNEL, STABLE_CHANNEL)
+        else -> listOf(STABLE_CHANNEL)
+    }
+
+/**
+ * Offers the highest version across several release channels.
+ *
+ * A [PotassiumUpdater] resolves exactly one channel: `beta` finds the newest beta tag in the GitHub
+ * releases feed and never looks at stable releases, and `latest` follows GitHub's latest-release
+ * redirect, which skips prereleases. Our channel setting is cumulative instead (see
+ * [channelsToCheck]), so this runs one updater per channel and keeps whichever offers the greatest
+ * version.
+ */
+internal class ChannelUpdater(
+    private val updaters: List<PotassiumUpdater>,
+) {
+    /**
+     * Downloading and installing run against a single updater. Neither depends on the channel - the
+     * artifact URLs come from the [UpdateInfo] the check produced - and `installAndRestart` records
+     * the version that the same instance downloaded, so both have to be the same updater.
+     */
+    private val installer = updaters.first()
+
+    val currentVersion: String get() = installer.currentVersion
+
+    fun isUpdateSupported(): Boolean = installer.isUpdateSupported()
+
+    suspend fun checkForUpdates(): UpdateResult = bestUpdate(updaters.map { it.checkForUpdates() })
+
+    fun downloadUpdate(info: UpdateInfo): Flow<DownloadProgress> = installer.downloadUpdate(info)
+
+    fun installAndRestart(installerFile: File) = installer.installAndRestart(installerFile)
+}
+
+/**
+ * The highest version offered across a set of per-channel results.
+ *
+ * A channel that has never been published fails its lookup - the releases feed holds no matching
+ * tag - which is routine for alpha on a repo that only ships betas. So an error is only reported
+ * when no channel managed to answer at all; otherwise it is a channel that simply isn't there.
+ */
+internal fun bestUpdate(results: List<UpdateResult>): UpdateResult =
+    results
+        .filterIsInstance<UpdateResult.Available>()
+        .maxByOrNull { Version.fromString(it.info.version) }
+        ?: results.firstOrNull { it is UpdateResult.NotAvailable }
+        ?: results.firstOrNull { it is UpdateResult.Error }
+        ?: UpdateResult.NotAvailable

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/updater/ChannelUpdater.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/updater/ChannelUpdater.kt
@@ -18,9 +18,18 @@ internal const val STABLE_CHANNEL = "latest"
  * The channel a version string belongs to: its first semver pre-release identifier, which is how
  * both potassium and electron-updater classify a tag (`3.1.0-beta.8` -> `beta`). Anything we don't
  * publish under counts as stable.
+ *
+ * Build metadata is dropped first. Our tags never carry any, but semver puts it after the
+ * pre-release (`3.1.0-beta+build.7`), where it would otherwise glue itself onto the identifier and
+ * read as a stable release - which would strand that build on the stable channel.
  */
 internal fun channelOfVersion(version: String): String =
-    when (version.substringAfter('-', missingDelimiterValue = "").substringBefore('.')) {
+    when (
+        version
+            .substringAfter('-', missingDelimiterValue = "")
+            .substringBefore('+')
+            .substringBefore('.')
+    ) {
         ALPHA_CHANNEL -> ALPHA_CHANNEL
         BETA_CHANNEL -> BETA_CHANNEL
         else -> STABLE_CHANNEL

--- a/desktopApp/src/test/kotlin/warlockfe/warlock3/app/updater/ChannelUpdaterTest.kt
+++ b/desktopApp/src/test/kotlin/warlockfe/warlock3/app/updater/ChannelUpdaterTest.kt
@@ -1,0 +1,96 @@
+package warlockfe.warlock3.app.updater
+
+import com.seanproctor.potassium.updater.UpdateFile
+import com.seanproctor.potassium.updater.UpdateInfo
+import com.seanproctor.potassium.updater.UpdateLevel
+import com.seanproctor.potassium.updater.UpdateResult
+import com.seanproctor.potassium.updater.exception.NetworkException
+import warlockfe.warlock3.core.prefs.ReleaseChannelSetting
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChannelUpdaterTest {
+    @Test
+    fun `stable only checks stable`() {
+        assertEquals(
+            listOf(STABLE_CHANNEL),
+            ReleaseChannelSetting.STABLE.channelsToCheck("3.1.0-beta.4"),
+        )
+    }
+
+    @Test
+    fun `beta checks beta and stable`() {
+        assertEquals(
+            listOf(BETA_CHANNEL, STABLE_CHANNEL),
+            ReleaseChannelSetting.BETA.channelsToCheck("3.1.0"),
+        )
+    }
+
+    @Test
+    fun `alpha checks every channel`() {
+        assertEquals(
+            listOf(ALPHA_CHANNEL, BETA_CHANNEL, STABLE_CHANNEL),
+            ReleaseChannelSetting.ALPHA.channelsToCheck("3.1.0"),
+        )
+    }
+
+    @Test
+    fun `current follows the running version's channel`() {
+        val setting = ReleaseChannelSetting.CURRENT
+        assertEquals(listOf(STABLE_CHANNEL), setting.channelsToCheck("3.1.0"))
+        assertEquals(listOf(BETA_CHANNEL, STABLE_CHANNEL), setting.channelsToCheck("3.1.0-beta.21"))
+        assertEquals(
+            listOf(ALPHA_CHANNEL, BETA_CHANNEL, STABLE_CHANNEL),
+            setting.channelsToCheck("3.1.0-alpha.2"),
+        )
+    }
+
+    @Test
+    fun `an unrecognized prerelease is treated as stable`() {
+        // Only alpha and beta are published; anything else shouldn't widen the search.
+        assertEquals(listOf(STABLE_CHANNEL), ReleaseChannelSetting.CURRENT.channelsToCheck("3.1.0-rc.1"))
+        assertEquals(listOf(STABLE_CHANNEL), ReleaseChannelSetting.CURRENT.channelsToCheck("0.0.0-dev"))
+    }
+
+    @Test
+    fun `the highest offered version wins`() {
+        val result =
+            bestUpdate(
+                listOf(
+                    available("3.2.0-beta.1"),
+                    available("3.2.0"),
+                    available("3.3.0-alpha.1"),
+                ),
+            )
+        assertEquals("3.3.0-alpha.1", (result as UpdateResult.Available).info.version)
+    }
+
+    @Test
+    fun `a stable release outranks a prerelease of the same version`() {
+        val result = bestUpdate(listOf(available("3.2.0-beta.9"), available("3.2.0")))
+        assertEquals("3.2.0", (result as UpdateResult.Available).info.version)
+    }
+
+    @Test
+    fun `a channel with no releases does not mask an answer from another`() {
+        // Asking for alphas on a repo that has never published one fails that lookup.
+        val noAlphas = UpdateResult.Error(NetworkException("no alpha tag"))
+        assertEquals(UpdateResult.NotAvailable, bestUpdate(listOf(noAlphas, UpdateResult.NotAvailable)))
+        val result = bestUpdate(listOf(noAlphas, available("3.2.0")))
+        assertEquals("3.2.0", (result as UpdateResult.Available).info.version)
+    }
+
+    @Test
+    fun `an error survives when no channel could answer`() {
+        val failure = UpdateResult.Error(NetworkException("offline"))
+        assertEquals(failure, bestUpdate(listOf(failure, UpdateResult.Error(NetworkException("offline")))))
+    }
+
+    private fun available(version: String): UpdateResult.Available {
+        val file = UpdateFile(url = "warlock-$version.deb", sha512 = "", size = 0, fileName = "warlock-$version.deb")
+        return UpdateResult.Available(
+            info = UpdateInfo(version = version, releaseDate = "", files = listOf(file), currentFile = file),
+            level = UpdateLevel.MINOR,
+        )
+    }
+}

--- a/desktopApp/src/test/kotlin/warlockfe/warlock3/app/updater/ChannelUpdaterTest.kt
+++ b/desktopApp/src/test/kotlin/warlockfe/warlock3/app/updater/ChannelUpdaterTest.kt
@@ -46,6 +46,17 @@ class ChannelUpdaterTest {
     }
 
     @Test
+    fun `build metadata does not hide the prerelease identifier`() {
+        val setting = ReleaseChannelSetting.CURRENT
+        assertEquals(listOf(BETA_CHANNEL, STABLE_CHANNEL), setting.channelsToCheck("3.1.0-beta+build.7"))
+        assertEquals(
+            listOf(ALPHA_CHANNEL, BETA_CHANNEL, STABLE_CHANNEL),
+            setting.channelsToCheck("3.1.0-alpha.2+sha.9f3c1d0"),
+        )
+        assertEquals(listOf(STABLE_CHANNEL), setting.channelsToCheck("3.1.0+build.7"))
+    }
+
+    @Test
     fun `an unrecognized prerelease is treated as stable`() {
         // Only alpha and beta are published; anything else shouldn't widen the search.
         assertEquals(listOf(STABLE_CHANNEL), ReleaseChannelSetting.CURRENT.channelsToCheck("3.1.0-rc.1"))


### PR DESCRIPTION
The release channel setting existed already, but it mapped each choice to a single potassium channel. Potassium resolves exactly one: `beta` finds the newest `-beta.N` tag in the GitHub releases feed and never looks at stable, `latest` follows GitHub's latest-release redirect and skips prereleases. So a beta user sat on the beta line forever and was never offered the stable release that superseded their build.

## What changed

Each channel now includes everything more stable than itself:

| setting | checks |
| --- | --- |
| alpha | alpha + beta + stable (highest version published anywhere) |
| beta | beta + stable (whichever is greater) |
| stable | stable only |
| current | the running build's channel, under the same rule |

`current` derives the channel from the running version's semver prerelease identifier (`3.1.0-beta.21` -> beta), which is how potassium and electron-updater classify a tag; anything we don't publish under counts as stable.

That takes one updater per channel, so the new `ChannelUpdater` runs them all and keeps whichever offers the greatest version (potassium's `Version` comparison, so `3.2.0` beats `3.2.0-beta.9`). Downloads and installs stay on a single instance, since `installAndRestart` records the version that same instance downloaded.

A channel that has never been published fails its feed lookup. That is routine for alpha here - `release.sh` has no mode that cuts one - so an error is only surfaced when no channel could answer at all, rather than logging a missing alpha line as an update failure.

Settings labels now say what each option covers instead of showing the bare enum name.

## Testing

New test source set on `desktopApp`, 9 tests over the channel resolution and the pick-highest logic. `:desktopApp:test` and ktlint pass.

Not exercised against a live feed: the alpha path has no published release to resolve, and stable/beta resolution is potassium's own code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release channel options now include clear descriptions of the updates each channel receives.
  * Update checks now support multiple channels and select the highest available update.
  * Stable, beta, alpha, current, and other prerelease versions are handled appropriately.

* **Bug Fixes**
  * Update results are handled more reliably when channels are unavailable or return errors.

* **Tests**
  * Added coverage for channel selection, update prioritization, prerelease ordering, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->