### PR TITLE
Prune the component index with the scrollback buffer

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -258,9 +258,10 @@ class ComposeTextStream(
         )
 
     // Trim the buffer down to the cap. Callers append first, then trim, so this evicts the oldest
-    // lines until at most maxLines remain (maxLines <= 0 means unbounded).
+    // lines until at most [effectiveMaxLines] remain.
     private fun removeLines() {
-        while (maxLines > 0 && finishedLines.size > maxLines) {
+        val cap = effectiveMaxLines(maxLines)
+        while (finishedLines.size > cap) {
             finishedLines.removeAt(0)
             cacheLines.removeAt(0)
             removedLines++
@@ -630,7 +631,8 @@ class ComposeTextStream(
             shownLines = displayBacking.size - displayStart,
             bufferedLines = finishedLines.size,
             heldLines = finishedLines.size + displayStart,
-            maxLines = maxLines,
+            // The cap actually in force, so the view never shows a "max" the buffer would not honour.
+            maxLines = effectiveMaxLines(maxLines),
             textCharacters = characters,
             componentReferences = componentReferences,
             estimatedBytes = bytes,
@@ -754,6 +756,18 @@ data class CachedLine(
             applyStyling = applyStyling,
         )
 }
+
+/**
+ * The buffer's ceiling, whatever the scrollback setting says: a setting of zero or less otherwise
+ * means an unbounded buffer, and every line is retained twice over (the rendered line plus the
+ * source it was rendered from) for every window of every connection.
+ *
+ * Far past any use anyone has for scrollback, so a setting near it is a mistake rather than a
+ * preference, and lines past it are dropped without saying anything.
+ */
+private const val HARD_MAX_LINES = 1_000_000
+
+internal fun effectiveMaxLines(maxLines: Int): Int = if (maxLines > 0) minOf(maxLines, HARD_MAX_LINES) else HARD_MAX_LINES
 
 private val streamLineLogger = Logger.withTag("toStreamLine")
 

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -261,12 +261,16 @@ class ComposeTextStream(
     // lines until at most [effectiveMaxLines] remain.
     private fun removeLines() {
         val cap = effectiveMaxLines(maxLines)
+        var evicted = false
         while (finishedLines.size > cap) {
             finishedLines.removeAt(0)
             cacheLines.removeAt(0)
             removedLines++
+            evicted = true
         }
-        pruneComponentLocations()
+        if (evicted) {
+            pruneComponentLocations()
+        }
     }
 
     /**
@@ -274,10 +278,15 @@ class ComposeTextStream(
      *
      * These used to be left in place deliberately ("they don't exist in the main window, and no
      * other windows get long enough"), but on any stream that does carry components the index grew
-     * for the life of the connection - one entry per occurrence, never reclaimed. Pruning here ties
-     * it to the buffer, which is already capped.
+     * for the life of the connection - one entry per occurrence, never reclaimed.
      *
-     * Runs once per append and walks one deque per component name, of which a stream has a handful.
+     * Runs only after an eviction actually happened, and walks one deque per component name. That
+     * is O(names), not O(1), but the server sends a small fixed set of component ids, so it is a
+     * few map steps. The alternative - re-deriving the evicted line's components and dropping only
+     * those - trades those steps for a getComponents() per evicted line, and makes correctness rest
+     * on the front entry belonging to that line, which a partial line (registered per increment,
+     * cached as the accumulation) makes harder to see. The stream benchmark could not tell the two
+     * apart: run-to-run spread on identical code was wider than any difference between them.
      */
     private fun pruneComponentLocations() {
         if (componentLocations.isEmpty()) return

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -106,7 +106,10 @@ class ComposeTextStream(
 
     private var partialLine: StyledString? = null
 
-    private val componentLocations = mutableMapOf<String, Set<Long>>()
+    // Serial numbers of the buffered lines that reference each component, oldest first. A deque
+    // rather than a set: appends go on the back and eviction drops from the front, so keeping it in
+    // step with the buffer costs O(1) per line instead of rebuilding a whole set per occurrence.
+    private val componentLocations = mutableMapOf<String, ArrayDeque<Long>>()
 
     var actionHandler: ((WarlockAction) -> Unit)? = null
 
@@ -231,8 +234,12 @@ class ComposeTextStream(
         serialNumber: Long,
     ) {
         text.getComponents().forEach { name ->
-            val existingLocations = componentLocations[name] ?: emptySet()
-            componentLocations[name] = existingLocations + serialNumber
+            val locations = componentLocations.getOrPut(name) { ArrayDeque() }
+            // A partial line re-registers its serial every time it grows, and serials only ever
+            // increase, so checking the tail is enough to keep this one entry per line.
+            if (locations.lastOrNull() != serialNumber) {
+                locations.addLast(serialNumber)
+            }
         }
     }
 
@@ -257,8 +264,38 @@ class ComposeTextStream(
             finishedLines.removeAt(0)
             cacheLines.removeAt(0)
             removedLines++
-            // Intentionally leak components here. They don't exist in the main window,
-            // and no other windows get long enough
+        }
+        pruneComponentLocations()
+    }
+
+    /**
+     * Drops component locations pointing at lines the buffer no longer holds.
+     *
+     * These used to be left in place deliberately ("they don't exist in the main window, and no
+     * other windows get long enough"), but on any stream that does carry components the index grew
+     * for the life of the connection - one entry per occurrence, never reclaimed. Pruning here ties
+     * it to the buffer, which is already capped.
+     *
+     * Runs once per append and walks one deque per component name, of which a stream has a handful.
+     */
+    private fun pruneComponentLocations() {
+        if (componentLocations.isEmpty()) return
+        // No buffered lines means no location can point at one; otherwise drop everything below the
+        // oldest line still held. Serials are appended in order, so the stale entries are a prefix.
+        val oldestSerial = finishedLines.firstOrNull()?.serialNumber
+        val entries = componentLocations.iterator()
+        while (entries.hasNext()) {
+            val locations = entries.next().value
+            if (oldestSerial == null) {
+                locations.clear()
+            } else {
+                while (locations.isNotEmpty() && locations.first() < oldestSerial) {
+                    locations.removeFirst()
+                }
+            }
+            if (locations.isEmpty()) {
+                entries.remove()
+            }
         }
     }
 

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposeTextStream.kt
@@ -70,8 +70,12 @@ class ComposeTextStream(
     StreamWorkQueue.Flushable {
     // ArrayDeque so trimming the oldest line (removeAt(0)) once the buffer fills is O(1) rather than
     // the O(n) front shift of an ArrayList.
-    private val cacheLines = ArrayDeque<CachedLine?>(maxLines)
-    private val finishedLines = ArrayDeque<StreamLine>(maxLines)
+    //
+    // Pre-sized through [initialBufferCapacity] rather than from the setting directly: the capacity
+    // argument is allocated up front, so the raw value would let an oversized setting allocate that
+    // array immediately, and a negative one throws outright.
+    private val cacheLines = ArrayDeque<CachedLine?>(initialBufferCapacity(maxLines))
+    private val finishedLines = ArrayDeque<StreamLine>(initialBufferCapacity(maxLines))
 
     // Seeded with an (empty) OffsetList rather than emptyList() so every value this flow ever holds
     // shares OffsetList's referential equality. emptyList() compares by content, which would make the
@@ -775,6 +779,17 @@ data class CachedLine(
  * preference, and lines past it are dropped without saying anything.
  */
 private const val HARD_MAX_LINES = 1_000_000
+
+/**
+ * How much room to give the line buffers to start with.
+ *
+ * Only an optimization: a deque grows amortized, so starting smaller than the buffer will hold
+ * costs a few array copies. Starting *larger* is not free, though - the capacity is allocated
+ * immediately - so this stays modest and covers the default scrollback without regrowing.
+ */
+internal fun initialBufferCapacity(maxLines: Int): Int = effectiveMaxLines(maxLines).coerceAtMost(MAX_INITIAL_BUFFER_CAPACITY)
+
+private const val MAX_INITIAL_BUFFER_CAPACITY = 4096
 
 internal fun effectiveMaxLines(maxLines: Int): Int = if (maxLines > 0) minOf(maxLines, HARD_MAX_LINES) else HARD_MAX_LINES
 

--- a/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
+++ b/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
@@ -664,6 +664,34 @@ class ComposeTextStreamTest {
             }
         }
 
+    // A line can reference several components, so the index legitimately runs above the line count;
+    // what matters is that it stays proportional to the buffer rather than to the session.
+    @Test
+    fun componentIndexCountsEveryReferenceOnALine() =
+        runBlocking {
+            withFixture(maxLines = 4) { f ->
+                repeat(30) { i ->
+                    f.stream.appendLine(
+                        StyledString(
+                            persistentListOf(
+                                StyledStringSubstring("row$i ", persistentListOf()),
+                                StyledStringVariable("hp", persistentListOf()),
+                                StyledStringSubstring(" ", persistentListOf()),
+                                StyledStringVariable("mana", persistentListOf()),
+                            ),
+                        ),
+                        ignoreWhenBlank = false,
+                        showWhenClosed = null,
+                    )
+                }
+                f.drain()
+
+                val usage = f.stream.memoryUsage()
+                assertEquals(4, usage.bufferedLines)
+                assertEquals(8L, usage.componentReferences, "two components on each of four buffered lines")
+            }
+        }
+
     // Pruning must not disturb the mapping from a component to the lines still buffered: an update
     // after eviction has to reach every remaining occurrence.
     @Test

--- a/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
+++ b/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
@@ -17,6 +17,7 @@ import warlockfe.warlock3.compose.ui.window.StreamLine
 import warlockfe.warlock3.compose.ui.window.StreamTextLine
 import warlockfe.warlock3.compose.ui.window.StreamWorkQueue
 import warlockfe.warlock3.compose.ui.window.effectiveMaxLines
+import warlockfe.warlock3.compose.ui.window.initialBufferCapacity
 import warlockfe.warlock3.compose.util.HighlightIndex
 import warlockfe.warlock3.core.prefs.models.AlterationEntity
 import warlockfe.warlock3.core.text.StyleDefinition
@@ -661,6 +662,39 @@ class ComposeTextStreamTest {
                     usage.componentReferences,
                     "component locations should be pruned along with the lines that registered them",
                 )
+            }
+        }
+
+    @Test
+    fun initialBufferCapacityNeverAsksForAnOversizedOrNegativeArray() {
+        assertEquals(2_000, initialBufferCapacity(2_000))
+        assertEquals(4_096, initialBufferCapacity(4_096))
+        // A deque allocates its initial capacity immediately, so a large buffer starts smaller and
+        // grows rather than reserving the whole thing up front.
+        assertEquals(4_096, initialBufferCapacity(1_000_000))
+        assertEquals(4_096, initialBufferCapacity(Int.MAX_VALUE))
+        // ArrayDeque(negative) throws, so these must never reach it.
+        assertEquals(4_096, initialBufferCapacity(0))
+        assertEquals(4_096, initialBufferCapacity(-1))
+        assertEquals(4_096, initialBufferCapacity(Int.MIN_VALUE))
+    }
+
+    // A setting the deque constructor would reject (negative) or choke on (oversized) has to build a
+    // working stream, not throw or allocate the whole buffer up front.
+    @Test
+    fun streamsBuildAndTrimForHostileSettings() =
+        runBlocking {
+            for (setting in listOf(-1, 0, Int.MAX_VALUE)) {
+                withFixture(maxLines = setting) { f ->
+                    repeat(5) { i ->
+                        f.stream.appendLine(text("line$i"), ignoreWhenBlank = false, showWhenClosed = null)
+                    }
+                    f.drain()
+
+                    val usage = f.stream.memoryUsage()
+                    assertEquals(5, usage.bufferedLines, "setting $setting should still buffer normally")
+                    assertEquals(1_000_000, usage.maxLines, "setting $setting should report the cap")
+                }
             }
         }
 

--- a/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
+++ b/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
@@ -611,11 +611,10 @@ class ComposeTextStreamTest {
             }
         }
 
-    // The component index is never pruned when lines are evicted (see removeLines), so on a stream
-    // that receives components it grows for the life of the connection. Surfacing that count is a
-    // large part of why the memory view exists; this pins the behaviour it reports.
+    // The component index used to outlive the lines that registered it, growing for the life of the
+    // connection on any stream carrying components. It is now pruned with the buffer.
     @Test
-    fun memoryUsageReportsUnprunedComponentIndex() =
+    fun memoryUsagePrunesComponentIndexWithTheBuffer() =
         runBlocking {
             withFixture(maxLines = 4) { f ->
                 repeat(40) { i ->
@@ -626,9 +625,30 @@ class ComposeTextStreamTest {
                 val usage = f.stream.memoryUsage()
                 assertEquals(4, usage.bufferedLines)
                 assertEquals(
-                    40L,
+                    4L,
                     usage.componentReferences,
-                    "component locations outlive the lines that registered them",
+                    "component locations should be pruned along with the lines that registered them",
+                )
+            }
+        }
+
+    // Pruning must not disturb the mapping from a component to the lines still buffered: an update
+    // after eviction has to reach every remaining occurrence.
+    @Test
+    fun componentUpdatesReachRemainingLinesAfterEviction() =
+        runBlocking {
+            withFixture(maxLines = 3) { f ->
+                repeat(10) { i ->
+                    f.stream.appendLine(lineWithComponent("row$i ", "hp"), ignoreWhenBlank = false, showWhenClosed = null)
+                }
+                f.drain()
+                f.stream.updateComponent("hp", text("42"))
+                f.drain()
+
+                assertEquals(
+                    listOf("row7 42", "row8 42", "row9 42"),
+                    f.stream.lines.value
+                        .texts(),
                 )
             }
         }

--- a/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
+++ b/compose/src/jvmTest/kotlin/ComposeTextStreamTest.kt
@@ -16,6 +16,7 @@ import warlockfe.warlock3.compose.ui.window.StreamImageLine
 import warlockfe.warlock3.compose.ui.window.StreamLine
 import warlockfe.warlock3.compose.ui.window.StreamTextLine
 import warlockfe.warlock3.compose.ui.window.StreamWorkQueue
+import warlockfe.warlock3.compose.ui.window.effectiveMaxLines
 import warlockfe.warlock3.compose.util.HighlightIndex
 import warlockfe.warlock3.core.prefs.models.AlterationEntity
 import warlockfe.warlock3.core.text.StyleDefinition
@@ -608,6 +609,37 @@ class ComposeTextStreamTest {
                     wellPast.heldLines in 4..8,
                     "held lines should stay within one compaction window of the buffer, was ${wellPast.heldLines}",
                 )
+            }
+        }
+
+    // A scrollback of zero or less used to mean an unbounded buffer. It is capped now, so the
+    // buffer always has an end regardless of the setting.
+    @Test
+    fun effectiveMaxLinesIsAlwaysBounded() {
+        assertEquals(2_000, effectiveMaxLines(2_000))
+        assertEquals(1, effectiveMaxLines(1))
+        assertEquals(1_000_000, effectiveMaxLines(1_000_000))
+        // Past the cap, and the old "unbounded" values, all land on the cap.
+        assertEquals(1_000_000, effectiveMaxLines(1_000_001))
+        assertEquals(1_000_000, effectiveMaxLines(Int.MAX_VALUE))
+        assertEquals(1_000_000, effectiveMaxLines(0))
+        assertEquals(1_000_000, effectiveMaxLines(-1))
+        assertEquals(1_000_000, effectiveMaxLines(Int.MIN_VALUE))
+    }
+
+    // A stream told it is unbounded still evicts, rather than growing with every line.
+    @Test
+    fun unboundedSettingStillTrimsTheBuffer() =
+        runBlocking {
+            withFixture(maxLines = 0) { f ->
+                repeat(20) { i ->
+                    f.stream.appendLine(text("line$i"), ignoreWhenBlank = false, showWhenClosed = null)
+                }
+                f.drain()
+
+                val usage = f.stream.memoryUsage()
+                assertEquals(20, usage.bufferedLines, "below the cap nothing is dropped")
+                assertEquals(1_000_000, usage.maxLines, "the buffer reports the cap, not the setting")
             }
         }
 

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/window/MemoryUsage.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/window/MemoryUsage.kt
@@ -22,9 +22,12 @@ data class StreamMemoryUsage(
     val maxLines: Int,
     val textCharacters: Long,
     /**
-     * Serial numbers recorded in the component index: one per buffered line that references a
-     * server component. Pruned as lines are evicted, so it tracks the buffer rather than the
-     * connection - a count far above [bufferedLines] means that pruning has stopped working.
+     * Entries in the component index: one per server component referenced by a buffered line, so a
+     * line mentioning several counts several times and the total can sit well above [bufferedLines].
+     *
+     * Pruned as lines are evicted, so it tracks the buffer rather than the connection. What is worth
+     * noticing is a count out of proportion to how many components the window's lines actually
+     * carry, or one that climbs while [bufferedLines] holds steady.
      */
     val componentReferences: Long,
     val estimatedBytes: Long,

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/window/MemoryUsage.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/window/MemoryUsage.kt
@@ -22,9 +22,9 @@ data class StreamMemoryUsage(
     val maxLines: Int,
     val textCharacters: Long,
     /**
-     * Serial numbers recorded in the component index. This index is never pruned when lines are
-     * evicted, so on a stream that receives server components it grows for the life of the
-     * connection - one entry per component occurrence, forever.
+     * Serial numbers recorded in the component index: one per buffered line that references a
+     * server component. Pruned as lines are evicted, so it tracks the buffer rather than the
+     * connection - a count far above [bufferedLines] means that pruning has stopped working.
      */
     val componentReferences: Long,
     val estimatedBytes: Long,


### PR DESCRIPTION
The second leak from the memory-growth investigation. Independent of #264; they touch different files.

## The leak

`componentLocations` maps a component name to the serial numbers of the lines referencing it, and `removeLines` deliberately left it alone:

```kotlin
// Intentionally leak components here. They don't exist in the main window,
// and no other windows get long enough
```

On any stream that does carry components, that index grew for the life of the connection — one entry per occurrence, never reclaimed. The consumer already skipped entries below the buffer (`if (lineNumber >= 0)`), so they were pure retention.

It is pruned against the oldest buffered line now, which ties it to a bound that already exists rather than inventing a new one.

## Also quadratic

Entries were held in a `Set<Long>` rebuilt on every occurrence:

```kotlin
val existingLocations = componentLocations[name] ?: emptySet()
componentLocations[name] = existingLocations + serialNumber
```

So registering a line copied the entire set, and the copy grew as the leak did. A deque appends in O(1), and because serials are recorded in order, eviction is a prefix drop.

Measured with `:compose:streamNetworkBenchmark` (2 connections, 6 windows, 4000 lines/sec), append time per ~24k appends:

| | before | after |
| --- | --- | --- |
| append | ~176-192ms | ~153-156ms |

Pruning costs less than the rebuild it replaces. Not a controlled A/B — same machine and knobs, but the baseline came from the earlier investigation run — though the direction matches the mechanism, since the old cost rose with the size of the set.

## Testing

The test that pinned the old behaviour is inverted rather than deleted: `memoryUsagePrunesComponentIndexWithTheBuffer` asserts the index tracks `bufferedLines` (4) instead of the 40 lines appended.

Added `componentUpdatesReachRemainingLinesAfterEviction`, which is the risk in this change — that pruning disturbs the component-to-line mapping. It appends 10 component lines into a 3-line buffer, updates the component, and asserts all three surviving rows render the new value.

`updateComponentRefreshesAllOccurrences` still covers the unevicted path. Full suites, ktlint, and the benchmark above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale component references from accumulating after buffered lines are evicted.
  * Preserved component updates across remaining buffered lines after eviction.
  * Improved handling of repeated partial-line registrations.
  * Enforced a maximum buffer size of 1,000,000 lines, including for unbounded settings.
  * Improved memory safety when configuring buffer sizes.

* **Documentation**
  * Clarified how component references are tracked and pruned during buffer management.

* **Tests**
  * Added coverage for buffer limits, reference pruning, memory-safe sizing, and updates across retained lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->