### PR TITLE
Add a memory usage view

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -110,6 +110,7 @@ import warlockfe.warlock3.core.text.WarlockColor
 import warlockfe.warlock3.core.text.WarlockStyle
 import warlockfe.warlock3.core.util.splitFirstWord
 import warlockfe.warlock3.core.window.WindowLocation
+import warlockfe.warlock3.core.window.WindowMemoryUsage
 import warlockfe.warlock3.core.window.WindowPlacement
 import warlockfe.warlock3.core.window.WindowRegistry
 import warlockfe.warlock3.core.window.WindowType
@@ -370,6 +371,11 @@ class GameViewModel(
 
     private val runningScripts =
         scriptManager.runningScripts.stateIn(viewModelScope, SharingStarted.Eagerly, persistentMapOf())
+
+    /** What this connection's windows are retaining, for the memory usage view. */
+    suspend fun memoryUsage(): WindowMemoryUsage = windowRegistry.memoryUsage()
+
+    val runningScriptCount: Int get() = runningScripts.value.size
 
     val roundTimeEnd =
         client.roundTimeEnd

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -533,8 +533,22 @@ class ComposeTextStream(
      */
     suspend fun memoryUsage(): StreamMemoryUsage {
         val result = CompletableDeferred<StreamMemoryUsage>()
-        workQueue.submit("memory") { result.complete(computeMemoryUsage()) }
-        return result.await()
+        try {
+            workQueue.submit("memory") {
+                // Cancelling the caller does not cancel a standalone CompletableDeferred, so a
+                // caller that gave up (the dialog times out) leaves this op still queued. The walk
+                // is O(buffer) and the queue it would run on is the one feeding the windows, so
+                // skip it rather than spend that time on a report nobody is waiting for. A scan
+                // already under way runs to completion - computeMemoryUsage never suspends.
+                if (result.isActive) {
+                    result.complete(computeMemoryUsage())
+                }
+            }
+            return result.await()
+        } finally {
+            // No-op once completed; on cancellation it is what the queued op checks for.
+            result.cancel()
+        }
     }
 
     private fun computeMemoryUsage(): StreamMemoryUsage {

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -6,6 +6,7 @@ import co.touchlab.kermit.Logger
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -30,8 +31,13 @@ import warlockfe.warlock3.core.client.WarlockAction
 import warlockfe.warlock3.core.text.FontConfig
 import warlockfe.warlock3.core.text.StyleLayer
 import warlockfe.warlock3.core.text.StyledString
+import warlockfe.warlock3.core.text.StyledStringLeaf
+import warlockfe.warlock3.core.text.StyledStringSubstring
+import warlockfe.warlock3.core.text.StyledStringVariable
 import warlockfe.warlock3.core.text.flattenStyles
 import warlockfe.warlock3.core.util.SoundPlayer
+import warlockfe.warlock3.core.window.MemoryEstimate
+import warlockfe.warlock3.core.window.StreamMemoryUsage
 import warlockfe.warlock3.core.window.TextStream
 import warlockfe.warlock3.core.window.getComponents
 import warlockfe.warlock3.wrayth.util.CompiledAlteration
@@ -518,6 +524,91 @@ class ComposeTextStream(
             linesUpdated()
         }
     }
+
+    /**
+     * What this stream is retaining, for the memory usage view.
+     *
+     * Measured on the work queue, the only coroutine that touches these buffers - reading them from
+     * the UI thread could observe a half-applied append or trip over a concurrent eviction.
+     */
+    suspend fun memoryUsage(): StreamMemoryUsage {
+        val result = CompletableDeferred<StreamMemoryUsage>()
+        workQueue.submit("memory") { result.complete(computeMemoryUsage()) }
+        return result.await()
+    }
+
+    private fun computeMemoryUsage(): StreamMemoryUsage {
+        var characters = 0L
+        var bytes = 0L
+
+        // The rendered lines, and the source each was rendered from. The two are index-parallel and
+        // both bounded by maxLines, so a line in the buffer is paid for twice - once as an
+        // AnnotatedString, once as the StyledString it came from.
+        for (line in finishedLines) {
+            bytes += streamLineBytes(line)
+            characters += (line as? StreamTextLine)?.text?.length?.toLong() ?: 0L
+        }
+        for (cachedLine in cacheLines) {
+            bytes += MemoryEstimate.REFERENCE_BYTES
+            if (cachedLine == null) continue
+            bytes += MemoryEstimate.OBJECT_BYTES
+            bytes += cachedLine.text.substrings.sumOf { leafBytes(it) }
+        }
+
+        // Lines evicted from the buffer but still pinned by the displayed list's backing, which only
+        // compacts once the dropped prefix grows as large as the live window.
+        for (index in 0 until displayStart) {
+            bytes += streamLineBytes(displayBacking[index])
+        }
+        bytes += displayBacking.size * MemoryEstimate.REFERENCE_BYTES
+
+        var componentReferences = 0L
+        for ((name, serialNumbers) in componentLocations) {
+            componentReferences += serialNumbers.size
+            bytes += MemoryEstimate.string(name.length) + MemoryEstimate.OBJECT_BYTES
+            // Boxed Longs in a Set: the entry plus the box it points at.
+            bytes += serialNumbers.size * (MemoryEstimate.OBJECT_BYTES + MemoryEstimate.REFERENCE_BYTES)
+        }
+        for ((name, value) in components) {
+            bytes += MemoryEstimate.string(name.length) + MemoryEstimate.OBJECT_BYTES
+            bytes += value.substrings.sumOf { leafBytes(it) }
+        }
+
+        return StreamMemoryUsage(
+            streamId = id,
+            shownLines = displayBacking.size - displayStart,
+            bufferedLines = finishedLines.size,
+            heldLines = finishedLines.size + displayStart,
+            maxLines = maxLines,
+            textCharacters = characters,
+            componentReferences = componentReferences,
+            estimatedBytes = bytes,
+        )
+    }
+
+    private fun leafBytes(leaf: StyledStringLeaf): Long =
+        MemoryEstimate.OBJECT_BYTES + leaf.styles.size * MemoryEstimate.REFERENCE_BYTES +
+            when (leaf) {
+                is StyledStringSubstring -> MemoryEstimate.string(leaf.text.length)
+                is StyledStringVariable -> MemoryEstimate.string(leaf.name.length)
+            }
+
+    private fun streamLineBytes(line: StreamLine): Long =
+        MemoryEstimate.OBJECT_BYTES +
+            when (line) {
+                is StreamTextLine -> {
+                    val text = line.text
+                    if (text == null) {
+                        0L
+                    } else {
+                        MemoryEstimate.string(text.length) + text.spanStyles.size * MemoryEstimate.SPAN_BYTES
+                    }
+                }
+
+                is StreamImageLine -> {
+                    MemoryEstimate.string(line.url.length)
+                }
+            }
 
     fun setMarkLinks(markLinks: Boolean) {
         this.markLinks = markLinks

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowRegistryImpl.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowRegistryImpl.kt
@@ -41,6 +41,7 @@ import warlockfe.warlock3.core.text.toLayer
 import warlockfe.warlock3.core.util.SoundPlayer
 import warlockfe.warlock3.core.window.PanelState
 import warlockfe.warlock3.core.window.TextStream
+import warlockfe.warlock3.core.window.WindowMemoryUsage
 import warlockfe.warlock3.core.window.WindowRegistry
 import warlockfe.warlock3.wrayth.util.CompiledAlteration
 import kotlin.concurrent.atomics.AtomicReference
@@ -331,6 +332,14 @@ class WindowRegistryImpl(
             }
         }
     }
+
+    // Streams report one at a time rather than in parallel: they all share a single work queue, so
+    // concurrent requests would only queue up behind each other anyway.
+    override suspend fun memoryUsage(): WindowMemoryUsage =
+        WindowMemoryUsage(
+            streams = streams.load().values.map { it.memoryUsage() },
+            panelCount = panels.load().size,
+        )
 
     override fun setCharacterId(characterId: String) {
         this.characterId.value = characterId

--- a/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
+++ b/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
@@ -40,6 +40,7 @@ import warlockfe.warlock3.core.util.SoundPlayer
 import warlockfe.warlock3.core.util.WarlockDirs
 import warlockfe.warlock3.core.window.PanelState
 import warlockfe.warlock3.core.window.TextStream
+import warlockfe.warlock3.core.window.WindowMemoryUsage
 import warlockfe.warlock3.core.window.WindowRegistry
 import warlockfe.warlock3.wrayth.network.NetworkSocket
 import warlockfe.warlock3.wrayth.network.WraythClient
@@ -386,6 +387,12 @@ private class BenchWindowRegistry(
     }
 
     override fun getOrCreatePanel(name: String): PanelState = panels.computeIfAbsent(name) { ComposePanelState(name) }
+
+    override suspend fun memoryUsage(): WindowMemoryUsage =
+        WindowMemoryUsage(
+            streams = streams.values.map { it.memoryUsage() },
+            panelCount = panels.size,
+        )
 
     override fun setCharacterId(characterId: String) {
         workQueue.tag = characterId

--- a/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
+++ b/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
@@ -558,4 +558,78 @@ class ComposeTextStreamTest {
                 )
             }
         }
+
+    // The memory usage view reports what the stream is holding; the line counts have to be exact for
+    // it to be worth anything.
+    @Test
+    fun memoryUsageCountsBufferedLines() =
+        runBlocking {
+            withFixture { f ->
+                repeat(5) { i ->
+                    f.stream.appendLine(text("line$i"), ignoreWhenBlank = false, showWhenClosed = null)
+                }
+                f.drain()
+
+                val usage = f.stream.memoryUsage()
+                assertEquals("main", usage.streamId)
+                assertEquals(5, usage.shownLines)
+                assertEquals(5, usage.bufferedLines)
+                assertEquals(5, usage.heldLines)
+                assertEquals(1000, usage.maxLines)
+                assertEquals(25L, usage.textCharacters)
+                assertEquals(0L, usage.componentReferences)
+                assertTrue(usage.estimatedBytes > 0, "a buffer holding lines should estimate above zero")
+            }
+        }
+
+    // Past capacity the buffer stops growing, so the reported size has to stop growing with it.
+    @Test
+    fun memoryUsageStopsGrowingAtCapacity() =
+        runBlocking {
+            withFixture(maxLines = 4) { f ->
+                repeat(4) { i ->
+                    f.stream.appendLine(text("line$i"), ignoreWhenBlank = false, showWhenClosed = null)
+                }
+                f.drain()
+                val atCapacity = f.stream.memoryUsage()
+
+                repeat(40) { i ->
+                    f.stream.appendLine(text("later$i"), ignoreWhenBlank = false, showWhenClosed = null)
+                }
+                f.drain()
+                val wellPast = f.stream.memoryUsage()
+
+                assertEquals(4, atCapacity.bufferedLines)
+                assertEquals(4, wellPast.bufferedLines)
+                assertEquals(4, wellPast.shownLines)
+                // The displayed list compacts lazily, so it can still pin an evicted prefix - bounded
+                // by the live window, never unbounded.
+                assertTrue(
+                    wellPast.heldLines in 4..8,
+                    "held lines should stay within one compaction window of the buffer, was ${wellPast.heldLines}",
+                )
+            }
+        }
+
+    // The component index is never pruned when lines are evicted (see removeLines), so on a stream
+    // that receives components it grows for the life of the connection. Surfacing that count is a
+    // large part of why the memory view exists; this pins the behaviour it reports.
+    @Test
+    fun memoryUsageReportsUnprunedComponentIndex() =
+        runBlocking {
+            withFixture(maxLines = 4) { f ->
+                repeat(40) { i ->
+                    f.stream.appendLine(lineWithComponent("row$i ", "hp"), ignoreWhenBlank = false, showWhenClosed = null)
+                }
+                f.drain()
+
+                val usage = f.stream.memoryUsage()
+                assertEquals(4, usage.bufferedLines)
+                assertEquals(
+                    40L,
+                    usage.componentReferences,
+                    "component locations outlive the lines that registered them",
+                )
+            }
+        }
 }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/window/MemoryUsage.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/window/MemoryUsage.kt
@@ -1,0 +1,67 @@
+package warlockfe.warlock3.core.window
+
+/**
+ * What one text stream is holding on to.
+ *
+ * Every count here is exact. [estimatedBytes] is a cost model (see [MemoryEstimate]), not a
+ * measurement - the JVM offers no in-process way to size an object graph - so treat it as a way to
+ * rank windows against each other, not as a heap figure.
+ */
+data class StreamMemoryUsage(
+    val streamId: String,
+    /** Lines currently visible in the window, after any name filter. */
+    val shownLines: Int,
+    /** Lines in the scrollback buffer, which is what [maxLines] caps. */
+    val bufferedLines: Int,
+    /**
+     * Lines the stream still references, including ones already evicted from the buffer but not yet
+     * dropped from the displayed list's backing (it compacts lazily). A [heldLines] far above
+     * [bufferedLines] means something is pinning lines past their eviction.
+     */
+    val heldLines: Int,
+    val maxLines: Int,
+    val textCharacters: Long,
+    /**
+     * Serial numbers recorded in the component index. This index is never pruned when lines are
+     * evicted, so on a stream that receives server components it grows for the life of the
+     * connection - one entry per component occurrence, forever.
+     */
+    val componentReferences: Long,
+    val estimatedBytes: Long,
+)
+
+/** What a connection's window registry is holding, across all of its streams and panels. */
+data class WindowMemoryUsage(
+    val streams: List<StreamMemoryUsage>,
+    val panelCount: Int,
+) {
+    val estimatedBytes: Long get() = streams.sumOf { it.estimatedBytes }
+
+    companion object {
+        val EMPTY = WindowMemoryUsage(streams = emptyList(), panelCount = 0)
+    }
+}
+
+/**
+ * A rough per-object cost model for [StreamMemoryUsage.estimatedBytes].
+ *
+ * Sized for a 64-bit JVM with compressed references: 16-byte object headers, 4-byte references, and
+ * compact strings, which store ASCII (all game text) at one byte per character. The numbers are
+ * deliberately coarse - the point is to show which window is holding the memory, and roughly how
+ * much, without walking an object graph the JVM will not let us measure anyway.
+ */
+object MemoryEstimate {
+    /** A small object: header plus a handful of fields or references. */
+    const val OBJECT_BYTES = 48L
+
+    /** An AnnotatedString span: the range object plus the SpanStyle it points at. */
+    const val SPAN_BYTES = 120L
+
+    /** One reference-sized slot, e.g. an entry in a list's backing array. */
+    const val REFERENCE_BYTES = 4L
+
+    private const val STRING_BASE_BYTES = 40L
+
+    /** A String of [length] characters, including its backing byte array. */
+    fun string(length: Int): Long = STRING_BASE_BYTES + length
+}

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/window/WindowRegistry.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/window/WindowRegistry.kt
@@ -32,6 +32,10 @@ interface WindowRegistry {
 
     fun getOrCreatePanel(name: String): PanelState
 
+    // What this connection's streams and panels are currently retaining, for the memory usage view.
+    // Suspends because each stream reports from the work-queue coroutine that owns its buffers.
+    suspend fun memoryUsage(): WindowMemoryUsage
+
     fun setCharacterId(characterId: String)
 
     fun close()

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -124,6 +124,9 @@ potassium {
         "jdk.accessibility",
         "java.instrument",
         "java.management",
+        // HotSpotDiagnosticMXBean, which the memory usage dialog's heap dump goes through. Not part
+        // of java.management, so without this the packaged app can see heap totals but cannot dump.
+        "jdk.management",
         "jdk.dynalink",
         "jdk.security.auth",
         "jdk.unsupported",

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -323,6 +323,7 @@ private class WarlockCommand : CliktCommand() {
                                     warlockVersion = version ?: "Development",
                                     appContainer = appContainer,
                                     gameState = gameState,
+                                    games = games,
                                     openNewWindow = {
                                         // A manually opened window shows the dashboard; never auto-connect into it.
                                         games.add(GameState().apply { autoConnectAttempted = true })
@@ -734,7 +735,7 @@ private fun UpdateDialog(
     }
 }
 
-private fun GameState.getTitle(): Flow<String> =
+internal fun GameState.getTitle(): Flow<String> =
     when (val screen = this.screen) {
         GameScreen.Dashboard -> {
             flow { emit("Dashboard") }

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/MemoryUsageDialog.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/MemoryUsageDialog.kt
@@ -24,6 +24,9 @@ import com.sun.management.HotSpotDiagnosticMXBean
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.compose.rememberFileSaverLauncher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -272,30 +275,45 @@ private data class ConnectionMemoryReport(
 
 private suspend fun collectReport(games: List<GameState>): MemoryReport {
     val heap = ManagementFactory.getMemoryMXBean().heapMemoryUsage
+    // Snapshot first: games is the live window list, and it can gain or lose an entry while the
+    // report is being gathered.
+    val snapshot = games.toList()
+    // One coroutine per connection. Each has its own work queue, so a connection that never answers
+    // costs its own timeout rather than delaying every connection behind it. Within a connection the
+    // streams still report one at a time - they share a queue, so there is nothing to overlap.
     val connections =
-        games.mapIndexed { index, gameState ->
-            val viewModel = (gameState.screen as? GameScreen.ConnectedGameState)?.viewModel
-            // Bounded like the usage read below: the report is a diagnostic, so it should always
-            // arrive, even if some part of a wedged connection never answers.
-            val name = withTimeoutOrNull(1.seconds) { gameState.getTitle().first() } ?: "unknown"
-            val title = "Window ${index + 1}: $name"
-            if (viewModel == null) {
-                ConnectionMemoryReport(title = title, usage = WindowMemoryUsage.EMPTY, runningScripts = 0)
-            } else {
-                // A stream reports from the work queue that owns its buffers, so a wedged or saturated
-                // queue would otherwise hang the dialog. Report what we can instead.
-                val usage = withTimeoutOrNull(5.seconds) { viewModel.memoryUsage() }
-                ConnectionMemoryReport(
-                    title = if (usage == null) "$title (did not respond)" else title,
-                    usage = usage ?: WindowMemoryUsage.EMPTY,
-                    runningScripts = viewModel.runningScriptCount,
-                )
-            }
+        coroutineScope {
+            snapshot
+                .mapIndexed { index, gameState ->
+                    async { collectConnectionReport(index, gameState) }
+                }.awaitAll()
         }
     return MemoryReport(
         heapUsedBytes = heap.used,
         heapMaxBytes = heap.max,
         connections = connections,
+    )
+}
+
+private suspend fun collectConnectionReport(
+    index: Int,
+    gameState: GameState,
+): ConnectionMemoryReport {
+    val viewModel = (gameState.screen as? GameScreen.ConnectedGameState)?.viewModel
+    // Bounded like the usage read below: the report is a diagnostic, so it should always arrive,
+    // even if some part of a wedged connection never answers.
+    val name = withTimeoutOrNull(1.seconds) { gameState.getTitle().first() } ?: "unknown"
+    val title = "Window ${index + 1}: $name"
+    if (viewModel == null) {
+        return ConnectionMemoryReport(title = title, usage = WindowMemoryUsage.EMPTY, runningScripts = 0)
+    }
+    // A stream reports from the work queue that owns its buffers, so a wedged or saturated queue
+    // would otherwise hang the dialog. Report what we can instead.
+    val usage = withTimeoutOrNull(5.seconds) { viewModel.memoryUsage() }
+    return ConnectionMemoryReport(
+        title = if (usage == null) "$title (did not respond)" else title,
+        usage = usage ?: WindowMemoryUsage.EMPTY,
+        runningScripts = viewModel.runningScriptCount,
     )
 }
 

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/MemoryUsageDialog.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/MemoryUsageDialog.kt
@@ -1,0 +1,325 @@
+package warlockfe.warlock3.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import co.touchlab.kermit.Logger
+import com.sun.management.HotSpotDiagnosticMXBean
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.dialogs.compose.rememberFileSaverLauncher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.jetbrains.jewel.ui.component.Text
+import warlockfe.warlock3.compose.desktop.shim.WarlockButton
+import warlockfe.warlock3.compose.desktop.shim.WarlockDialog
+import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
+import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
+import warlockfe.warlock3.compose.model.GameScreen
+import warlockfe.warlock3.compose.model.GameState
+import warlockfe.warlock3.compose.util.createPlatformDialogSettings
+import warlockfe.warlock3.core.window.WindowMemoryUsage
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+import java.io.File
+import java.lang.management.ManagementFactory
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Where the app's memory is going, in the app's own terms: how much scrollback each game window is
+ * holding, and what else each connection is retaining.
+ *
+ * Aimed at a user reporting growth rather than at a profiler. The counts are exact and the sizes are
+ * estimates (see [warlockfe.warlock3.core.window.MemoryEstimate]), which is enough to point at the
+ * window or connection responsible; "save heap dump" is there for when it isn't.
+ */
+@Suppress("ktlint:compose:modifier-missing-check")
+@Composable
+fun MemoryUsageDialog(
+    games: List<GameState>,
+    onCloseRequest: () -> Unit,
+) {
+    val logger = remember { Logger.withTag("MemoryUsageDialog") }
+    var report: MemoryReport? by remember { mutableStateOf(null) }
+    var status: String? by remember { mutableStateOf(null) }
+    var busy by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    suspend fun refresh() {
+        report = collectReport(games)
+    }
+
+    LaunchedEffect(Unit) { refresh() }
+
+    val heapDumpSaveLauncher =
+        rememberFileSaverLauncher(
+            dialogSettings = FileKitDialogSettings.createPlatformDialogSettings("Save heap dump"),
+        ) { file ->
+            val target = file?.file ?: return@rememberFileSaverLauncher
+            busy = true
+            status = "Writing heap dump..."
+            scope.launch {
+                status =
+                    try {
+                        val size = withContext(Dispatchers.IO) { dumpHeap(target) }
+                        "Wrote ${formatBytes(size)} to ${target.absolutePath}"
+                    } catch (e: Exception) {
+                        ensureActive()
+                        logger.e(e) { "Heap dump failed" }
+                        "Heap dump failed: ${e.message}"
+                    }
+                busy = false
+            }
+        }
+
+    WarlockDialog(
+        title = "Memory usage",
+        onCloseRequest = onCloseRequest,
+        width = 760.dp,
+        height = 600.dp,
+    ) {
+        Column(Modifier.fillMaxSize()) {
+            val snapshot = report
+            if (snapshot == null) {
+                Text("Measuring...")
+            } else {
+                Text(
+                    "Heap: ${formatBytes(snapshot.heapUsedBytes)} used of " +
+                        "${formatBytes(snapshot.heapMaxBytes)} max",
+                )
+                Text(
+                    "Most of what Warlock holds is window scrollback. Line counts are exact; sizes are " +
+                        "estimates, useful for comparing windows rather than as heap figures.",
+                )
+                Spacer(Modifier.height(12.dp))
+                WarlockScrollableColumn(Modifier.weight(1f)) {
+                    snapshot.connections.forEach { connection ->
+                        ConnectionSection(connection)
+                        Spacer(Modifier.height(16.dp))
+                    }
+                    if (snapshot.connections.isEmpty()) {
+                        Text("No connections are open.")
+                    }
+                }
+            }
+            status?.let {
+                Spacer(Modifier.height(8.dp))
+                Text(it)
+            }
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+            ) {
+                WarlockOutlinedButton(
+                    onClick = {
+                        scope.launch {
+                            busy = true
+                            refresh()
+                            busy = false
+                        }
+                    },
+                    text = "Refresh",
+                    enabled = !busy,
+                )
+                WarlockOutlinedButton(
+                    onClick = {
+                        val text = report?.toText() ?: return@WarlockOutlinedButton
+                        Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(text), null)
+                        status = "Report copied to the clipboard."
+                    },
+                    text = "Copy report",
+                    enabled = report != null && !busy,
+                )
+                WarlockOutlinedButton(
+                    onClick = {
+                        heapDumpSaveLauncher.launch(suggestedName = "warlock", defaultExtension = "hprof")
+                    },
+                    text = "Save heap dump...",
+                    enabled = !busy,
+                )
+                WarlockButton(onClick = onCloseRequest, text = "Close")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConnectionSection(
+    connection: ConnectionMemoryReport,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier) {
+        Text(connection.title)
+        Spacer(Modifier.height(4.dp))
+        if (connection.usage.streams.isEmpty()) {
+            // Nothing is connected in this window, so there is no scrollback to account for.
+            Text("No game windows.")
+        } else {
+            UsageRow(
+                window = "Window",
+                shown = "Shown",
+                buffered = "Buffered",
+                held = "Held",
+                componentRefs = "Component refs",
+                size = "Est. size",
+            )
+            connection.usage.streams
+                .sortedByDescending { it.estimatedBytes }
+                .forEach { stream ->
+                    UsageRow(
+                        window = stream.streamId,
+                        shown = stream.shownLines.toString(),
+                        buffered = "${stream.bufferedLines} / ${stream.maxLines}",
+                        held = stream.heldLines.toString(),
+                        componentRefs = formatCount(stream.componentReferences),
+                        size = formatBytes(stream.estimatedBytes),
+                    )
+                }
+            UsageRow(
+                window = "Total",
+                shown = "",
+                buffered = "",
+                held = "",
+                componentRefs = formatCount(connection.usage.streams.sumOf { it.componentReferences }),
+                size = formatBytes(connection.usage.estimatedBytes),
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Windows: ${connection.usage.streams.size}   " +
+                "Panels: ${connection.usage.panelCount}   " +
+                "Running scripts: ${connection.runningScripts}",
+        )
+    }
+}
+
+@Composable
+private fun UsageRow(
+    window: String,
+    shown: String,
+    buffered: String,
+    held: String,
+    componentRefs: String,
+    size: String,
+) {
+    Row(Modifier.fillMaxWidth()) {
+        Text(window, modifier = Modifier.width(180.dp), fontFamily = FontFamily.Monospace)
+        Text(shown, modifier = Modifier.width(80.dp), fontFamily = FontFamily.Monospace)
+        Text(buffered, modifier = Modifier.width(120.dp), fontFamily = FontFamily.Monospace)
+        Text(held, modifier = Modifier.width(80.dp), fontFamily = FontFamily.Monospace)
+        Text(componentRefs, modifier = Modifier.width(130.dp), fontFamily = FontFamily.Monospace)
+        Text(size, fontFamily = FontFamily.Monospace)
+    }
+}
+
+private data class MemoryReport(
+    val heapUsedBytes: Long,
+    val heapMaxBytes: Long,
+    val connections: List<ConnectionMemoryReport>,
+) {
+    // The plain-text form of what the dialog shows, for pasting into a bug report.
+    fun toText(): String =
+        buildString {
+            appendLine("Warlock memory usage")
+            appendLine("Heap: ${formatBytes(heapUsedBytes)} used of ${formatBytes(heapMaxBytes)} max")
+            connections.forEach { connection ->
+                appendLine()
+                appendLine(connection.title)
+                appendLine("  window / shown / buffered / max / held / component refs / est. size")
+                connection.usage.streams
+                    .sortedByDescending { it.estimatedBytes }
+                    .forEach { stream ->
+                        appendLine(
+                            "  ${stream.streamId} / ${stream.shownLines} / ${stream.bufferedLines} / " +
+                                "${stream.maxLines} / ${stream.heldLines} / ${stream.componentReferences} / " +
+                                formatBytes(stream.estimatedBytes),
+                        )
+                    }
+                appendLine(
+                    "  windows=${connection.usage.streams.size} panels=${connection.usage.panelCount} " +
+                        "scripts=${connection.runningScripts} " +
+                        "total=${formatBytes(connection.usage.estimatedBytes)}",
+                )
+            }
+        }
+}
+
+private data class ConnectionMemoryReport(
+    val title: String,
+    val usage: WindowMemoryUsage,
+    val runningScripts: Int,
+)
+
+private suspend fun collectReport(games: List<GameState>): MemoryReport {
+    val heap = ManagementFactory.getMemoryMXBean().heapMemoryUsage
+    val connections =
+        games.mapIndexed { index, gameState ->
+            val viewModel = (gameState.screen as? GameScreen.ConnectedGameState)?.viewModel
+            // Bounded like the usage read below: the report is a diagnostic, so it should always
+            // arrive, even if some part of a wedged connection never answers.
+            val name = withTimeoutOrNull(1.seconds) { gameState.getTitle().first() } ?: "unknown"
+            val title = "Window ${index + 1}: $name"
+            if (viewModel == null) {
+                ConnectionMemoryReport(title = title, usage = WindowMemoryUsage.EMPTY, runningScripts = 0)
+            } else {
+                // A stream reports from the work queue that owns its buffers, so a wedged or saturated
+                // queue would otherwise hang the dialog. Report what we can instead.
+                val usage = withTimeoutOrNull(5.seconds) { viewModel.memoryUsage() }
+                ConnectionMemoryReport(
+                    title = if (usage == null) "$title (did not respond)" else title,
+                    usage = usage ?: WindowMemoryUsage.EMPTY,
+                    runningScripts = viewModel.runningScriptCount,
+                )
+            }
+        }
+    return MemoryReport(
+        heapUsedBytes = heap.used,
+        heapMaxBytes = heap.max,
+        connections = connections,
+    )
+}
+
+/** Writes a live-objects heap dump to [target], returning its size. */
+private fun dumpHeap(target: File): Long {
+    // dumpHeap refuses to overwrite, and the save dialog has already taken the user's confirmation
+    // for this path, so clear it first.
+    if (target.exists()) {
+        target.delete()
+    }
+    val bean = ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean::class.java)
+    // live = true runs a full GC first and dumps only reachable objects: a much smaller file, and
+    // what you want when the question is what is being retained.
+    bean.dumpHeap(target.absolutePath, true)
+    return target.length()
+}
+
+private fun formatBytes(bytes: Long): String =
+    when {
+        bytes < 0 -> "unknown"
+        bytes < 1024 -> "$bytes B"
+        bytes < 1024 * 1024 -> String.format("%.1f KB", bytes / 1024.0)
+        bytes < 1024L * 1024 * 1024 -> String.format("%.1f MB", bytes / (1024.0 * 1024))
+        else -> String.format("%.2f GB", bytes / (1024.0 * 1024 * 1024))
+    }
+
+private fun formatCount(count: Long): String = String.format("%,d", count)

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/TitleBarView.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/TitleBarView.kt
@@ -65,6 +65,7 @@ internal fun DecoratedWindowScope.TitleBarView(
     runScript: (Path) -> Unit,
     showUpdateDialog: () -> Unit,
     showAboutDialog: () -> Unit,
+    showMemoryDialog: () -> Unit,
     exportSettings: (File) -> Unit,
     exportCharacterSettings: (File) -> Unit,
     importSettings: (File) -> Unit,
@@ -172,6 +173,7 @@ internal fun DecoratedWindowScope.TitleBarView(
                         items =
                             listOf(
                                 AppMenuItem("Updates", onClick = showUpdateDialog),
+                                AppMenuItem("Memory usage...", onClick = showMemoryDialog),
                                 AppMenuItem("About", onClick = showAboutDialog),
                             ),
                     ),

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/WarlockApp.kt
@@ -35,6 +35,8 @@ fun DecoratedWindowScope.WarlockApp(
     warlockVersion: String,
     appContainer: AppContainer,
     gameState: GameState,
+    // Every open window, so the memory view can account for the whole app rather than just this one.
+    games: List<GameState>,
     openNewWindow: () -> Unit,
     showUpdateDialog: () -> Unit,
     sgeSettings: SgeSettings,
@@ -71,6 +73,7 @@ fun DecoratedWindowScope.WarlockApp(
     }
 
     var showAboutDialog by remember { mutableStateOf(false) }
+    var showMemoryDialog by remember { mutableStateOf(false) }
     var sideBarVisible by remember { mutableStateOf(false) }
     val wraythFileLauncher =
         rememberFilePickerLauncher(
@@ -156,6 +159,7 @@ fun DecoratedWindowScope.WarlockApp(
         },
         showUpdateDialog = showUpdateDialog,
         showAboutDialog = { showAboutDialog = !showAboutDialog },
+        showMemoryDialog = { showMemoryDialog = true },
         exportSettings = { file ->
             runTransfer("Failed to export settings") {
                 file.writeText(transfer.exportAll())
@@ -246,6 +250,12 @@ fun DecoratedWindowScope.WarlockApp(
     }
     if (showAboutDialog) {
         AboutDialog(warlockVersion) { showAboutDialog = false }
+    }
+    if (showMemoryDialog) {
+        MemoryUsageDialog(
+            games = games,
+            onCloseRequest = { showMemoryDialog = false },
+        )
     }
     if (reconnecting) {
         DesktopReconnectingDialog(onGoToDashboard = goToDashboard)


### PR DESCRIPTION
A user reports large memory growth and there was no way for them to tell us where it was going. **Help > Memory usage** breaks down what the app is retaining, in the app's own terms.

## What it shows

Per connection, one row per game window:

| column | meaning |
| --- | --- |
| Shown | lines currently visible, after any name filter |
| Buffered / max | lines in the scrollback buffer against its cap |
| Held | lines still referenced, including ones evicted from the buffer but still pinned by the displayed list's lazily-compacted backing |
| Component refs | entries in the stream's component index |
| Est. size | modelled bytes, for ranking windows against each other |

Plus window/panel/script counts per connection, and one heap used/max line for scale.

Counts are exact. Sizes are a documented cost model (`MemoryEstimate`) rather than measurements — the JVM offers no in-process way to size an object graph — so they are for comparing windows, not for reporting heap.

- **Copy report** puts a plain-text version on the clipboard to paste into an issue.
- **Save heap dump** writes a live-objects `.hprof` for when the breakdown is not enough. That goes through `HotSpotDiagnosticMXBean`, so `jdk.management` joins the packaged runtime image.

## Notes

Streams measure themselves on the work queue that owns their buffers rather than racing the UI thread, which is why the registry call suspends. Both the title and the usage read are timeout-bounded, so a wedged connection degrades to "did not respond" instead of hanging the dialog.

"Component refs" is a column rather than an internal detail because `removeLines` deliberately never prunes `componentLocations`:

```
// Intentionally leak components here. They don't exist in the main window,
// and no other windows get long enough
```

On a stream that does receive components that index grows for the life of the connection. This PR does not change that behaviour, only surfaces it; `memoryUsageReportsUnprunedComponentIndex` pins it (40 lines appended into a 4-line buffer leaves 4 buffered lines and 40 component references).

## Testing

Three new stream tests over the accounting, plus the existing suites. Desktop app launched and the dialog verified on screen. `jdk.management` confirmed present in the packaged runtime image via `createDistributable`, with the packaged binary's `--version` exiting 0. `dumpHeap(path, live = true)` checked on JDK 25, producing a valid `JAVA PROFILE 1.0.2` file.

Not exercised: the mobile UI (desktop-only feature), and the heap dump button itself was not clicked in a GUI session — the MXBean call it makes was verified separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Memory Usage dialog accessible from the Help menu.
  * View heap usage, per-connection memory estimates, panels, component references, and running scripts.
  * Refresh usage data, copy reports, and save heap dumps with progress and error feedback.
  * Added bounded memory accounting for buffered, displayed, cached, and styled stream content.
  * Reports remain responsive when individual connections are unavailable or slow.

* **Tests**
  * Added coverage for memory estimates, capacity limits, and retained component references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->