### PR TITLE
Select a dropdown option by its label, not its value

### DIFF
--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/shim/WarlockDropdownSelect.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/shim/WarlockDropdownSelect.kt
@@ -12,20 +12,28 @@ import org.jetbrains.jewel.ui.component.ListComboBox
 @Composable
 fun <T> WarlockDropdownSelect(
     items: List<T>,
-    selected: T,
+    selected: T?,
     onSelect: (T) -> Unit,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = JewelTheme.defaultTextStyle,
     itemLabelBuilder: (T) -> String = { it.toString() },
 ) {
     val labels = remember(items) { items.map(itemLabelBuilder) }
-    val selectedIndex = items.indexOf(selected).coerceAtLeast(0)
+    // ListComboBox shows an empty label for index -1, which is how a caller says nothing is selected
+    // - a panel dropdown whose game-sent selection names no option, say. Only a null [selected] that
+    // is not itself one of the items means that: null is a real item where T is nullable (the
+    // character selector's "Global"), and a non-null one that has since left the list still falls
+    // back to the first, as it always has.
+    val selectedIndex =
+        items.indexOfFirst { it == selected }.let { index ->
+            if (index < 0 && selected != null) 0 else index
+        }
     // ListComboBox is single-select, but its default list state is created with SelectionMode.Multiple,
     // which logs a "selectionMode does not match" warning on every recomposition. Give it a
     // single-selection state so they agree.
     val listState =
         rememberSelectableLazyListState(
-            initialFirstVisibleItemIndex = selectedIndex,
+            initialFirstVisibleItemIndex = selectedIndex.coerceAtLeast(0),
             selectionMode = SelectionMode.Single,
         )
     ListComboBox(

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
@@ -175,13 +175,15 @@ fun DesktopPanelContent(
                 }
 
                 is PanelObject.DropDownBox -> {
-                    // Seed/refresh the shared value from the server; local selections override until the next update.
-                    LaunchedEffect(data.id, data.value) { data.value?.let { values[data.id] = it } }
+                    // Seed/refresh from the server, resolving its label to the option's value so the
+                    // map holds what `%<id>%` expands to. Local selections override until the next
+                    // update.
+                    val serverOption = data.serverOption
+                    LaunchedEffect(data.id, serverOption) { serverOption?.let { values[data.id] = it.value } }
                     if (data.options.isEmpty()) {
                         Box {}
                     } else {
-                        val selectedValue = values[data.id] ?: data.value
-                        val selected = data.options.firstOrNull { it.value == selectedValue } ?: data.options.first()
+                        val selected = data.optionFor(values[data.id]) ?: data.options.first()
                         WarlockDropdownSelect(
                             items = data.options,
                             selected = selected,

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
@@ -178,15 +178,15 @@ fun DesktopPanelContent(
                     // Seed/refresh from the server, resolving its label to the option's value so the
                     // map holds what `%<id>%` expands to. Local selections override until the next
                     // update.
-                    val serverOption = data.serverOption
-                    LaunchedEffect(data.id, serverOption) { serverOption?.let { values[data.id] = it.value } }
+                    LaunchedEffect(data.id, data.value, data.serverOption) { data.applyServerSelection(values) }
                     if (data.options.isEmpty()) {
                         Box {}
                     } else {
-                        val selected = data.optionFor(values[data.id]) ?: data.options.first()
+                        // Null when the server named an option that does not exist, which the box has
+                        // to show as nothing selected rather than as some other option.
                         WarlockDropdownSelect(
                             items = data.options,
-                            selected = selected,
+                            selected = data.optionFor(values[data.id]),
                             onSelect = { option ->
                                 values[data.id] = option.value
                                 data.cmd?.let(execute)

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
@@ -194,10 +194,11 @@ private fun DropDownBox(
 ) {
     // Seed/refresh from the server, resolving its label to the option's value so the map holds what
     // `%<id>%` expands to. Local selections below override until the next update.
-    val serverOption = data.serverOption
-    LaunchedEffect(data.id, serverOption) { serverOption?.let { values[data.id] = it.value } }
+    LaunchedEffect(data.id, data.value, data.serverOption) { data.applyServerSelection(values) }
     var expanded by remember { mutableStateOf(false) }
-    val currentLabel = data.optionFor(values[data.id])?.text ?: data.value ?: ""
+    // Empty when the server named an option that does not exist. Its raw value is not a label, and
+    // showing it would read as a selection the box does not have.
+    val currentLabel = data.optionFor(values[data.id])?.text ?: ""
     Box(modifier = Modifier.padding(2.dp)) {
         TextButton(onClick = { expanded = true }) {
             Text(currentLabel, style = MaterialTheme.typography.labelSmall, maxLines = 1)

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
@@ -192,11 +192,12 @@ private fun DropDownBox(
     values: SnapshotStateMap<String, String>,
     executeCommand: (String) -> Unit,
 ) {
-    // Seed/refresh the shared value from the server; local selections below override until the next update.
-    LaunchedEffect(data.id, data.value) { data.value?.let { values[data.id] = it } }
+    // Seed/refresh from the server, resolving its label to the option's value so the map holds what
+    // `%<id>%` expands to. Local selections below override until the next update.
+    val serverOption = data.serverOption
+    LaunchedEffect(data.id, serverOption) { serverOption?.let { values[data.id] = it.value } }
     var expanded by remember { mutableStateOf(false) }
-    val selectedValue = values[data.id] ?: data.value
-    val currentLabel = data.options.firstOrNull { it.value == selectedValue }?.text ?: selectedValue ?: ""
+    val currentLabel = data.optionFor(values[data.id])?.text ?: data.value ?: ""
     Box(modifier = Modifier.padding(2.dp)) {
         TextButton(onClick = { expanded = true }) {
             Text(currentLabel, style = MaterialTheme.typography.labelSmall, maxLines = 1)

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/PanelObject.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/PanelObject.kt
@@ -99,6 +99,22 @@ sealed class PanelObject {
         val cmd: String?,
         val options: List<Option>,
     ) : PanelObject() {
+        /**
+         * The option the server's [value] names. It names the option's [Option.text], not its
+         * [Option.value]: a box sent as `value='neck'` alongside `content_text='random,head,neck'`
+         * and `content_value='rnd,hd,nk'` shows "neck" and substitutes "nk". Matching the wrong
+         * column finds nothing, which is what made the real client show a literal "(ERROR)".
+         */
+        val serverOption: Option?
+            get() = options.firstOrNull { it.text == value }
+
+        /**
+         * The option to show, given [current] - the value held for this widget in the panel's value
+         * map, which is an [Option.value] because that is what `%<id>%` expands to. Falls back to
+         * the server's selection when the map has nothing for this widget yet.
+         */
+        fun optionFor(current: String?): Option? = options.firstOrNull { it.value == current } ?: serverOption
+
         data class Option(
             val text: String,
             val value: String,

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/PanelObject.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/PanelObject.kt
@@ -111,9 +111,27 @@ sealed class PanelObject {
         /**
          * The option to show, given [current] - the value held for this widget in the panel's value
          * map, which is an [Option.value] because that is what `%<id>%` expands to. Falls back to
-         * the server's selection when the map has nothing for this widget yet.
+         * the server's selection when the map has nothing for this widget yet. Null means nothing is
+         * selected, which is a state the panel has to be able to show: see [applyServerSelection].
          */
         fun optionFor(current: String?): Option? = options.firstOrNull { it.value == current } ?: serverOption
+
+        /**
+         * Folds a server update into a panel's [values] map, which holds [Option.value]s because
+         * that is what `%<id>%` expands to.
+         *
+         * A [value] naming no option is the server's error state rather than a selection - the real
+         * client renders a literal "(ERROR)" for it - so any entry left over from an earlier update
+         * or a local pick goes, leaving the box showing nothing. A box that arrives with no [value]
+         * at all says nothing about the selection, so a local one survives it.
+         */
+        fun applyServerSelection(values: MutableMap<String, String>) {
+            val option = serverOption
+            when {
+                option != null -> values[id] = option.value
+                value != null -> values.remove(id)
+            }
+        }
 
         data class Option(
             val text: String,

--- a/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
+++ b/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
@@ -9,6 +9,7 @@ import warlockfe.warlock3.wrayth.protocol.WraythUnhandledTagEvent
 import warlockfe.warlock3.wrayth.util.WraythDialogWindow
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class WraythProtocolHandlerTests {
     @Test
@@ -195,6 +196,44 @@ class WraythProtocolHandlerTests {
         // Wrayth's string-to-number conversion yields no horizontal bits here, so it draws left.
         // Real game data only ever sends numbers; this pins the edge to what the client does.
         assertEquals(PanelJustify.Left, parseLabelJustify("right"))
+    }
+
+    @Test
+    fun dropDownBoxValueNamesTheLabelNotTheValue() {
+        val box =
+            parsePanelObject<PanelObject.DropDownBox>(
+                "<dropDownBox id='dDBAim' value='neck' cmd='aim %dDBAim%' " +
+                    "content_text='random,head,neck' content_value='rnd,hd,nk'/>",
+            )
+        // The real client shows "neck" for this and sends "aim nk" when a button reads it. Matching
+        // `value` against the content_value column instead finds nothing, which is what left the
+        // combat panel showing its first option while the game held another.
+        assertEquals(PanelObject.DropDownBox.Option("neck", "nk"), box.serverOption)
+        assertEquals(PanelObject.DropDownBox.Option("neck", "nk"), box.optionFor(null))
+    }
+
+    @Test
+    fun dropDownBoxNamingNoLabelSelectsNothing() {
+        // 'hd' is a content_value, not a label. The real client renders a literal "(ERROR)" here
+        // rather than quietly selecting something.
+        val box =
+            parsePanelObject<PanelObject.DropDownBox>(
+                "<dropDownBox id='dDBAim' value='hd' content_text='random,head,neck' " +
+                    "content_value='rnd,hd,nk'/>",
+            )
+        assertNull(box.serverOption)
+        assertNull(box.optionFor(null))
+    }
+
+    @Test
+    fun dropDownBoxPrefersTheLocalSelectionOverTheServerLabel() {
+        val box =
+            parsePanelObject<PanelObject.DropDownBox>(
+                "<dropDownBox id='dDBAim' value='neck' content_text='random,head,neck' " +
+                    "content_value='rnd,hd,nk'/>",
+            )
+        // The panel's value map holds option values, since that is what `%<id>%` expands to.
+        assertEquals(PanelObject.DropDownBox.Option("head", "hd"), box.optionFor("hd"))
     }
 
     @Test

--- a/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
+++ b/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
@@ -237,6 +237,48 @@ class WraythProtocolHandlerTests {
     }
 
     @Test
+    fun dropDownBoxUpdateStoresTheOptionValue() {
+        val box =
+            parsePanelObject<PanelObject.DropDownBox>(
+                "<dropDownBox id='dDBAim' value='neck' content_text='random,head,neck' " +
+                    "content_value='rnd,hd,nk'/>",
+            )
+        val values = mutableMapOf("dDBAim" to "hd")
+        box.applyServerSelection(values)
+
+        assertEquals(mapOf("dDBAim" to "nk"), values)
+    }
+
+    @Test
+    fun dropDownBoxUpdateNamingNoLabelDropsTheStoredValue() {
+        // The server named nothing this box has, so it has no selection - not the stale one, and not
+        // the raw 'hd', which is a content_value rather than a label.
+        val box =
+            parsePanelObject<PanelObject.DropDownBox>(
+                "<dropDownBox id='dDBAim' value='hd' content_text='random,head,neck' " +
+                    "content_value='rnd,hd,nk'/>",
+            )
+        val values = mutableMapOf("dDBAim" to "nk")
+        box.applyServerSelection(values)
+
+        assertEquals(emptyMap(), values)
+        assertNull(box.optionFor(values["dDBAim"]))
+    }
+
+    @Test
+    fun dropDownBoxUpdateWithoutAValueKeepsTheLocalSelection() {
+        // No `value` at all says nothing about the selection, so a local pick survives the update.
+        val box =
+            parsePanelObject<PanelObject.DropDownBox>(
+                "<dropDownBox id='dDBAim' content_text='random,head,neck' content_value='rnd,hd,nk'/>",
+            )
+        val values = mutableMapOf("dDBAim" to "hd")
+        box.applyServerSelection(values)
+
+        assertEquals(mapOf("dDBAim" to "hd"), values)
+    }
+
+    @Test
     fun upDownEditBoxParsesBounds() {
         val box = parsePanelObject<PanelObject.UpDownEditBox>("<upDownEditBox id='uDEQuickstrike' min='-60' max='60' value='-1'/>")
 


### PR DESCRIPTION
Reported on Discord: "Combat panel remembers what I set but doesn't show it on the panel." The panel showed its first option whatever the game actually had set.

### What happens

The server names the selected option by its **label**. A box arrives as:

```xml
<dropDownBox id='dDBAim' value='neck' cmd='aim %dDBAim%'
             content_text='random,head,neck' content_value='rnd,hd,nk'/>
```

`value='neck'` is a `content_text` entry. We matched it against the `content_value` column (`rnd,hd,nk`), never matched, and fell through to `data.options.first()`.

Checked against the real client rather than inferred:

- `value='head'` (a label) displays **"head"**
- `value='hd'` (a content_value) displays a literal **"(ERROR)"**

So it resolves against the label column, and a value naming no label is an error rather than a fallback to the first option.

### The second half

The same probe settled what `%<id>%` expands to. It substitutes the option's **value**, not its label: a button on `aimtest %dDBAim%` beside a box set to `'neck'` sends `aimtest nk`. We seeded the value map with the server's raw `value`, so a command fired before the user touched the box would have sent the label instead.

That was latent on desktop and was the *only* bug on mobile, where the display happened to look right because it prints the raw string when no option matches.

### The fix

Resolution lives on the model as `serverOption` / `optionFor(current)` so both platforms share it and it is testable. The value map always holds option values, which is what `%<id>%` expands to, and the server's label is resolved on the way in.

### Testing

Three tests pinning the label-vs-value distinction, including the "(ERROR)" case as "selects nothing". Verified in our own client against the same fragment: the semantic tree reports `role: DropdownList, text: "neck"` (was `random`), and the button sent `aimtest nk` - byte-identical to the real client.

`check -PiosSkip=true -PlintSkip=true` is green.

### Note

One of three panel branches in flight. Independent of `panel-update-in-place`. Shares `WraythProtocolHandlerTests.kt` with `panel-checkbox-closebutton`, where both add tests at the same point - whichever merges second will need a trivial adjacent-insert resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown selection handling across desktop and mobile interfaces.
  * Dropdowns now correctly display server-provided labels while preserving local selections until refreshed.
  * Invalid or unmatched selections no longer display an incorrect option or stale value.
  * Server updates now apply the matching option value, clear invalid selections, and preserve local choices when no server value is provided.

* **Tests**
  * Added coverage for label-based selections, invalid values, server updates, and local selection precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->