### PR TITLE
Update a panel widget in place instead of moving it to the end

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposePanelState.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/ComposePanelState.kt
@@ -13,9 +13,22 @@ class ComposePanelState(
     private val _objects = MutableStateFlow(emptyList<PanelObject>())
     val objects = _objects.asStateFlow()
 
+    /**
+     * Replaces the widget with this id where it already sits, and appends it only when it is new.
+     *
+     * The server updates a panel by resending just the widgets that changed, so this runs constantly
+     * during play. Moving an updated widget to the end instead would reorder the panel under the
+     * user: the layout reads flow position and draw order from this list, and the UI identifies a
+     * widget by its slot in it, so every widget after the updated one would be handed the state of
+     * its neighbour - which is what reset the first combat maneuver when the second was set.
+     */
     override suspend fun setObject(value: PanelObject) {
-        cachedList.removeAll { it.id == value.id }
-        cachedList.add(value)
+        val index = cachedList.indexOfFirst { it.id == value.id }
+        if (index >= 0) {
+            cachedList[index] = value
+        } else {
+            cachedList.add(value)
+        }
     }
 
     override suspend fun clear() {

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelObjectLayout.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelObjectLayout.kt
@@ -1,6 +1,7 @@
 package warlockfe.warlock3.compose.ui.window
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.layout.Layout
@@ -73,9 +74,14 @@ fun PanelObjectLayout(
     Layout(
         modifier = modifier.clipToBounds(),
         content = {
-            // Emit each object, paired with the skin child that styles it (matched by id).
+            // Emit each object, paired with the skin child that styles it (matched by id). Keyed by
+            // id so a widget's UI state follows the widget rather than its position: without it a
+            // widget that changes place hands its state (a dropdown's selection, a checkbox's tick)
+            // to whatever now occupies the slot. Ids are unique here - the panel state keys on them.
             dataObjects.forEach { data ->
-                content(data, skinObjects.getIgnoringCase(data.id))
+                key(data.id) {
+                    content(data, skinObjects.getIgnoringCase(data.id))
+                }
             }
         },
     ) { measurables, constraints ->
@@ -155,9 +161,9 @@ fun PanelObjectLayout(
             }
 
         // Resolve placements in topological order so an item's anchors/parent are
-        // already placed when we read them. Items may reference anchors that appear
-        // later in the data list because the panel state appends updated items to
-        // the end. Drawing still happens in data order to preserve z-ordering.
+        // already placed when we read them. An item may anchor to one that appears
+        // later in the data list: the server is free to send them in any order.
+        // Drawing still happens in data order to preserve z-ordering.
         val indexById = itemInfos.withIndex().associate { (idx, info) -> info.data.id to idx }
         val visitState = IntArray(itemInfos.size) // 0=unvisited, 1=in-progress, 2=done
         val placementOrder = ArrayList<Int>(itemInfos.size)

--- a/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/window/ComposePanelStateTest.kt
+++ b/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/window/ComposePanelStateTest.kt
@@ -1,0 +1,66 @@
+package warlockfe.warlock3.compose.ui.window
+
+import kotlinx.coroutines.test.runTest
+import warlockfe.warlock3.core.client.PanelObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ComposePanelStateTest {
+    private fun label(
+        id: String,
+        value: String,
+    ): PanelObject =
+        PanelObject.Label(
+            id = id,
+            value = value,
+            justify = warlockfe.warlock3.core.client.PanelJustify.Left,
+            left = null,
+            top = null,
+            width = null,
+            height = null,
+            align = null,
+            topAnchor = null,
+            leftAnchor = null,
+            tooltip = null,
+        )
+
+    private suspend fun ComposePanelState.ids(): List<String> {
+        updateState()
+        return objects.value.map { it.id }
+    }
+
+    @Test
+    fun anUpdatedWidgetKeepsItsPlace() =
+        runTest {
+            val state = ComposePanelState("combat")
+            listOf("m1", "m2", "m3").forEach { state.setObject(label(it, "none")) }
+            assertEquals(listOf("m1", "m2", "m3"), state.ids())
+
+            // The server acknowledges a change by resending just that widget. Moving it to the end
+            // would reorder the panel and shift every widget after it into a new slot.
+            state.setObject(label("m1", "feint"))
+            assertEquals(listOf("m1", "m2", "m3"), state.ids())
+            assertEquals(
+                listOf("feint", "none", "none"),
+                state.objects.value.map { (it as PanelObject.Label).value },
+            )
+        }
+
+    @Test
+    fun anUnknownWidgetIsAppended() =
+        runTest {
+            val state = ComposePanelState("combat")
+            state.setObject(label("m1", "none"))
+            state.setObject(label("m2", "none"))
+            assertEquals(listOf("m1", "m2"), state.ids())
+        }
+
+    @Test
+    fun clearEmptiesThePanel() =
+        runTest {
+            val state = ComposePanelState("combat")
+            state.setObject(label("m1", "none"))
+            state.clear()
+            assertEquals(emptyList(), state.ids())
+        }
+}


### PR DESCRIPTION
Reported on Discord: "when I go to set my first maneuver it resets when I go to set the second one."

### What happens

The server updates a panel by resending only the widgets that changed, so this path runs constantly during play. `ComposePanelState.setObject` removed the widget with that id and appended the new one, moving it to the **end** of the list:

```kotlin
cachedList.removeAll { it.id == value.id }
cachedList.add(value)
```

`PanelObjectLayout` then emitted its children with no `key`, so Compose identified each widget by its slot. Set maneuver 1, the server acks by resending that widget, it jumps to the end, and every widget after its old position shifts up a slot - each one handed the state of its former neighbour. The seeding effect re-runs against a different widget and overwrites the user's selection with a server value.

### The fix

`setObject` now replaces in place and appends only genuinely new widgets. That is also what the layout wants: it reads flow position and draw order from this list, so reordering moved the panel around under the user as well.

The children are keyed by widget id too, so state follows the widget rather than the slot even if the order does change for another reason. Ids are unique in this list by construction, since `setObject` keys on them.

### Testing

Three tests on the ordering, plus an end-to-end run against `wrayth-lab` using a checkbox positioned *after* a widget the server then updated:

```
before update:   first          | Checkbox "my toggle" Off
toggle + update: first UPDATED  | Checkbox "my toggle" On   <- survived
button reads it: sent on
```

The label updated in place, the order held, the tick survived, and the button reading it still received the toggled value. Before this the checkbox came back cleared.

`check -PiosSkip=true -PlintSkip=true` is green.

### Note

Related to `#269`'s panel work but independent of the other two panel branches in flight (`dropdown-selected-option`, `panel-checkbox-closebutton`) - this one touches no files they touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved panel widget order when existing objects are updated.
  * Preserved widget state when objects move positions.
  * Ensured newly encountered widgets are appended correctly.
  * Clarified that incoming panel data may arrive in any order.

* **Tests**
  * Added coverage for updates, new widgets, ordering, and clearing panel contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->