### PR TITLE
Wait for the restored windows before docking a saved layout

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -112,6 +112,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
 
         getByName("jvmBenchmark").dependencies {

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
@@ -117,6 +117,24 @@ internal fun gameDockLayout(): DockLayout =
     }
 
 /**
+ * The windows to reconcile against, keyed by name. Insertion-ordered: main first, then the view
+ * model's restore/open order. A window the game put in the client's own chrome is drawn there and
+ * never docked, so it is left out - which also undocks one an older build's saved layout still
+ * names.
+ */
+internal fun openGameWindows(
+    main: WindowUiState,
+    windows: List<WindowUiState>,
+): Map<String, OpenGameWindow> =
+    buildMap {
+        put(main.name, OpenGameWindow(main))
+        windows
+            .map { OpenGameWindow(it) }
+            .filterNot { it.location.isChrome }
+            .forEach { put(it.name, it) }
+    }
+
+/**
  * One open game window as the docking bridge sees it. [location] is where the game's announcement
  * asks for, read live from the window info (announcements can arrive after the window opens); it
  * seeds the default spot for a window the saved layout does not know.
@@ -168,18 +186,14 @@ fun rememberGameDockState(
     val main by viewModel.mainWindowUiState.collectAsState()
     val windows by viewModel.windowUiStates.collectAsState()
 
-    // Insertion-ordered: main first, then the view model's restore/open order. A window the game
-    // put in the client's own chrome is drawn there and never docked, so it is left out here -
-    // which also undocks one an older build's saved layout still names.
-    val openWindows: Map<String, OpenGameWindow> =
-        buildMap {
-            put(main.name, OpenGameWindow(main))
-            windows
-                .map { OpenGameWindow(it) }
-                .filterNot { it.location.isChrome }
-                .forEach { put(it.name, it) }
-        }
+    val openWindows: Map<String, OpenGameWindow> = openGameWindows(main, windows)
     val currentOpenWindows: State<Map<String, OpenGameWindow>> = rememberUpdatedState(openWindows)
+
+    // The open set as the view model has it right now, rather than as of the last composition.
+    // Reconciles run from coroutines that can outpace recomposition - the first one after a restore
+    // reliably does - and reconciling against a stale, still-empty set undocks the whole restored
+    // arrangement. The composition-lagged state above stays as the recomposition trigger only.
+    fun liveOpenWindows(): Map<String, OpenGameWindow> = openGameWindows(viewModel.mainWindowUiState.value, viewModel.windowUiStates.value)
 
     // Snapshot-state mirror read by the dockable specs' lambdas (title, actions, content), so a
     // registered dockable keeps rendering the live ui state without re-registration.
@@ -284,25 +298,17 @@ fun rememberGameDockState(
             // identifies a character has nothing to restore from or save under.
             launch {
                 viewModel.connectedCharacterId.filterNotNull().first()
-                val saved = runCatching { viewModel.loadDockLayout() }.getOrNull()
-                if (saved != null) {
-                    runCatching { DockingPersistence.decode(saved) }
-                        .onSuccess { state.restoreLayout(it, mergeFloatingWindows = true) }
-                        .onFailure { Logger.w(it) { "Discarding unreadable dock layout" } }
+                // The view model restores the character's open windows off that same emission, and
+                // nothing orders the two. Wait for its list before reconciling: the reconcile below
+                // undocks every window the saved arrangement names that is not open, so running it
+                // against a list that has not been filled in yet throws the arrangement away and
+                // then saves the wreckage over it a second later. Bounded like the gate below, so a
+                // restore that never finishes cannot strand the layout unrestored.
+                if (withTimeoutOrNull(CHARACTER_WAIT) { viewModel.awaitWindowsRestored() } == null) {
+                    Logger.w { "Window restore still running after $CHARACTER_WAIT; docking against it" }
                 }
-                // A restore replaces the layout the builder made, so a character whose JSON was
-                // saved before the areas were declared comes back without them - and would have
-                // nowhere to drop a window. Put back whichever are missing; each call is a no-op
-                // when the area is already there, whether as a placeholder or as windows the
-                // character has in it.
-                state.ensureAnchor(LEFT_ANCHOR, DockRegion.West, SIDE_COLUMN_PROPORTION)
-                state.ensureAnchor(RIGHT_ANCHOR, DockRegion.East, SIDE_COLUMN_PROPORTION)
-                state.ensureAnchor(CENTER_ANCHOR, DockRegion.North, BAND_PROPORTION)
-                // A restored layout retains a leaf for every window it remembers, including ones
-                // that are closed right now; reconcile immediately so they never render as
-                // placeholders. This also re-docks anything a late restore displaced, when the
-                // bounded wait below gave up and laid windows out first.
-                reconcile(state, currentOpenWindows.value, ::registerWindow)
+                val saved = runCatching { viewModel.loadDockLayout() }.getOrNull()
+                applyRestoredLayout(state, saved, liveOpenWindows(), ::registerWindow)
                 restoreFinished.complete(Unit)
                 snapshotFlow { state.layout }
                     .drop(1)
@@ -317,7 +323,7 @@ fun rememberGameDockState(
             // after the timeout reconciles again above.
             launch {
                 withTimeoutOrNull(CHARACTER_WAIT) { restoreFinished.await() }
-                reconcile(state, currentOpenWindows.value, ::registerWindow)
+                reconcile(state, liveOpenWindows(), ::registerWindow)
                 merge(
                     snapshotFlow { currentOpenWindows.value }.map { },
                     // A drop can re-dock a window the game closed mid-drag; a Docked event is the
@@ -327,13 +333,48 @@ fun rememberGameDockState(
                         .filter { !it.isTemporary }
                         .map { },
                 ).collect {
-                    reconcile(state, currentOpenWindows.value, ::registerWindow)
+                    reconcile(state, liveOpenWindows(), ::registerWindow)
                 }
             }
         }
     }
 
     return state
+}
+
+/**
+ * Puts the character's saved arrangement back: decodes [saved] over the layout, restores any area
+ * it does not carry, and reconciles the result against [openWindows].
+ *
+ * [openWindows] must be the character's restored window list, not an empty or partial one.
+ * [reconcile] cannot tell a window the user closed from one that has not been restored yet, so it
+ * undocks everything the arrangement names that is not in the set - and the debounced save then
+ * writes the wreckage over the arrangement a second later. That is why the caller waits on
+ * [GameViewModel.awaitWindowsRestored] before getting here.
+ */
+internal fun applyRestoredLayout(
+    state: DockState,
+    saved: String?,
+    openWindows: Map<String, OpenGameWindow>,
+    registerWindow: (String, AnchorId?) -> Unit,
+) {
+    if (saved != null) {
+        runCatching { DockingPersistence.decode(saved) }
+            .onSuccess { state.restoreLayout(it, mergeFloatingWindows = true) }
+            .onFailure { Logger.w(it) { "Discarding unreadable dock layout" } }
+    }
+    // A restore replaces the layout the builder made, so a character whose JSON was saved before
+    // the areas were declared comes back without them - and would have nowhere to drop a window.
+    // Put back whichever are missing; each call is a no-op when the area is already there, whether
+    // as a placeholder or as windows the character has in it.
+    state.ensureAnchor(LEFT_ANCHOR, DockRegion.West, SIDE_COLUMN_PROPORTION)
+    state.ensureAnchor(RIGHT_ANCHOR, DockRegion.East, SIDE_COLUMN_PROPORTION)
+    state.ensureAnchor(CENTER_ANCHOR, DockRegion.North, BAND_PROPORTION)
+    // A restored layout retains a leaf for every window it remembers, including ones that are
+    // closed right now; reconcile immediately so they never render as placeholders. This also
+    // re-docks anything a late restore displaced, when the bounded wait in the bridge gave up and
+    // laid windows out first.
+    reconcile(state, openWindows, registerWindow)
 }
 
 /**

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -438,6 +438,18 @@ class GameViewModel(
     // racing it into the docks.
     private val layoutRestored = CompletableDeferred<Unit>()
 
+    /**
+     * Suspends until the character's saved open windows have been loaded into [windowUiStates].
+     *
+     * The docking bridge waits on this before it reconciles a restored arrangement, for the same
+     * reason [openWindowFromGame] does. Both it and [restoreWindowLayoutOnConnect] wake on the same
+     * [connectedCharacterId] emission with nothing ordering them, and a reconcile against a window
+     * list that is still empty undocks every window the arrangement just restored.
+     */
+    suspend fun awaitWindowsRestored() {
+        layoutRestored.await()
+    }
+
     // Stamp of the game's latest open/close instruction per window, taken while the event
     // collector is still synchronous. The handlers suspend (on the character id and the layout
     // restore) before acting, so each re-checks that it still holds the newest instruction and
@@ -1452,13 +1464,26 @@ class GameViewModel(
             characterSettingsRepository.get(characterId, DOCK_LAYOUT_KEY)
         }
 
+    // The most recently encoded dock layout. Kept so [close] can write one the bridge's debounce
+    // has not gotten to yet: an arrangement changed within a second of quitting would otherwise
+    // never reach the database, because the composition holding the debounce is torn down first.
+    private var pendingDockLayout: String? = null
+
     /** Persists the docking-layout JSON. Layout churn is debounced by the caller. */
     fun saveDockLayout(layout: String) {
-        viewModelScope.launch {
-            client.characterId.value?.let { characterId ->
-                characterSettingsRepository.save(characterId, DOCK_LAYOUT_KEY, layout)
-            }
-        }
+        pendingDockLayout = layout
+        viewModelScope.launch { flushDockLayout() }
+    }
+
+    /**
+     * Writes the latest dock layout. Re-writing one that already landed is a harmless upsert, so
+     * this does not track what has been written - which keeps a failed write from dropping the
+     * layout that a later flush would otherwise have saved.
+     */
+    private suspend fun flushDockLayout() {
+        val layout = pendingDockLayout ?: return
+        val characterId = client.characterId.value ?: return
+        characterSettingsRepository.save(characterId, DOCK_LAYOUT_KEY, layout)
     }
 
     /** Shared handling for a clickable game-text action (command link or menu). */
@@ -1591,6 +1616,10 @@ class GameViewModel(
     }
 
     suspend fun close() {
+        // Write any arrangement the bridge's debounce has not saved yet. This runs here rather than
+        // from the composition because callers await close() before tearing the window down (and,
+        // on the last window, before exiting the process), so the write is ordered ahead of both.
+        flushDockLayout()
         // If a reconnect is still in flight (e.g. the user returned to the dashboard while it was
         // running), cancel it first so the in-progress attempt is unwound: cancellation runs the
         // connect use case's finally blocks, which close any half-opened client/socket so nothing leaks.

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -66,6 +66,7 @@ import warlockfe.warlock3.compose.ui.window.WindowFindController
 import warlockfe.warlock3.compose.ui.window.WindowFindUiState
 import warlockfe.warlock3.compose.ui.window.WindowUiState
 import warlockfe.warlock3.compose.ui.window.getStyle
+import warlockfe.warlock3.compose.util.LatestValueWriter
 import warlockfe.warlock3.compose.util.SAFE_DEFAULT_STYLE
 import warlockfe.warlock3.compose.util.openUrl
 import warlockfe.warlock3.core.client.ClientCloseWindowEvent
@@ -1464,26 +1465,26 @@ class GameViewModel(
             characterSettingsRepository.get(characterId, DOCK_LAYOUT_KEY)
         }
 
-    // The most recently encoded dock layout. Kept so [close] can write one the bridge's debounce
-    // has not gotten to yet: an arrangement changed within a second of quitting would otherwise
-    // never reach the database, because the composition holding the debounce is torn down first.
-    private var pendingDockLayout: String? = null
+    // The dock layout is auto-saved, so two writes that finished out of order would leave the older
+    // arrangement stored with nothing to correct it. Both writers - the bridge's debounced save and
+    // the flush in [close] - go through one [LatestValueWriter], which keeps the newest layout the
+    // last one written. It lives here rather than in the composition so [close] can flush a layout
+    // the debounce has not gotten to: an arrangement changed within a second of quitting would
+    // otherwise never reach the database, the composition being torn down first.
+    private val dockLayoutWriter = LatestValueWriter(::writeDockLayout)
 
-    /** Persists the docking-layout JSON. Layout churn is debounced by the caller. */
-    fun saveDockLayout(layout: String) {
-        pendingDockLayout = layout
-        viewModelScope.launch { flushDockLayout() }
+    private suspend fun writeDockLayout(layout: String) {
+        client.characterId.value?.let { characterId ->
+            characterSettingsRepository.save(characterId, DOCK_LAYOUT_KEY, layout)
+        }
     }
 
     /**
-     * Writes the latest dock layout. Re-writing one that already landed is a harmless upsert, so
-     * this does not track what has been written - which keeps a failed write from dropping the
-     * layout that a later flush would otherwise have saved.
+     * Persists the docking-layout JSON. Layout churn is debounced by the caller, which collects
+     * sequentially and awaits this, so saves never pile up behind one another.
      */
-    private suspend fun flushDockLayout() {
-        val layout = pendingDockLayout ?: return
-        val characterId = client.characterId.value ?: return
-        characterSettingsRepository.save(characterId, DOCK_LAYOUT_KEY, layout)
+    suspend fun saveDockLayout(layout: String) {
+        dockLayoutWriter.write(layout)
     }
 
     /** Shared handling for a clickable game-text action (command link or menu). */
@@ -1619,7 +1620,7 @@ class GameViewModel(
         // Write any arrangement the bridge's debounce has not saved yet. This runs here rather than
         // from the composition because callers await close() before tearing the window down (and,
         // on the last window, before exiting the process), so the write is ordered ahead of both.
-        flushDockLayout()
+        dockLayoutWriter.flush()
         // If a reconnect is still in flight (e.g. the user returned to the dashboard while it was
         // running), cancel it first so the in-progress attempt is unwound: cancellation runs the
         // connect use case's finally blocks, which close any half-opened client/socket so nothing leaks.

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/LatestValueWriter.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/LatestValueWriter.kt
@@ -1,0 +1,38 @@
+package warlockfe.warlock3.compose.util
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Writes the latest value it has been given, one write at a time.
+ *
+ * The pending value is read inside the lock rather than captured when the write was asked for, so a
+ * write that queues behind another still stores the newest value and the last write to land can
+ * never be a stale one. That is the failure this exists to rule out: for auto-saved state, two
+ * writes that finish out of order leave the older version in the store with nothing to correct it,
+ * and the user sees their most recent change quietly reverted.
+ *
+ * Nothing here tracks what has already been written, so a value can be written twice - [save] is
+ * expected to be an idempotent upsert. That is deliberate: remembering what landed would let a
+ * failed write drop a value that a later flush would otherwise have stored.
+ */
+internal class LatestValueWriter<T : Any>(
+    private val save: suspend (T) -> Unit,
+) {
+    private val mutex = Mutex()
+    private var pending: T? = null
+
+    /** Records [value] as the latest and writes it, waiting for any write already in flight. */
+    suspend fun write(value: T) {
+        pending = value
+        flush()
+    }
+
+    /** Writes the latest value, if one has been recorded. */
+    suspend fun flush() {
+        mutex.withLock {
+            val value = pending ?: return
+            save(value)
+        }
+    }
+}

--- a/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
+++ b/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
@@ -5,6 +5,9 @@ import com.seanproctor.docking.model.AnchorId
 import com.seanproctor.docking.model.DockRegion
 import com.seanproctor.docking.model.DockableId
 import com.seanproctor.docking.model.DockableOptions
+import com.seanproctor.docking.persistence.DockingPersistence
+import com.seanproctor.docking.persistence.captureLayout
+import com.seanproctor.docking.persistence.restoreLayout
 import com.seanproctor.docking.state.DockState
 import com.seanproctor.docking.state.DockTarget
 import com.seanproctor.docking.state.DockableSpec
@@ -393,5 +396,79 @@ class GameDockingTest {
                     ),
             )
         assertEquals(DockRegion.East, next.region)
+    }
+
+    // The arrangement a session saves: the game's defaults, then the user drags room out of the
+    // band above main and down into the left column. Returns the layout JSON.
+    private fun savedArrangement(announced: Map<String, OpenGameWindow>): String {
+        val state = newState()
+        val registerWindow = register(state)
+        reconcile(state, announced, registerWindow)
+        state.dock(DockableId("room"), DockTarget.OnDockable(DockableId("thoughts")), DockRegion.South)
+        reconcile(state, announced, registerWindow)
+        assertEquals(
+            WindowLocation.LEFT.anchor,
+            currentAnchorOf(state.layout.mainWindow.root!!, "room"),
+            "precondition: the user's arrangement puts room in the left column",
+        )
+        return DockingPersistence.encode(state.captureLayout())
+    }
+
+    private val announced =
+        openWindows(
+            MAIN_WINDOW_NAME to WindowLocation.CENTER,
+            "thoughts" to WindowLocation.LEFT,
+            "room" to WindowLocation.CENTER,
+        )
+
+    private fun anchorOfRoom(state: DockState): AnchorId? = currentAnchorOf(state.layout.mainWindow.root!!, "room")
+
+    @Test
+    fun aRestoreAppliedAgainstTheRestoredWindowsKeepsTheArrangement() {
+        val state = newState()
+        applyRestoredLayout(state, savedArrangement(announced), announced, register(state))
+        assertEquals(
+            WindowLocation.LEFT.anchor,
+            anchorOfRoom(state),
+            "room should come back in the left column the user dragged it to",
+        )
+    }
+
+    // Why rememberGameDockState waits on GameViewModel.awaitWindowsRestored() before it applies a
+    // restore: reconcile cannot tell a window the user closed from one the view model has not
+    // restored yet, so applying the arrangement against a list that is still empty undocks the
+    // whole thing - and the debounced save writes the result over it a second later, which is what
+    // users saw as the layout never being saved. Pinned so the gate is not removed as redundant.
+    @Test
+    fun aRestoreAppliedBeforeTheWindowsAreRestoredLosesTheArrangement() {
+        val state = newState()
+        val onlyMain = openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER)
+        applyRestoredLayout(state, savedArrangement(announced), onlyMain, register(state))
+        // The windows arrive a moment later and fall back to their game-announced spots.
+        reconcile(state, announced, register(state))
+        assertEquals(
+            WindowLocation.CENTER.anchor,
+            anchorOfRoom(state),
+            "without the gate, room falls back to the location the game announced",
+        )
+    }
+
+    @Test
+    fun anUnreadableSavedLayoutFallsBackToTheDefaults() {
+        val state = newState()
+        applyRestoredLayout(state, "{not json", announced, register(state))
+        // The areas are still there and every window is docked, rather than the connect failing.
+        announced.keys.forEach { name ->
+            assertTrue(state.isOpen(DockableId(name)), "$name should be docked")
+        }
+        assertEquals(WindowLocation.CENTER.anchor, anchorOfRoom(state))
+    }
+
+    @Test
+    fun aCharacterWithNoSavedLayoutGetsTheAnnouncedSpots() {
+        val state = newState()
+        applyRestoredLayout(state, null, announced, register(state))
+        assertEquals(WindowLocation.LEFT.anchor, currentAnchorOf(state.layout.mainWindow.root!!, "thoughts"))
+        assertEquals(WindowLocation.CENTER.anchor, anchorOfRoom(state))
     }
 }

--- a/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/util/LatestValueWriterTest.kt
+++ b/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/util/LatestValueWriterTest.kt
@@ -1,0 +1,75 @@
+package warlockfe.warlock3.compose.util
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LatestValueWriterTest {
+    @Test
+    fun aSlowWriteDoesNotLandAfterANewerOne() =
+        runTest {
+            val stored = mutableListOf<String>()
+            // The first write blocks until we let it go, which is the shape that inverts a pair of
+            // plain concurrent writes: the older one is still in the store when the newer finishes.
+            val firstWriteReached = CompletableDeferred<Unit>()
+            val releaseFirstWrite = CompletableDeferred<Unit>()
+            val writer =
+                LatestValueWriter<String> { value ->
+                    if (stored.isEmpty()) {
+                        firstWriteReached.complete(Unit)
+                        releaseFirstWrite.await()
+                    }
+                    stored += value
+                }
+
+            val old = launch { writer.write("old") }
+            firstWriteReached.await()
+            val new = launch { writer.write("new") }
+            releaseFirstWrite.complete(Unit)
+            old.join()
+            new.join()
+
+            assertEquals("new", stored.last(), "the newest layout must be the last one stored")
+        }
+
+    @Test
+    fun aFlushQueuedBehindAWriteStillStoresTheNewestValue() =
+        runTest {
+            val stored = mutableListOf<String>()
+            val firstWriteReached = CompletableDeferred<Unit>()
+            val releaseFirstWrite = CompletableDeferred<Unit>()
+            val writer =
+                LatestValueWriter<String> { value ->
+                    if (stored.isEmpty()) {
+                        firstWriteReached.complete(Unit)
+                        releaseFirstWrite.await()
+                    }
+                    stored += value
+                }
+
+            // A save is in flight, the user changes the layout again, and the app is closing: the
+            // close path's flush must not write the value the in-flight save was carrying.
+            val inFlight = launch { writer.write("old") }
+            firstWriteReached.await()
+            val closing =
+                launch {
+                    writer.write("new")
+                    writer.flush()
+                }
+            releaseFirstWrite.complete(Unit)
+            inFlight.join()
+            closing.join()
+
+            assertEquals("new", stored.last())
+        }
+
+    @Test
+    fun aFlushWithNothingRecordedWritesNothing() =
+        runTest {
+            val stored = mutableListOf<String>()
+            LatestValueWriter<String> { stored += it }.flush()
+            assertEquals(emptyList(), stored)
+        }
+}


### PR DESCRIPTION
Reported on Discord by users on `v3.1.0-beta.30`: the window arrangement is never saved. It saves fine. It gets thrown away on the next connect, and then overwritten.

### What happens

`GameViewModel.restoreWindowLayoutOnConnect` and the docking bridge both wake on the same `client.characterId` emission, and nothing orders them. The bridge restores the saved arrangement and reconciles it straight away, but `reconcile` cannot tell a window the user closed from one the view model has not restored yet, so it undocks everything the arrangement names that is not in the open list:

```kotlin
dockedIds(state.layout)
    .filter { it.value != MAIN_WINDOW_NAME && it.value !in openWindows }
    .forEach { state.undock(it) }
```

Lose the race and `openWindows` is just `main`. The whole arrangement is undocked, the windows reopen at their game-announced defaults, and the debounced save writes that over the saved layout a second later. **Once it happens the good layout is gone**, which is why users experience it as never saving rather than as occasionally wrong.

The undock is worse than it looks, too: at that point the restored dockables are not in the registry yet, so an area emptied this way collapses outright instead of leaving the placeholder that would have held its slot.

`openWindowFromGame` already waits on the `layoutRestored` gate for exactly this reason. The bridge never did.

### The fix

Expose that gate as `awaitWindowsRestored()` and have the bridge wait on it, bounded by the same `CHARACTER_WAIT` as the gate below it.

Reconciles also read the open set through a `rememberUpdatedState`, so even in the winning order the bridge could read a set composition had not caught up to. They now read live from the view model; the composition-lagged state stays as the recomposition trigger, so trigger semantics are unchanged.

Separately, `saveDockLayout` is debounced by a second, so an arrangement changed just before quitting never reached the database, because the composition holding the debounce is torn down first. The layout is now kept on the view model and flushed by `close()`, which callers await before tearing the window down and, on the last one, before exiting.

### Serializing the writes

That flush introduced a second-order problem, caught in review. `saveDockLayout` started an independent coroutine per layout, and two of those could enter `characterSettingsRepository.save` in either order - Room's write lock does not hand out ordering by arrival. Between debounced saves the window is tiny, a second apart against a millisecond upsert, but `close()`'s flush races a save launched moments earlier: exactly the quit-right-after-a-change case the flush exists for. Left alone it would have undercut the guarantee it was added to provide.

Rather than wrapping a mutex around the launches, the launches are gone. The caller is a sequential flow collector, so making `saveDockLayout` suspend and awaiting it means debounced saves cannot pile up at all. The only concurrency left is that collector against `close()`, which a mutex does cover.

Both now go through one `LatestValueWriter`, which reads the pending value *inside* the lock rather than capturing it when the write was requested. That is stronger than serialization alone: a write that queues behind another re-reads and stores the newest value, so the last write to land can never be a stale one, whatever order the two arrive in. It deliberately does not track what has already been written - re-writing is an idempotent upsert, and remembering would let a failed write drop a value a later flush would have saved.

### Testing

Extracting `applyRestoredLayout` is what makes any of this testable; the sequence was locked inside the composable. Two of the four new tests are the pair that matters:

- `aRestoreAppliedAgainstTheRestoredWindowsKeepsTheArrangement` - `room` comes back in the left column the user dragged it to.
- `aRestoreAppliedBeforeTheWindowsAreRestoredLosesTheArrangement` - the same restore against a list that is still empty loses it, falling back to the announced `center`. Pins the hazard so the gate is not removed as redundant later.

`LatestValueWriter` was extracted rather than inlined so the write ordering could be tested at all: `GameViewModel` takes sixteen collaborators and has no tests to build on. Two of its three tests hold the first write open on a `CompletableDeferred` and let a newer one overtake it, one through `write()` and one through the close path's `flush()`, asserting the newest value is the last stored. Both fail with the lock removed, so they are not vacuous.

18 tests pass across `GameDockingTest` and `LatestValueWriterTest`; `check -PiosSkip=true -PlintSkip=true` is green.

Also run against `wrayth-lab`: a real connect restored the character's four windows and re-saved the layout byte-identical to a backup taken beforehand, with no gate timeouts and no decode failures in the log - so the new wait resolves promptly rather than costing 10s on every connect.

The close-path flush is not covered by a test. Closing the window needs a window-manager interaction, so it rests on the ordering in `closeGame`, which awaits `close()` before tearing the window down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game window docking and saved-layout restoration.
  * Ensured layouts are applied after all windows finish restoring, preventing stale or incomplete arrangements.
  * Preserved the latest docking layout during saving and game closure.
  * Added fallback handling for missing or invalid saved layouts.

* **Tests**
  * Added coverage for layout persistence, restoration timing, concurrent saves, and default window placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
