### PR TITLE
Justify panel labels, and give panel objects room to breathe

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelObjectLayout.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelObjectLayout.kt
@@ -122,11 +122,26 @@ fun PanelObjectLayout(
 
                 val placeable = measurables[index].measure(childConstraints)
 
-                // Offsets prefer the skin's pixel top/left over the server's. Both margins are
-                // measured against widthBasis; Pixels ignore the basis, so this only affects Percent
-                // offsets.
-                val dataTop = skinObject?.top?.let { DataDistance.Pixels(it) } ?: data.top
-                val dataLeft = skinObject?.left?.let { DataDistance.Pixels(it) } ?: data.left
+                // A skin child's top/left places the object inside its skin container, so it only has
+                // something to say about an object the server did not anchor (the injuries panel's
+                // body parts, the compass arrows). Once an object is anchored, top/left are the gap
+                // from that anchor and belong to the server: UberBar stacks its vital bars that way,
+                // pairing each with a `<skin controls=...>` whose child sits at 0,0, and preferring
+                // the skin there would drop every `top='3'` and leave the bars touching.
+                // Both margins are measured against widthBasis; Pixels ignore the basis, so this only
+                // affects Percent offsets.
+                val dataTop =
+                    if (data.topAnchor != null) {
+                        data.top
+                    } else {
+                        skinObject?.top?.let { DataDistance.Pixels(it) } ?: data.top
+                    }
+                val dataLeft =
+                    if (data.leftAnchor != null) {
+                        data.left
+                    } else {
+                        skinObject?.left?.let { DataDistance.Pixels(it) } ?: data.left
+                    }
 
                 ItemInfo(
                     data = data,
@@ -306,9 +321,15 @@ private class ItemInfo(
     }
 }
 
+// The server sizes and positions panels for Wrayth's compact pixel grid, and for the small font it
+// drew labels with. Treating those pixels as dp 1:1 leaves a box only just wide enough for Wrayth's
+// font, so our wider one gets clipped. Scaling them up buys that room back; positions, sizes and
+// margins scale together, so the layout stays proportional. 1.5 proved too generous.
+private const val PANEL_PIXEL_SCALE = 1.2f
+
 /**
  * Resolves a panel distance to pixels: a [DataDistance.Percent] is a fraction of [basis], while a
- * [DataDistance.Pixels] is treated as a dp count (and so ignores [basis]).
+ * [DataDistance.Pixels] is treated as a (scaled) dp count (and so ignores [basis]).
  */
 private fun DataDistance.toPx(
     basis: Int,
@@ -316,5 +337,5 @@ private fun DataDistance.toPx(
 ): Int =
     when (this) {
         is DataDistance.Percent -> basis * value.value / 100
-        is DataDistance.Pixels -> with(density) { value.dp.roundToPx() }
+        is DataDistance.Pixels -> with(density) { (value * PANEL_PIXEL_SCALE).dp.roundToPx() }
     }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/PanelJustifyAlignment.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/PanelJustifyAlignment.kt
@@ -1,0 +1,15 @@
+package warlockfe.warlock3.compose.util
+
+import androidx.compose.ui.Alignment
+import warlockfe.warlock3.core.client.PanelJustify
+
+/**
+ * The alignment that justifies a label's text within its box. Vertically centered either way, since
+ * `justify` only speaks to the horizontal placement.
+ */
+internal fun PanelJustify.toAlignment(): Alignment =
+    when (this) {
+        PanelJustify.Left -> Alignment.CenterStart
+        PanelJustify.Center -> Alignment.Center
+        PanelJustify.Right -> Alignment.CenterEnd
+    }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
@@ -47,6 +47,7 @@ import warlockfe.warlock3.compose.util.LocalSkin
 import warlockfe.warlock3.compose.util.LocalStyleMap
 import warlockfe.warlock3.compose.util.createFontFamily
 import warlockfe.warlock3.compose.util.getColorGroup
+import warlockfe.warlock3.compose.util.toAlignment
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.core.client.PanelObject
 import warlockfe.warlock3.core.client.WarlockAction
@@ -355,7 +356,7 @@ private fun Label(
     val colorGroup = skinObject.getColorGroup()
     Box(modifier = Modifier.padding(horizontal = 4.dp)) {
         Text(
-            modifier = Modifier.align(Alignment.Center),
+            modifier = Modifier.align(data.justify.toAlignment()),
             text = data.value ?: "",
             color = colorGroup.text,
             style = labelStyle,

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
@@ -41,6 +41,7 @@ import warlockfe.warlock3.compose.util.LocalSkin
 import warlockfe.warlock3.compose.util.LocalStyleMap
 import warlockfe.warlock3.compose.util.createFontFamily
 import warlockfe.warlock3.compose.util.getColorGroup
+import warlockfe.warlock3.compose.util.toAlignment
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.core.client.PanelObject
 import warlockfe.warlock3.core.client.WarlockAction
@@ -390,7 +391,7 @@ private fun Label(
     val colorGroup = skinObject.getColorGroup()
     Box(modifier = Modifier.padding(horizontal = 4.dp)) {
         Text(
-            modifier = Modifier.align(Alignment.Center),
+            modifier = Modifier.align(data.justify.toAlignment()),
             text = data.value ?: "",
             color = colorGroup.text,
             style = MaterialTheme.typography.labelSmall,

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContentPreviews.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContentPreviews.kt
@@ -31,6 +31,7 @@ import warlockfe.warlock3.compose.util.LocalSkin
 import warlockfe.warlock3.compose.util.getColorGroup
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.core.client.DataDistance
+import warlockfe.warlock3.core.client.PanelJustify
 import warlockfe.warlock3.core.client.PanelObject
 import warlockfe.warlock3.core.client.Percentage
 import warlockfe.warlock3.core.text.StyleDefinition
@@ -482,6 +483,7 @@ private fun ExperiencePreview() {
                 leftAnchor = null,
                 tooltip = null,
                 value = "Level 0",
+                justify = PanelJustify.Center,
             ),
             PanelObject.ProgressBar(
                 id = "mindState",
@@ -520,6 +522,7 @@ private fun ExperiencePreview() {
                 leftAnchor = null,
                 tooltip = "Physical Training Points",
                 value = "5 PTPs",
+                justify = PanelJustify.Center,
             ),
             PanelObject.Label(
                 id = "MTPs",
@@ -532,6 +535,7 @@ private fun ExperiencePreview() {
                 leftAnchor = "PTPs",
                 tooltip = "Mental Training Points",
                 value = "3 MTPs",
+                justify = PanelJustify.Center,
             ),
             PanelObject.Label(
                 id = "p2m",
@@ -544,6 +548,7 @@ private fun ExperiencePreview() {
                 leftAnchor = null,
                 tooltip = "Physical tps that have been converted to Mental tps",
                 value = "0 P2M",
+                justify = PanelJustify.Center,
             ),
             PanelObject.Label(
                 id = "m2p",
@@ -556,6 +561,7 @@ private fun ExperiencePreview() {
                 leftAnchor = "p2m",
                 tooltip = "Mental tps that have been converted to Physical tps",
                 value = "0 M2P",
+                justify = PanelJustify.Center,
             ),
             PanelObject.Link(
                 id = "exprLNK",

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/PanelObject.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/PanelObject.kt
@@ -50,6 +50,7 @@ sealed class PanelObject {
         override val leftAnchor: String?,
         override val tooltip: String?,
         val value: String?,
+        val justify: PanelJustify,
     ) : PanelObject()
 
     data class Link(
@@ -186,6 +187,16 @@ sealed class PanelObject {
         val exist: String?,
         val noun: String?,
     ) : PanelObject()
+}
+
+/**
+ * How a label's text sits inside the box its width gives it. Not to be confused with [PanelObject.align],
+ * which places the box itself within the panel.
+ */
+enum class PanelJustify {
+    Left,
+    Center,
+    Right,
 }
 
 sealed class DataDistance {

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/LabelHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/LabelHandler.kt
@@ -6,6 +6,7 @@ import warlockfe.warlock3.wrayth.protocol.StartElement
 import warlockfe.warlock3.wrayth.protocol.WraythDialogObjectEvent
 import warlockfe.warlock3.wrayth.protocol.WraythEvent
 import warlockfe.warlock3.wrayth.util.parseDistance
+import warlockfe.warlock3.wrayth.util.parseJustify
 
 class LabelHandler : BaseElementListener() {
     override fun startElement(element: StartElement): WraythEvent? {
@@ -22,6 +23,7 @@ class LabelHandler : BaseElementListener() {
                 topAnchor = element.attributes["anchor_top"],
                 leftAnchor = element.attributes["anchor_left"],
                 tooltip = element.attributes["tooltip"],
+                justify = parseJustify(element.attributes["justify"]),
             ),
         )
     }

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/util/JustifyParser.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/util/JustifyParser.kt
@@ -1,0 +1,28 @@
+package warlockfe.warlock3.wrayth.util
+
+import warlockfe.warlock3.core.client.PanelJustify
+
+// Wrayth's default when a label carries no `justify` at all: DT_VCENTER or DT_CENTER.
+private const val DEFAULT_JUSTIFY = 5
+
+private const val DT_CENTER = 1
+private const val DT_RIGHT = 2
+
+/**
+ * Reads a label's `justify` attribute, which aligns its text inside the width the label was given
+ * (a label with no width hugs its text, so justifying it changes nothing).
+ *
+ * The attribute is not an enum but a raw Win32 `DrawText` format mask, which Wrayth parses as a
+ * number and hands to the text drawing call as-is. Only two of its bits speak to horizontal
+ * placement - DT_CENTER and DT_RIGHT - and center wins when both are set, so 0, 4 and 8 all go left
+ * while 2, 6 and 10 all go right. A missing or empty `justify` draws with 5 (DT_VCENTER or
+ * DT_CENTER) and so centers, while a non-empty value that is not a number reads as 0 and goes left.
+ */
+fun parseJustify(text: String?): PanelJustify {
+    val flags = if (text.isNullOrEmpty()) DEFAULT_JUSTIFY else text.toIntOrNull() ?: 0
+    return when {
+        flags and DT_CENTER != 0 -> PanelJustify.Center
+        flags and DT_RIGHT != 0 -> PanelJustify.Right
+        else -> PanelJustify.Left
+    }
+}

--- a/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
+++ b/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
@@ -1,3 +1,4 @@
+import warlockfe.warlock3.core.client.PanelJustify
 import warlockfe.warlock3.core.client.PanelObject
 import warlockfe.warlock3.wrayth.protocol.WraythActionEvent
 import warlockfe.warlock3.wrayth.protocol.WraythCloseDialogEvent
@@ -160,6 +161,40 @@ class WraythProtocolHandlerTests {
         assertEquals("befriend clear 1", remove.cmd)
         assertEquals("befriend clear 1", remove.echo)
         assertEquals("Remove", remove.tooltip)
+    }
+
+    private fun parseLabelJustify(justify: String): PanelJustify =
+        parsePanelObject<PanelObject.Label>("<label id='l' value='x' width='100%' justify='$justify'/>").justify
+
+    @Test
+    fun labelJustifyIsADrawTextMask() {
+        // `justify` is a Win32 DrawText format mask, not an enum: DT_CENTER (1) beats DT_RIGHT (2),
+        // and every other bit leaves the text on the left. Each of these was rendered by the real
+        // client and read off the screen.
+        assertEquals(listOf(0, 4, 8).map { PanelJustify.Left }, listOf(0, 4, 8).map { parseLabelJustify("$it") })
+        assertEquals(
+            listOf(1, 3, 5, 7, 9).map { PanelJustify.Center },
+            listOf(1, 3, 5, 7, 9).map { parseLabelJustify("$it") },
+        )
+        assertEquals(listOf(2, 6, 10).map { PanelJustify.Right }, listOf(2, 6, 10).map { parseLabelJustify("$it") })
+    }
+
+    @Test
+    fun missingOrEmptyJustifyCenters() {
+        // Wrayth draws a label with no usable `justify` with a hardcoded 5 (DT_VCENTER or DT_CENTER).
+        // An empty attribute takes that same path, unlike a non-empty one that merely is not a number.
+        assertEquals(
+            PanelJustify.Center,
+            parsePanelObject<PanelObject.Label>("<label id='l' value='x' width='100%'/>").justify,
+        )
+        assertEquals(PanelJustify.Center, parseLabelJustify(""))
+    }
+
+    @Test
+    fun labelJustifyThatIsNotANumberGoesLeft() {
+        // Wrayth's string-to-number conversion yields no horizontal bits here, so it draws left.
+        // Real game data only ever sends numbers; this pins the edge to what the client does.
+        assertEquals(PanelJustify.Left, parseLabelJustify("right"))
     }
 
     @Test


### PR DESCRIPTION
Three fixes to how panels render, all checked against the real client with `wrayth-lab`.

### Labels ignored `justify`

Every label drew centered. `justify` is not an enum but a raw Win32 `DrawText` format mask that Wrayth parses as a number and hands to the drawing call as-is, so only `DT_CENTER` (1) and `DT_RIGHT` (2) speak to horizontal placement, and center wins when both bits are set. That makes 0, 4 and 8 all left; 2, 6 and 10 all right. A missing or empty attribute draws with a hardcoded 5 (`DT_VCENTER | DT_CENTER`) and so centers, while a non-empty value that is not a number reads as 0 and goes left.

Each case in the new tests was rendered by the client and read off the screen, rather than derived from the parser.

### The skin's offsets outranked the server's

`top`/`left` preferred the skin's pixel values unconditionally. A skin child's offset places the object inside its skin container, so it only has something to say about an object the server did not anchor (the injuries panel's body parts, the compass arrows). Once an object is anchored, `top`/`left` are the gap from that anchor and belong to the server.

UberBar stacks its vital bars exactly that way, anchoring each to the one above and pairing it with a `<skin controls=...>` whose child sits at 0,0. Preferring the skin there dropped every `top='3'` and left the bars touching.

### Panel pixels are now scaled 1.2x

The server sizes and positions panel objects for Wrayth's compact pixel grid, and for the small font it drew labels with. Treating those pixels as dp 1:1 leaves a box only just wide enough for Wrayth's font, so our wider one gets clipped. Positions, sizes and margins scale together, so the layout stays proportional. 1.5 proved too generous.

### Testing

`:wrayth:jvmTest` and `ktlintCheck` pass; the justify parsing is covered by three new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Panel labels now support left, center, and right text alignment.
  * Label alignment settings are applied consistently across desktop and mobile interfaces.
  * Server-provided panel positioning and pixel-scaled offsets are now honored when available.

* **Bug Fixes**
  * Corrected panel label positioning and alignment behavior.
  * Added sensible defaults for missing or invalid alignment settings.

* **Tests**
  * Added coverage for alignment parsing, defaults, and invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->