### PR TITLE
Match protocol tag names case-sensitively

### DIFF
--- a/utils/wrayth-lab/bootstrap.txt
+++ b/utils/wrayth-lab/bootstrap.txt
@@ -10,8 +10,12 @@
 <settingsInfo space_not_found="0" crc="0" instance="DR"/>
 <app char="Wlab" game="DR" title="[DR: Wlab]"/>
 ## --- windows ---------------------------------------------------------------
+## Tag names are case-sensitive to Wrayth and locations are checked: <opendialog>
+## is ignored outright, and a location it does not know comes back as
+## "_error bad location in <the tag>". These lines are copied from real DR/GS4
+## sessions, so keep them that way rather than inventing plausible-looking ones.
 <streamWindow id='main' title='Story' subtitle=" - [Wrayth Lab]" location='center' target='drop'/>
-<streamWindow id='inv' title='My Inventory' location='inv' target='wear' ifClosed='' resident='true'/>
+<streamWindow id='inv' title='My Inventory' target='wear' ifClosed='' resident='true'/>
 <streamWindow id='thoughts' title='Thoughts' location='left' target='thoughts' resident='true'/>
 <streamWindow id='logons' title='Arrivals' location='left' target='logons' resident='true'/>
 <streamWindow id='death' title='Deaths' location='left' target='death' resident='true'/>
@@ -19,7 +23,7 @@
 ## Wrayth parses one line at a time and wants each line to be well formed: a tag
 ## opened on one line and closed on the next comes back as "<c>_error ... Ending
 ## tag not found", so keep container tags and their contents on a single line.
-<opendialog type='dynamic' id='minivitals' title='Vitals' location='statusbar' target='minivitals' resident='true'><dialogData id='minivitals'><progressBar id='health' value='100' text='health 100%' left='0%' customText='t' top='0%' width='20%' height='100%'/><progressBar id='mana' value='100' text='mana 100%' left='20%' customText='t' top='0%' width='20%' height='100%'/><progressBar id='stamina' value='100' text='stamina 100%' left='40%' customText='t' top='0%' width='20%' height='100%'/><progressBar id='spirit' value='100' text='spirit 100%' left='60%' customText='t' top='0%' width='20%' height='100%'/><progressBar id='concentration' value='100' text='concentration 100%' left='80%' customText='t' top='0%' width='20%' height='100%'/></dialogData></opendialog>
+<openDialog type='dynamic' id='minivitals' title='Vitals' location='statBar' target='minivitals' resident='true'><dialogData id='minivitals'><progressBar id='health' value='100' text='health 100%' left='0%' customText='t' top='0%' width='20%' height='100%'/><progressBar id='mana' value='100' text='mana 100%' left='20%' customText='t' top='0%' width='20%' height='100%'/><progressBar id='stamina' value='100' text='stamina 100%' left='40%' customText='t' top='0%' width='20%' height='100%'/><progressBar id='spirit' value='100' text='spirit 100%' left='60%' customText='t' top='0%' width='20%' height='100%'/><progressBar id='concentration' value='100' text='concentration 100%' left='80%' customText='t' top='0%' width='20%' height='100%'/></dialogData></openDialog>
 ## --- some room text so the main window is not empty ------------------------
 <streamWindow id='room' title='Room' subtitle=" - [Wrayth Lab]" location='center' target='drop'/>
 <compass><dir value="n"/><dir value="e"/><dir value="out"/></compass>

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
@@ -60,12 +60,18 @@ import warlockfe.warlock3.wrayth.protocol.elements.StyleHandler
 import warlockfe.warlock3.wrayth.protocol.elements.UpDownEditBoxHandler
 import warlockfe.warlock3.wrayth.protocol.elements.UpdateVerbsHandler
 
+// How many distinct unknown tag names one connection will report before giving up on them. Sized
+// well above the whole known protocol so a real vocabulary can never reach it.
+private const val MAX_UNKNOWN_TAGS_REPORTED = 256
+
 class WraythProtocolHandler {
     private val logger = Logger.withTag("WraythProtocolHandler")
 
     // Tags already reported by [warnOnUnknownTag]. A tag on every line warns once, not thousands
-    // of times.
+    // of times. Capped because nothing on the wire promises a finite set of names: the connection
+    // can carry whatever a Lich script emits, and this set lives as long as the connection does.
     private val unknownReported = mutableSetOf<String>()
+    private var unknownOverflowReported = false
 
     /**
      * Warns the first time a tag arrives that the table does not account for at all. Every tag the
@@ -74,9 +80,25 @@ class WraythProtocolHandler {
      * spelling in the table is wrong - and since tag names are matched exactly, a single wrong
      * letter would otherwise be invisible. The message names the nearest spelling we do hold when
      * there is one, which is usually the whole diagnosis.
+     *
+     * Past [MAX_UNKNOWN_TAGS_REPORTED] distinct names this goes quiet and stops remembering them.
+     * The whole protocol is not much over a hundred tags, so passing that many *unknown* ones means
+     * something is generating names rather than sending a vocabulary, and neither the warnings nor
+     * the set are any use at that point.
      */
     private fun warnOnUnknownTag(tagName: String) {
-        if (!unknownReported.add(tagName)) return
+        if (tagName in unknownReported) return
+        if (unknownReported.size >= MAX_UNKNOWN_TAGS_REPORTED) {
+            if (!unknownOverflowReported) {
+                unknownOverflowReported = true
+                logger.w {
+                    "Seen $MAX_UNKNOWN_TAGS_REPORTED distinct unknown tags; no longer reporting them. " +
+                        "Something is generating tag names rather than sending a fixed set."
+                }
+            }
+            return
+        }
+        unknownReported.add(tagName)
         val miscased = elementListeners.keys.firstOrNull { it.equals(tagName, ignoreCase = true) }
         if (miscased != null) {
             logger.w { "Ignoring <$tagName>: the tag we handle is spelled <$miscased>. One of the two is wrong." }

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
@@ -63,63 +63,149 @@ import warlockfe.warlock3.wrayth.protocol.elements.UpdateVerbsHandler
 class WraythProtocolHandler {
     private val logger = Logger.withTag("WraythProtocolHandler")
 
+    // Tags already reported by [warnOnUnknownTag]. A tag on every line warns once, not thousands
+    // of times.
+    private val unknownReported = mutableSetOf<String>()
+
+    /**
+     * Warns the first time a tag arrives that the table does not account for at all. Every tag the
+     * game is known to send is registered above, the ones we do nothing with as
+     * [IgnoredTagHandler], so reaching here means either the protocol has grown something new or a
+     * spelling in the table is wrong - and since tag names are matched exactly, a single wrong
+     * letter would otherwise be invisible. The message names the nearest spelling we do hold when
+     * there is one, which is usually the whole diagnosis.
+     */
+    private fun warnOnUnknownTag(tagName: String) {
+        if (!unknownReported.add(tagName)) return
+        val miscased = elementListeners.keys.firstOrNull { it.equals(tagName, ignoreCase = true) }
+        if (miscased != null) {
+            logger.w { "Ignoring <$tagName>: the tag we handle is spelled <$miscased>. One of the two is wrong." }
+        } else {
+            logger.w { "Ignoring <$tagName>: no handler for it. Add one, or an IgnoredTagHandler if it carries nothing we use." }
+        }
+    }
+
     private val elementListeners: Map<String, ElementListener> =
         mapOf(
-            // all keys must be lowercase
+            // Keyed by the protocol's exact spelling, because the real client matches tag
+            // names case-sensitively: <streamWindow> and <openDialog> are recognised, while
+            // <streamwindow> and <opendialog> are ignored without even an error (verified in
+            // utils/wrayth-lab). Every spelling below was read off captured DR/DRT/GS4
+            // sessions rather than inferred from the handler class name, which is not a
+            // reliable guide - UpdateVerbsHandler answers to <updateverbs>.
             "a" to AHandler(),
             "app" to AppHandler(),
             "b" to BHandler(),
             "background" to BackgroundHandler(),
-            "casttime" to CastTimeHandler(),
-            "clearcontainer" to ClearContainerHandler(),
-            "clearstream" to ClearStreamHandler(),
+            "castTime" to CastTimeHandler(),
+            "clearContainer" to ClearContainerHandler(),
+            "clearStream" to ClearStreamHandler(),
             "cli" to CliHandler(),
-            "closedialog" to CloseDialogHandler(),
-            "cmdbutton" to CmdButtonHandler(),
+            "closeDialog" to CloseDialogHandler(),
+            "cmdButton" to CmdButtonHandler(),
             "cmdlist" to CmdlistHandler(),
             "compass" to CompassHandler(),
-            "compdef" to CompDefHandler(),
+            "compDef" to CompDefHandler(),
             "component" to ComponentHandler(),
             "container" to ContainerHandler(),
             "d" to DHandler(),
-            "dialogdata" to DialogDataHandler(),
+            "dialogData" to DialogDataHandler(),
             "dir" to DirHandler(),
-            "dropdownbox" to DropDownBoxHandler(),
+            "dropDownBox" to DropDownBoxHandler(),
+            // No captured session contains these two, so their exact spelling is unknown.
+            // Both forms are registered rather than guessed at, because guessing wrong would
+            // silently drop a tag the game does send. Collapse each to a single entry once one
+            // shows up in a log.
             "dynastream" to DynaStreamHandler(),
+            "dynaStream" to DynaStreamHandler(),
             "image" to ImageHandler(),
             "indicator" to IndicatorHandler(),
             "inv" to InvHandler(),
             "label" to LabelHandler(),
             "launchurl" to LaunchURLHandler(),
+            "launchURL" to LaunchURLHandler(),
             "left" to LeftHandler(),
             "link" to LinkHandler(),
             "menu" to MenuHandler(),
-            "menuimage" to MenuImageHandler(),
-            "menulink" to MenuLinkHandler(),
+            "menuImage" to MenuImageHandler(),
+            "menuLink" to MenuLinkHandler(),
             "mi" to MiHandler(),
             "mode" to ModeHandler(),
             "nav" to NavHandler(),
-            "opendialog" to OpenDialogHandler(),
+            "openDialog" to OpenDialogHandler(),
             "output" to OutputHandler(),
             "preset" to PresetHandler(),
-            "popbold" to PopBoldHandler(),
-            "popstream" to PopStreamHandler(),
-            "progressbar" to ProgressBarHandler(),
+            "popBold" to PopBoldHandler(),
+            "popStream" to PopStreamHandler(),
+            "progressBar" to ProgressBarHandler(),
             "prompt" to PromptHandler(),
-            "pushbold" to PushBoldHandler(),
-            "pushstream" to PushStreamHandler(),
+            "pushBold" to PushBoldHandler(),
+            "pushStream" to PushStreamHandler(),
             "radio" to RadioHandler(),
             "resource" to ResourceHandler(),
             "right" to RightHandler(),
-            "roundtime" to RoundTimeHandler(),
-            "settingsinfo" to SettingsInfoHandler(),
+            "roundTime" to RoundTimeHandler(),
+            "settingsInfo" to SettingsInfoHandler(),
             "skin" to SkinHandler(),
             "spell" to SpellHandler(),
             "stream" to StreamHandler(),
-            "streamwindow" to StreamWindowHandler(),
+            "streamWindow" to StreamWindowHandler(),
             "style" to StyleHandler(),
             "updateverbs" to UpdateVerbsHandler(),
-            "updowneditbox" to UpDownEditBoxHandler(),
+            // Tags the game sends that carry nothing we use. Registered so the warning above
+            // stays meaningful: anything that reaches it is genuinely new, or misspelled. Every
+            // name here was taken from captured DR/DRT/GS4 sessions.
+            //
+            // The bulk of them are the settings blob the server replays at login - <settings> and
+            // its sections, down to the one-letter entries inside them (<i> palette, <k> macro key,
+            // <w> window, <o> option, <p> preset, <m> misc, <s> script). Warlock keeps its own
+            // settings, so none of it is read.
+            "builtin" to IgnoredTagHandler(),
+            "cmdline" to IgnoredTagHandler(),
+            "detach" to IgnoredTagHandler(),
+            "dialog" to IgnoredTagHandler(),
+            "display" to IgnoredTagHandler(),
+            "i" to IgnoredTagHandler(),
+            "ignores" to IgnoredTagHandler(),
+            "k" to IgnoredTagHandler(),
+            "keys" to IgnoredTagHandler(),
+            "m" to IgnoredTagHandler(),
+            "macros" to IgnoredTagHandler(),
+            "misc" to IgnoredTagHandler(),
+            "names" to IgnoredTagHandler(),
+            "o" to IgnoredTagHandler(),
+            "options" to IgnoredTagHandler(),
+            "p" to IgnoredTagHandler(),
+            "palette" to IgnoredTagHandler(),
+            "panels" to IgnoredTagHandler(),
+            "presets" to IgnoredTagHandler(),
+            "s" to IgnoredTagHandler(),
+            "scripts" to IgnoredTagHandler(),
+            "settings" to IgnoredTagHandler(),
+            "strings" to IgnoredTagHandler(),
+            "toggles" to IgnoredTagHandler(),
+            "vars" to IgnoredTagHandler(),
+            "w" to IgnoredTagHandler(),
+            // The rest arrive during play.
+            "closeButton" to IgnoredTagHandler(),
+            "checkBox" to IgnoredTagHandler(),
+            "cmdtimestamp" to IgnoredTagHandler(),
+            "command" to IgnoredTagHandler(),
+            "deleteContainer" to IgnoredTagHandler(),
+            "endSetup" to IgnoredTagHandler(),
+            "exposeContainer" to IgnoredTagHandler(),
+            "exposeDialog" to IgnoredTagHandler(),
+            "exposeStream" to IgnoredTagHandler(),
+            "font" to IgnoredTagHandler(),
+            "group" to IgnoredTagHandler(),
+            "module" to IgnoredTagHandler(),
+            "objectives" to IgnoredTagHandler(),
+            "playerID" to IgnoredTagHandler(),
+            "roommeta" to IgnoredTagHandler(),
+            "sep" to IgnoredTagHandler(),
+            "switchQuickBar" to IgnoredTagHandler(),
+            "timestamp" to IgnoredTagHandler(),
+            "upDownEditBox" to UpDownEditBoxHandler(),
         )
 
     // Reused across [parseLine] calls (see the note there). Error listeners are removed so malformed
@@ -160,7 +246,7 @@ class WraythProtocolHandler {
             when (content) {
                 is StartElement -> {
                     lineHasTags = true
-                    val tagName = content.name.lowercase()
+                    val tagName = content.name
                     tagStack.addFirst(OpenTag(tagName, content))
                     val listener = elementListeners[tagName]
                     if (listener != null) {
@@ -168,6 +254,7 @@ class WraythProtocolHandler {
                             events.add(it)
                         }
                     } else {
+                        warnOnUnknownTag(tagName)
                         events.add(WraythUnhandledTagEvent(content.name))
                     }
                 }
@@ -184,7 +271,7 @@ class WraythProtocolHandler {
                     val topOfStack =
                         tagStack.firstOrNull()
                             ?: continue // rule #1
-                    val tagName = content.name.lowercase()
+                    val tagName = content.name
                     val matched: OpenTag
                     if (topOfStack.name != tagName) {
                         logger.e {
@@ -275,3 +362,10 @@ abstract class BaseElementListener : ElementListener {
 
     override fun endElement(): WraythEvent? = null
 }
+
+/**
+ * A tag the game sends that we knowingly do nothing with. Registering it is what separates "we
+ * looked at this and it carries nothing we use" from "we have never seen this before", which is the
+ * only case [WraythProtocolHandler] warns about.
+ */
+class IgnoredTagHandler : BaseElementListener()

--- a/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
+++ b/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
@@ -4,6 +4,7 @@ import warlockfe.warlock3.wrayth.protocol.WraythCloseDialogEvent
 import warlockfe.warlock3.wrayth.protocol.WraythDialogObjectEvent
 import warlockfe.warlock3.wrayth.protocol.WraythDialogWindowEvent
 import warlockfe.warlock3.wrayth.protocol.WraythProtocolHandler
+import warlockfe.warlock3.wrayth.protocol.WraythUnhandledTagEvent
 import warlockfe.warlock3.wrayth.util.WraythDialogWindow
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -237,5 +238,30 @@ class WraythProtocolHandlerTests {
         val events = WraythProtocolHandler().parseLine("<closeDialog/>")
 
         assertEquals(emptyList(), events.filterIsInstance<WraythCloseDialogEvent>())
+    }
+
+    @Test
+    fun tagNamesAreMatchedCaseSensitively() {
+        // The real client reads <opendialog> as a tag it has never heard of and drops it on the
+        // floor, no error, no panel. Ours used to lowercase every name and so accepted spellings
+        // the game never sends - which hid a miscased tag in our own lab bootstrap for months.
+        val handled = WraythProtocolHandler().parseLine("<openDialog id=\"bank\" title=\"Bank\"/>")
+        assertEquals(1, handled.filterIsInstance<WraythDialogWindowEvent>().size)
+
+        val miscased = WraythProtocolHandler().parseLine("<opendialog id=\"bank\" title=\"Bank\"/>")
+        assertEquals(emptyList(), miscased.filterIsInstance<WraythDialogWindowEvent>())
+        assertEquals(
+            listOf("opendialog"),
+            miscased.filterIsInstance<WraythUnhandledTagEvent>().map { it.tag },
+        )
+    }
+
+    @Test
+    fun tagsWeKnowinglyIgnoreAreNotReportedAsUnhandled() {
+        // A tag carrying nothing we use is registered all the same, so the unhandled channel keeps
+        // meaning "we have never seen this" rather than "this is one of the forty we ignore".
+        val events = WraythProtocolHandler().parseLine("<timestamp time=\"1700000000\"/>")
+
+        assertEquals(emptyList(), events.filterIsInstance<WraythUnhandledTagEvent>())
     }
 }

--- a/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
+++ b/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
@@ -257,6 +257,19 @@ class WraythProtocolHandlerTests {
     }
 
     @Test
+    fun anEndlessStreamOfNewTagNamesDoesNotAccumulate() {
+        // Nothing on the wire promises a finite set of tag names - the connection carries whatever
+        // a Lich script emits - and the de-duplication set lives as long as the connection. Feed it
+        // far more distinct names than the protocol has and it must still be reporting them as
+        // unhandled without having kept them all.
+        val handler = WraythProtocolHandler()
+        repeat(2000) { i ->
+            val events = handler.parseLine("<generated$i/>")
+            assertEquals(listOf("generated$i"), events.filterIsInstance<WraythUnhandledTagEvent>().map { it.tag })
+        }
+    }
+
+    @Test
     fun tagsWeKnowinglyIgnoreAreNotReportedAsUnhandled() {
         // A tag carrying nothing we use is registered all the same, so the unhandled channel keeps
         // meaning "we have never seen this" rather than "this is one of the forty we ignore".


### PR DESCRIPTION
Wrayth matches tag names exactly: `<streamWindow>` and `<openDialog>` are recognised, `<streamwindow>` and `<opendialog>` are dropped without even an error (verified in `utils/wrayth-lab`). We lowercased every name and looked it up in a lowercase-keyed table, so we accepted spellings no game ever sends.

That leniency was not harmless. It hid a bug in our own lab bootstrap, whose `<opendialog>` meant the vitals bar had **never once rendered** there — which is exactly the kind of thing the lab exists to catch.

## What changed

The table is keyed by the protocol's exact spelling and lookup no longer lowercases.

Every spelling was read off captured DR/DRT/GS4 sessions rather than inferred. That mattered more than expected: the handler class names look like a guide but are not one, since `UpdateVerbsHandler` answers to `<updateverbs>`, all lowercase. The existing tests already used the camelCase forms, which corroborates them independently.

Two tags appear in no capture at all — `dynaStream` and `launchURL` — so both forms of each stay registered rather than guessed at. Picking wrong would silently drop a tag the game does send. There is a comment to collapse each to one entry once one shows up in a log.

## Unrecognised tags now mean something

Every other tag those sessions contain is registered as an `IgnoredTagHandler`: the settings blob the server replays at login and its one-letter entries (`<i>` palette, `<k>` macro key, `<w>` window, `<o>` option, `<p>` preset, `<m>` misc, `<s>` script), plus `timestamp`, `sep`, `command`, `playerID`, `switchQuickBar`, `endSetup`, the `expose*`/`deleteContainer` family, and the rest — 44 in all.

So a tag reaching the unhandled path now means the protocol has grown something or a spelling is wrong, and the handler warns once for each, naming the nearest spelling it does hold. `WraythUnhandledTagEvent` was a commented-out no-op before this, so a wrong spelling was completely invisible; this is the check that would have caught the bootstrap bug on the first run.

Lowercase `<opendialog>` is deliberately **not** in the ignore list — it only ever appears in our own lab logs, and it should warn.

## The bootstrap

Fixed to what the games actually send: `<openDialog>` with `location='statBar'` (not `statusbar`), and the inventory window with no `location` at all rather than the invented `location='inv'` that Wrayth rejects — real sessions send `<streamWindow id='inv' title='My Inventory' target='wear' ifClosed='' resident='true'/>`.

Verified by booting the lab with it: `recv` is clean of `bad location`, and the vitals bar renders in the status bar for the first time.

## Testing

`./gradlew check -PiosSkip=true -PlintSkip=true` is green. Two new cases in `WraythProtocolHandlerTests` (18 passing): one that `<openDialog>` is handled while `<opendialog>` is not, and one that a knowingly-ignored tag is not reported as unhandled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected protocol tag handling to recognize valid case-sensitive tags and aliases.
  * Fixed vitals and inventory window configuration for reliable display.
  * Prevented known unsupported tags from being incorrectly reported as unhandled.
  * Improved warnings for unrecognized or incorrectly cased tags.
  * Ensured distinct unrecognized tags continue to be reported without excessive warning accumulation.
* **Tests**
  * Added coverage for case-sensitive tag handling, intentionally ignored tags, and repeated unknown-tag reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->