### PR TITLE
Retry release builds that fail on transient infrastructure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,35 @@ jobs:
           # app-specific notarization password. Both are only read by the macOS package task.
           MAC_KEYCHAIN_PATH: ${{ steps.signing.outputs.keychain-path }}
           NOTARY_PWD: ${{ secrets.MAC_NOTARIZATION_PASSWORD }}
-        run: ./gradlew :desktopApp:packageDistributionForCurrentOS --stacktrace --no-daemon
+        # Three network paths have flaked here across releases, each clearing on a plain
+        # re-run: the wrapper's Gradle distribution download (it does not retry on its
+        # own), electron-builder fetching its packaging tools, and notarytool's poll of
+        # Apple's notary service dropping while a submission is still In Progress. Retry
+        # those, and only those -- a compile error has to fail on the first attempt
+        # rather than burn three builds on every runner before reporting it.
+        run: |
+          transient='Unexpected end of file from server|socket hang up|Connection reset|Connection timed out|Read timed out|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|The Internet connection appears to be offline|Could not (GET|HEAD|resolve)|429 Too Many Requests|502 Bad Gateway|503 Service|Remote host terminated the handshake'
+          # notarytool has also been killed outright mid-submission (exit 138 = SIGBUS).
+          # Anything past 128 is a signal death, not a verdict on what we built. Apple's
+          # "403 ... agreement is missing or has expired" deliberately matches neither:
+          # that one needs a human to go sign something, so it must fail on attempt one.
+          crashed='Exit code: 1(2[89]|[3-6][0-9])'
+          for attempt in 1 2 3; do
+            if [ "$attempt" -gt 1 ]; then
+              echo "::warning::Previous attempt failed in a way that clears on a re-run; retrying (attempt $attempt of 3)."
+              sleep $(( (attempt - 1) * 30 ))
+            fi
+            log="$(mktemp)"
+            if ./gradlew :desktopApp:packageDistributionForCurrentOS --stacktrace --no-daemon 2>&1 | tee "$log"; then
+              exit 0
+            fi
+            if ! grep -qiE "$transient" "$log" && ! grep -qE "$crashed" "$log"; then
+              echo "::error::Build failed for a reason that a retry will not fix; not retrying."
+              exit 1
+            fi
+          done
+          echo "::error::Build still failing after 3 attempts."
+          exit 1
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,6 +89,11 @@ jobs:
         # Apple's notary service dropping while a submission is still In Progress. Retry
         # those, and only those -- a compile error has to fail on the first attempt
         # rather than burn three builds on every runner before reporting it.
+        #
+        # Retrying that last one re-submits to Apple: Potassium saves the submission ID but
+        # never resumes a poll from it, so the in-progress submission is abandoned and a new
+        # one uploaded. That costs a round trip, which is still less than the manual job
+        # re-run it replaces (which re-submits too, after recompiling from scratch).
         run: |
           transient='Unexpected end of file from server|socket hang up|Connection reset|Connection timed out|Read timed out|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|The Internet connection appears to be offline|Could not (GET|HEAD|resolve)|429 Too Many Requests|502 Bad Gateway|503 Service|Remote host terminated the handshake'
           # notarytool has also been killed outright mid-submission (exit 138 = SIGBUS).
@@ -102,12 +107,21 @@ jobs:
               sleep $(( (attempt - 1) * 30 ))
             fi
             log="$(mktemp)"
-            if ./gradlew :desktopApp:packageDistributionForCurrentOS --stacktrace --no-daemon 2>&1 | tee "$log"; then
+            status=0
+            ./gradlew :desktopApp:packageDistributionForCurrentOS --stacktrace --no-daemon 2>&1 | tee "$log" \
+              || status="${PIPESTATUS[0]}"
+            if [ "$status" -eq 0 ]; then
               exit 0
             fi
-            if ! grep -qiE "$transient" "$log" && ! grep -qE "$crashed" "$log"; then
-              echo "::error::Build failed for a reason that a retry will not fix; not retrying."
-              exit 1
+            # A signal death reaches us two ways. Gradle prints "Exit code: 138" when a tool it
+            # ran was killed, which is the beta.20 notarytool case the pattern above catches. But
+            # when Gradle itself is the one killed -- the runner's OOM killer, say -- it gets no
+            # chance to write that line, and the signal shows up only as our own exit status.
+            if [ "$status" -lt 128 ] || [ "$status" -gt 169 ]; then
+              if ! grep -qiE "$transient" "$log" && ! grep -qE "$crashed" "$log"; then
+                echo "::error::Build failed for a reason that a retry will not fix; not retrying."
+                exit 1
+              fi
             fi
           done
           echo "::error::Build still failing after 3 attempts."


### PR DESCRIPTION
Six of the last twenty release runs needed a manual re-run. None of them
failed on anything we built: every one died on a network path outside the
build.

| Run | Job | Failure |
| --- | --- | --- |
| beta.30 | windows amd64 | Gradle wrapper distribution download, `Unexpected end of file from server` |
| beta.30 | linux arm64 | electron-builder `socket hang up` fetching packaging tools |
| beta.29 | macos intel | notarytool poll dropped, `The Internet connection appears to be offline` |
| beta.20 | macos intel | notarytool killed mid-submission, `Exit code: 138` (SIGBUS) |
| beta.18 | macos arm64 | Apple `403 ... agreement is missing or has expired` |

The beta.29 case is the shape of most of these: the submission had already
uploaded successfully and was `In Progress`, and it was the *poll* of
`appstoreconnect.apple.com/notary/v2/submissions/<id>` that dropped. Nothing
was wrong with the build or the signature. The wrapper case is similar, and
made worse by the wrapper logging `Attempt 1/1 failed` before giving up: it
does not retry its own distribution download at all.

## What this does

Retries the `Build packages` step up to three times with 30s/60s backoff,
gated on a failure signature that a re-run actually clears. Two patterns,
kept separate because they are different classes:

- `transient` covers the network drops (`Unexpected end of file from server`,
  `socket hang up`, `The Internet connection appears to be offline`, plus the
  usual `ECONNRESET` / `Could not GET` / `502` / `503` family).
- `crashed` covers `Exit code: 128-169`, a tool killed by a signal. That is
  what catches beta.20, where notarytool died of SIGBUS with no network text
  in the log at all.

Anything else fails on the first attempt. That exclusion is the point of the
gate rather than a blanket retry: beta.18 failed on Apple's `403 ... agreement
is missing or has expired`, which no amount of retrying fixes. It needed a
human to go sign an agreement. Retrying it would have cost ~30 minutes across
two macOS runners and still failed, with the actionable message buried three
attempts deep.

Retrying in-step is also strictly cheaper than the manual job re-run it
replaces: the build directory is still warm, so a notarization flake
re-packages instead of recompiling from scratch on a fresh runner.

## Verification

Replayed the archived logs of all five distinct historical failures through
the final patterns:

```
win.log (beta.30 win)       RETRY       gradle wrapper download dropped
arm.log (beta.30 arm64)     RETRY       electron-builder socket hang up
beta.29 macOS intel         RETRY       notarytool poll went offline
beta.20 macOS intel         RETRY       notarytool killed, exit 138
beta.18 macOS arm64         FAIL FAST   Apple 403, agreement expired
(synthetic compile error)   FAIL FAST   kotlin compile failure
```

Then drove the loop itself with a fake `gradlew` under the exact flags GitHub
uses for `shell: bash` (`--noprofile --norc -e -o pipefail`), confirming it
retries and gives up after three, fails fast on a compile error, retries the
SIGBUS case, fails fast on the 403, and exits 0 when a flaky build succeeds on
attempt three. The test extracts both regexes from the generated step script
rather than copying them, so it cannot drift from what ships.

`yaml.safe_load` parses the workflow and `bash -n` is clean on the extracted
step.

## Note

Tag-triggered runs read the workflow from the tag ref, so this takes effect on
the next `./release.sh`, not on any re-run of an existing tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop package build reliability by automatically retrying recognized temporary network or process failures.
  * Added progressively longer delays between retry attempts.
  * Builds now fail immediately for non-recoverable errors, while retryable failures are reported clearly after all attempts are exhausted.
  * Successful builds stop retrying immediately, reducing unnecessary build time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->