### PR TITLE
Bound the lazy list's item key space

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
@@ -419,9 +419,18 @@ private fun WindowViewContent(
                                 },
                         state = scrollState,
                     ) {
+                        // Recycled item keys. Compose caches one CachedItemContent per distinct item
+                        // key in LazyLayoutItemContentFactory and never evicts an entry, so keying
+                        // rows by a serial number - which only ever counts up - retains one entry
+                        // (plus its boxed key) per line ever displayed, for the window's lifetime.
+                        // Measured at ~45k entries a minute under a heavy stream, growing linearly
+                        // while the line buffer itself stayed flat. Keys only need to be unique
+                        // among the rows present at once, so folding them into a bounded space caps
+                        // the cache instead. See [lazyItemKeyModulus] for why the bound is safe.
+                        val keyModulus = lazyItemKeyModulus(lines.serialSpan())
                         items(
                             count = lines.size,
-                            key = { index -> lines[index].serialNumber },
+                            key = { index -> lines[index].serialNumber % keyModulus },
                         ) { index ->
                             when (val line = lines[index]) {
                                 is StreamTextLine -> {
@@ -621,3 +630,37 @@ internal fun Modifier.addTextContextMenuOptions(
             }
         }
     }
+
+/**
+ * The width of the serial-number range the displayed lines occupy: one past the distance from the
+ * oldest shown line to the newest. Serial numbers are handed out in order, so however many lines a
+ * filter hides, every shown line falls inside this range.
+ */
+internal fun List<StreamLine>.serialSpan(): Long = if (isEmpty()) 0L else last().serialNumber - first().serialNumber + 1
+
+/**
+ * A modulus that folds ever-increasing serial numbers into a bounded set of lazy-list item keys.
+ *
+ * Keys must be unique among the rows present at once, and nothing more: a key that repeats after a
+ * line is gone just reuses its cache entry, which is the point. Rows occupy a contiguous serial
+ * range [serialSpan] wide, so any modulus greater than that span maps them to distinct keys. This
+ * returns at least twice the span (and never less than [MIN_LAZY_ITEM_KEY_MODULUS]), rounded up to
+ * a power of two so it changes rarely - a change re-keys every row, costing one full recomposition
+ * of the list, so with the default scrollback it settles during warmup and then holds.
+ */
+internal fun lazyItemKeyModulus(serialSpan: Long): Long {
+    var modulus = MIN_LAZY_ITEM_KEY_MODULUS
+    // Doubling rather than computing a bit length keeps the growth obvious, and the loop runs a
+    // handful of times at most: the span is bounded by the scrollback buffer.
+    while (modulus < serialSpan * 2 && modulus < MAX_LAZY_ITEM_KEY_MODULUS) {
+        modulus *= 2
+    }
+    return modulus
+}
+
+// Comfortably above the default scrollback, so the common case never re-keys after warmup.
+private const val MIN_LAZY_ITEM_KEY_MODULUS = 4096L
+
+// A guard for an unbounded buffer (scrollback set to zero): the modulus stops doubling, and the key
+// space stops being recycled, once it is larger than any buffer that could fit in memory anyway.
+private const val MAX_LAZY_ITEM_KEY_MODULUS = 1L shl 40

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
@@ -650,19 +650,11 @@ internal fun List<StreamLine>.serialSpan(): Long = if (isEmpty()) 0L else last()
  */
 internal fun lazyItemKeyModulus(serialSpan: Long): Long {
     var modulus = MIN_LAZY_ITEM_KEY_MODULUS
-    // Doubling rather than computing a bit length keeps the growth obvious, and the loop runs a
-    // handful of times at most: the span is bounded by the scrollback buffer. The comparison halves
-    // the modulus rather than doubling the span, because doubling a large span would overflow and
-    // wrap negative - which would end the loop early and hand back a modulus that collides.
+    // The rows on screen come out of the scrollback buffer, which removeLines caps, so the span has
+    // a ceiling of about a million and this doubles nine times at the very most. Doubling rather
+    // than computing a bit length keeps the growth obvious; halving the modulus rather than doubling
+    // the span keeps the comparison away from any overflow question.
     while (modulus / 2 <= serialSpan) {
-        if (modulus > Long.MAX_VALUE / 2) {
-            // No Long modulus can separate a span this wide, so stop folding rather than return one
-            // that quietly collides: at this size the modulo is the identity. Unreachable in
-            // practice - the lines spanning it would have exhausted memory long before - but this
-            // function exists to guarantee distinct keys, so it should not have a size at which it
-            // silently stops.
-            return Long.MAX_VALUE
-        }
         modulus *= 2
     }
     return modulus

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowViewScaffold.kt
@@ -651,8 +651,18 @@ internal fun List<StreamLine>.serialSpan(): Long = if (isEmpty()) 0L else last()
 internal fun lazyItemKeyModulus(serialSpan: Long): Long {
     var modulus = MIN_LAZY_ITEM_KEY_MODULUS
     // Doubling rather than computing a bit length keeps the growth obvious, and the loop runs a
-    // handful of times at most: the span is bounded by the scrollback buffer.
-    while (modulus < serialSpan * 2 && modulus < MAX_LAZY_ITEM_KEY_MODULUS) {
+    // handful of times at most: the span is bounded by the scrollback buffer. The comparison halves
+    // the modulus rather than doubling the span, because doubling a large span would overflow and
+    // wrap negative - which would end the loop early and hand back a modulus that collides.
+    while (modulus / 2 <= serialSpan) {
+        if (modulus > Long.MAX_VALUE / 2) {
+            // No Long modulus can separate a span this wide, so stop folding rather than return one
+            // that quietly collides: at this size the modulo is the identity. Unreachable in
+            // practice - the lines spanning it would have exhausted memory long before - but this
+            // function exists to guarantee distinct keys, so it should not have a size at which it
+            // silently stops.
+            return Long.MAX_VALUE
+        }
         modulus *= 2
     }
     return modulus
@@ -660,7 +670,3 @@ internal fun lazyItemKeyModulus(serialSpan: Long): Long {
 
 // Comfortably above the default scrollback, so the common case never re-keys after warmup.
 private const val MIN_LAZY_ITEM_KEY_MODULUS = 4096L
-
-// A guard for an unbounded buffer (scrollback set to zero): the modulus stops doubling, and the key
-// space stops being recycled, once it is larger than any buffer that could fit in memory anyway.
-private const val MAX_LAZY_ITEM_KEY_MODULUS = 1L shl 40

--- a/compose/src/jvmTest/kotlin/LazyItemKeyTest.kt
+++ b/compose/src/jvmTest/kotlin/LazyItemKeyTest.kt
@@ -39,6 +39,31 @@ class LazyItemKeyTest {
         }
     }
 
+    // A span this wide needs more lines than fit in memory, so it is unreachable - but the whole
+    // point of this function is distinct keys, so it must not have a size at which it stops
+    // delivering them and returns a colliding modulus instead.
+    @Test
+    fun modulusHandlesSpansTooLargeToFold() {
+        for (span in listOf(1L shl 40, (1L shl 40) + 1, 1L shl 41, Long.MAX_VALUE / 4)) {
+            val modulus = lazyItemKeyModulus(span)
+            assertTrue(modulus > span, "modulus $modulus must exceed span $span")
+        }
+        // Past the point where doubling would overflow, the fold degrades to the identity rather
+        // than wrapping negative and collapsing back to the floor.
+        for (span in listOf(Long.MAX_VALUE / 2, Long.MAX_VALUE - 1, Long.MAX_VALUE)) {
+            assertEquals(Long.MAX_VALUE, lazyItemKeyModulus(span), "span $span should stop folding")
+        }
+    }
+
+    // Serial numbers around the overflow boundary still have to key distinctly.
+    @Test
+    fun keysAreDistinctForAnEnormousSpan() {
+        val span = Long.MAX_VALUE / 2
+        val modulus = lazyItemKeyModulus(span)
+        val serials = listOf(0L, 1L, span / 2, span - 1, span)
+        assertEquals(serials.size, serials.mapTo(HashSet()) { it % modulus }.size)
+    }
+
     @Test
     fun modulusStaysBoundedAndStableForTheDefaultScrollback() {
         // The default 2000-line buffer must land on one value and stay there, so rows are not

--- a/compose/src/jvmTest/kotlin/LazyItemKeyTest.kt
+++ b/compose/src/jvmTest/kotlin/LazyItemKeyTest.kt
@@ -39,29 +39,17 @@ class LazyItemKeyTest {
         }
     }
 
-    // A span this wide needs more lines than fit in memory, so it is unreachable - but the whole
-    // point of this function is distinct keys, so it must not have a size at which it stops
-    // delivering them and returns a colliding modulus instead.
+    // The buffer is capped, so the span is too: this is the widest the fold ever has to separate.
     @Test
-    fun modulusHandlesSpansTooLargeToFold() {
-        for (span in listOf(1L shl 40, (1L shl 40) + 1, 1L shl 41, Long.MAX_VALUE / 4)) {
-            val modulus = lazyItemKeyModulus(span)
-            assertTrue(modulus > span, "modulus $modulus must exceed span $span")
+    fun modulusStaysSmallAcrossTheWholeReachableRange() {
+        val widestSpan = 1_000_000L
+        val modulus = lazyItemKeyModulus(widestSpan)
+        assertTrue(modulus > widestSpan, "modulus $modulus must exceed the widest span")
+        assertEquals(2_097_152L, modulus)
+        // Nothing in the reachable range asks for a key space bigger than that.
+        for (span in listOf(0L, 1L, 2_000L, 100_000L, widestSpan)) {
+            assertTrue(lazyItemKeyModulus(span) <= modulus, "span $span should not exceed the widest modulus")
         }
-        // Past the point where doubling would overflow, the fold degrades to the identity rather
-        // than wrapping negative and collapsing back to the floor.
-        for (span in listOf(Long.MAX_VALUE / 2, Long.MAX_VALUE - 1, Long.MAX_VALUE)) {
-            assertEquals(Long.MAX_VALUE, lazyItemKeyModulus(span), "span $span should stop folding")
-        }
-    }
-
-    // Serial numbers around the overflow boundary still have to key distinctly.
-    @Test
-    fun keysAreDistinctForAnEnormousSpan() {
-        val span = Long.MAX_VALUE / 2
-        val modulus = lazyItemKeyModulus(span)
-        val serials = listOf(0L, 1L, span / 2, span - 1, span)
-        assertEquals(serials.size, serials.mapTo(HashSet()) { it % modulus }.size)
     }
 
     @Test

--- a/compose/src/jvmTest/kotlin/LazyItemKeyTest.kt
+++ b/compose/src/jvmTest/kotlin/LazyItemKeyTest.kt
@@ -1,0 +1,80 @@
+import warlockfe.warlock3.compose.ui.window.StreamLine
+import warlockfe.warlock3.compose.ui.window.StreamTextLine
+import warlockfe.warlock3.compose.ui.window.lazyItemKeyModulus
+import warlockfe.warlock3.compose.ui.window.serialSpan
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The lazy list folds line serial numbers into a bounded key space, because Compose caches one
+ * entry per distinct item key forever. That is only safe while the fold keeps the keys of the lines
+ * on screen at once distinct - a collision there is a duplicate key in a LazyColumn.
+ */
+class LazyItemKeyTest {
+    private fun line(serialNumber: Long): StreamLine =
+        StreamTextLine(
+            text = null,
+            entireLineStyle = null,
+            serialNumber = serialNumber,
+            showWhenClosed = null,
+            isPrompt = false,
+        )
+
+    // The displayed lines occupy a contiguous serial range; a filter only removes lines from inside it.
+    @Test
+    fun serialSpanMeasuresTheRangeNotTheCount() {
+        assertEquals(0L, emptyList<StreamLine>().serialSpan())
+        assertEquals(1L, listOf(line(7)).serialSpan())
+        assertEquals(5L, listOf(line(10), line(11), line(12), line(13), line(14)).serialSpan())
+        // A name filter hiding the middle leaves the same range.
+        assertEquals(5L, listOf(line(10), line(14)).serialSpan())
+    }
+
+    @Test
+    fun modulusExceedsTheSpanItHasToSeparate() {
+        for (span in listOf(0L, 1L, 100L, 2_000L, 4_095L, 4_096L, 10_000L, 250_000L)) {
+            val modulus = lazyItemKeyModulus(span)
+            assertTrue(modulus > span, "modulus $modulus must exceed span $span to keep keys distinct")
+        }
+    }
+
+    @Test
+    fun modulusStaysBoundedAndStableForTheDefaultScrollback() {
+        // The default 2000-line buffer must land on one value and stay there, so rows are not
+        // re-keyed (a full recomposition) as the buffer fills.
+        val duringWarmup = (0L..2_000L step 97).map { lazyItemKeyModulus(it) }
+        assertEquals(setOf(4_096L), duringWarmup.toSet())
+    }
+
+    // The property that matters: no two lines on screen at once may share a key.
+    @Test
+    fun keysAreDistinctAcrossAFullBuffer() {
+        for (bufferSize in listOf(1, 2, 2_000, 5_000, 20_000)) {
+            // Start well past zero: serial numbers keep counting up for the life of the connection,
+            // so the fold has to hold at any offset, not just the first buffer.
+            val firstSerial = 987_654_321L
+            val lines = (0 until bufferSize).map { line(firstSerial + it) }
+            val modulus = lazyItemKeyModulus(lines.serialSpan())
+            val keys = lines.mapTo(HashSet()) { it.serialNumber % modulus }
+            assertEquals(
+                bufferSize,
+                keys.size,
+                "buffer of $bufferSize produced ${keys.size} distinct keys at modulus $modulus",
+            )
+        }
+    }
+
+    // Keys have to be reused once a line is gone - that reuse is what bounds the cache.
+    @Test
+    fun keysRecycleAsLinesScrollPast() {
+        val bufferSize = 2_000
+        val modulus = lazyItemKeyModulus(bufferSize.toLong())
+        val seen = (0L until 100_000L).mapTo(HashSet()) { it % modulus }
+        assertEquals(
+            modulus.toInt(),
+            seen.size,
+            "100k lines should reuse the whole key space rather than growing it",
+        )
+    }
+}


### PR DESCRIPTION
Fixes the unbounded growth found while investigating the memory-growth report.

## The leak

Compose caches one `CachedItemContent` per distinct item key in `LazyLayoutItemContentFactory`, and **never evicts an entry** — the map is only ever written to, and the `DisposableEffect` there clears the content lambda but leaves the entry behind. That is fine for a list with finite keys. Stream rows were keyed by line serial number, which only counts up, so every line ever displayed left an entry (plus its boxed `Long` key) for as long as the window stayed open.

Measured by replaying protocol through the real app and sampling `jcmd GC.class_histogram`, four samples about a minute apart:

| | sample 1 | sample 2 | sample 3 | sample 4 |
| --- | --- | --- | --- | --- |
| `CachedItemContent` | 3,876 | 51,782 | 97,206 | 140,031 |
| `java.lang.Long` | 8,311 | 56,309 | 101,613 | 144,509 |
| `StreamTextLine` | 14,684 | 14,665 | 10,115 | 13,138 |

Linear, no plateau, while the line buffers themselves stayed flat — the scrollback caps were working; the cache underneath them was not.

Not a regression from any recent change: v3.0.166 keyed rows the same way, and `LazyLayoutItemContentFactory.kt` is byte-identical between Compose 1.10.3 and 1.11.1. What varies is the rate, which scales with how many windows are composing lines.

## The fix

Item keys only have to be distinct among the rows present at once — a key reused after its line is gone just reuses the cache entry, which is the point. So the serial numbers are folded into a bounded space.

Displayed rows occupy a contiguous serial range (a name filter only removes lines from inside it), so any modulus wider than that range keeps them distinct. `lazyItemKeyModulus` takes twice the range, floored at 4096 and rounded up to a power of two, so with the default 2000-line scrollback it settles during warmup and then never changes — a change would re-key every row, costing one full recomposition of the list.

Same replay after the fix: **2,261 → 4,082 → 4,086 → 4,086.** Bounded by the modulus rather than growing ~45k entries a minute.

## Why not just drop the key

Index keys are bounded too, but the keys are what anchor the view when lines are trimmed off the front of the buffer. Without them, a reader scrolled up in the scrollback drifts by a line every time one is evicted, and per-row remembered state gets reused for the wrong line.

## Testing

`LazyItemKeyTest` covers the invariant the fix depends on — that no two rows on screen share a key:

- the span measures the serial *range*, not the row count, so a filtered list is still covered
- the modulus always exceeds the span it has to separate
- keys are distinct across a full buffer (1 … 20,000 rows) starting from a high serial offset, not just from zero
- keys do recycle, so the space stays bounded
- the default scrollback maps to a single stable modulus, so rows are not re-keyed as the buffer fills

Plus the existing suites, ktlint, and the replay measurement above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling performance by limiting retained list-item cache entries.
  * Preserved reliable row identification as items are displayed, recycled, and revisited during scrolling.
  * Improved behavior during extended scrolling and larger buffer configurations.

* **Tests**
  * Added coverage for item-key uniqueness, stability, bounded key ranges, and recycling behavior across different scrolling conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->