### PR TITLE
Implement the checkBox and closeButton panel widgets

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -1513,6 +1513,13 @@ class GameViewModel(
                 requestMenu(action.exist, action.noun)
             }
 
+            is WarlockAction.ClosePanel -> {
+                // Same path as the window's own close button, so the panel is remembered hidden and
+                // the game cannot reopen it unasked.
+                closeWindow(action.id)
+                null
+            }
+
             else -> {
                 null
             }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -1374,6 +1374,29 @@ class GameViewModel(
     }
 
     /**
+     * A panel's own `closeButton`. The button's command goes first and the dismissal follows, both
+     * in one coroutine: raised as two actions they would be two coroutines racing for the socket,
+     * and the panel's `_DBCLOSE` could be written ahead of the command that was meant to precede it.
+     *
+     * A resident panel is a permanent fixture of the character's layout, and the real client refuses
+     * to close one rather than hiding it (it answers `_error Cannot close a resident dialog (<id>)`
+     * upstream). The button's command still runs either way.
+     */
+    private fun closePanelFromButton(action: WarlockAction.ClosePanel) {
+        val resident = windows.value.firstOrNull { it.name == action.id }?.resident == true
+        viewModelScope.launch {
+            action.command?.let { client.sendWidgetCommand(it, action.echo) }
+            if (resident) {
+                client.debug("Cannot close a resident dialog (${action.id})")
+                return@launch
+            }
+            // Same path as the window's own close button, so the panel is remembered hidden and the
+            // game cannot reopen it unasked.
+            closeWindow(action.id)
+        }
+    }
+
+    /**
      * The game closing a panel with a `closeDialog` tag. It leaves the layout but is not hidden: the
      * game is free to open it again later.
      *
@@ -1514,9 +1537,7 @@ class GameViewModel(
             }
 
             is WarlockAction.ClosePanel -> {
-                // Same path as the window's own close button, so the panel is remembered hidden and
-                // the game cannot reopen it unasked.
-                closeWindow(action.id)
+                closePanelFromButton(action)
                 null
             }
 

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameBottomBar.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameBottomBar.kt
@@ -91,6 +91,7 @@ fun DesktopGameBottomBar(
                     // around both this control bar and the text windows.
                     DesktopPanelContent(
                         dataObjects = vitalBars,
+                        panelId = null,
                         modifier = Modifier.fillMaxWidth().height(16.dp),
                         onAction = {
                             // Cannot execute commands from vitals bar

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
@@ -35,6 +35,7 @@ import org.jetbrains.jewel.ui.theme.defaultButtonStyle
 import org.jetbrains.jewel.ui.theme.linkStyle
 import warlockfe.warlock3.compose.desktop.components.DesktopColorPickerDialog
 import warlockfe.warlock3.compose.desktop.components.DesktopFontPickerDialog
+import warlockfe.warlock3.compose.desktop.shim.WarlockCheckboxRow
 import warlockfe.warlock3.compose.desktop.shim.WarlockDropdownSelect
 import warlockfe.warlock3.compose.desktop.shim.WarlockRadioButtonRow
 import warlockfe.warlock3.compose.model.SkinObject
@@ -68,6 +69,9 @@ private val labelStyle
 @Composable
 fun DesktopPanelContent(
     dataObjects: List<PanelObject>,
+    // The panel this content belongs to, or null when it is drawn as chrome (the status bar's
+    // vitals) rather than as a window - chrome has no panel for a close button to dismiss.
+    panelId: String?,
     onAction: (WarlockAction) -> Unit,
     style: StyleDefinition,
     modifier: Modifier = Modifier,
@@ -140,7 +144,14 @@ fun DesktopPanelContent(
                 is PanelObject.Button -> {
                     val colors = JewelTheme.defaultButtonStyle.colors
                     PanelButton(
-                        onClick = { data.cmd?.let { executeWidget(it, data.echo) } },
+                        onClick = {
+                            // A close button sends its command first and dismisses the panel after,
+                            // which is the order the real client uses.
+                            data.cmd?.let { executeWidget(it, data.echo) }
+                            if (data.closesPanel && panelId != null) {
+                                onAction(WarlockAction.ClosePanel(panelId))
+                            }
+                        },
                         modifier = Modifier.padding(2.dp),
                         shape = RoundedCornerShape(2.dp),
                         background = { isHovered, isPressed ->
@@ -201,6 +212,25 @@ fun DesktopPanelContent(
                         selected = data.selected,
                         onClick = { data.cmd?.let(execute) },
                         text = data.text ?: "",
+                    )
+                }
+
+                is PanelObject.CheckBox -> {
+                    // Seed/refresh the shared value from the server; local toggles override it until
+                    // the next update, the same rule the dropdown and spinner follow.
+                    LaunchedEffect(data.id, data.checked) {
+                        values[data.id] = if (data.checked) data.checkedValue else data.uncheckedValue
+                    }
+                    WarlockCheckboxRow(
+                        checked = values[data.id] == data.checkedValue,
+                        // Toggling sends nothing: a checkbox only holds a value for another widget's
+                        // command to pick up as `%<id>%`. Verified against the real client, which
+                        // sends nothing on the click and the new value on the button that reads it.
+                        onCheckedChange = { isChecked ->
+                            values[data.id] = if (isChecked) data.checkedValue else data.uncheckedValue
+                        },
+                        text = data.text ?: "",
+                        modifier = Modifier.padding(2.dp),
                     )
                 }
 

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
@@ -80,6 +80,10 @@ fun DesktopPanelContent(
     // widgets' commands reference them as %<id>% (e.g. "prep %dDBSpell0%", "quickstrike %uDEQuickstrike%").
     // A spinner has no command of its own, so its value lives here until another widget consumes it.
     val values = remember { mutableStateMapOf<String, String>() }
+    // A checkbox's tick, kept apart from its substitution value above: nothing stops a box from
+    // carrying the same string for both states, and reading the tick back off [values] would then
+    // leave it permanently ticked and impossible to clear.
+    val checkedStates = remember { mutableStateMapOf<String, Boolean>() }
     val executeWidget: (String, String?) -> Unit = { cmd, echo ->
         onAction(WarlockAction.SendWidgetCommand(substitute(cmd, values), echo))
     }
@@ -146,10 +150,19 @@ fun DesktopPanelContent(
                     PanelButton(
                         onClick = {
                             // A close button sends its command first and dismisses the panel after,
-                            // which is the order the real client uses.
-                            data.cmd?.let { executeWidget(it, data.echo) }
-                            if (data.closesPanel && panelId != null) {
-                                onAction(WarlockAction.ClosePanel(panelId))
+                            // which is the order the real client uses. It goes as one action so the
+                            // two halves cannot be reordered on their way to the socket.
+                            val closes = panelId?.takeIf { data.closesPanel }
+                            if (closes != null) {
+                                onAction(
+                                    WarlockAction.ClosePanel(
+                                        id = closes,
+                                        command = data.cmd?.let { substitute(it, values) },
+                                        echo = data.echo,
+                                    ),
+                                )
+                            } else {
+                                data.cmd?.let { executeWidget(it, data.echo) }
                             }
                         },
                         modifier = Modifier.padding(2.dp),
@@ -216,17 +229,21 @@ fun DesktopPanelContent(
                 }
 
                 is PanelObject.CheckBox -> {
-                    // Seed/refresh the shared value from the server; local toggles override it until
-                    // the next update, the same rule the dropdown and spinner follow.
-                    LaunchedEffect(data.id, data.checked) {
+                    // Seed/refresh the tick and the shared value from the server; local toggles
+                    // override them until the next update, the same rule the dropdown and spinner
+                    // follow. Either wire value changing is a refresh too, or the value left behind
+                    // would be one the box no longer offers.
+                    LaunchedEffect(data.id, data.checked, data.checkedValue, data.uncheckedValue) {
+                        checkedStates[data.id] = data.checked
                         values[data.id] = if (data.checked) data.checkedValue else data.uncheckedValue
                     }
                     WarlockCheckboxRow(
-                        checked = values[data.id] == data.checkedValue,
+                        checked = checkedStates[data.id] ?: data.checked,
                         // Toggling sends nothing: a checkbox only holds a value for another widget's
                         // command to pick up as `%<id>%`. Verified against the real client, which
                         // sends nothing on the click and the new value on the button that reads it.
                         onCheckedChange = { isChecked ->
+                            checkedStates[data.id] = isChecked
                             values[data.id] = if (isChecked) data.checkedValue else data.uncheckedValue
                         },
                         text = data.text ?: "",

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopWindowView.kt
@@ -215,6 +215,7 @@ fun DesktopWindowView(
                 val dataObjects by data.panelData.objects.collectAsState()
                 DesktopPanelContent(
                     dataObjects = dataObjects,
+                    panelId = data.panelData.id,
                     modifier = Modifier.padding(8.dp),
                     onAction = onAction,
                     style = style,

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameStatusCard.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameStatusCard.kt
@@ -37,6 +37,7 @@ fun GameStatusCard(
             val vitalBars by viewModel.vitalBars.collectAsState()
             PanelContent(
                 dataObjects = vitalBars,
+                panelId = null,
                 modifier = Modifier.fillMaxWidth().height(16.dp),
                 onAction = {
                     // Vitals are display-only.

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/game/GameView.kt
@@ -283,6 +283,7 @@ fun GameBottomBar(
             val vitalBars by viewModel.vitalBars.collectAsState()
             PanelContent(
                 dataObjects = vitalBars,
+                panelId = null,
                 modifier = Modifier.fillMaxWidth().height(16.dp),
                 onAction = {
                     // Cannot execute commands from vitals bar

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
@@ -66,6 +66,10 @@ fun PanelContent(
     // widgets' commands reference them as %<id>% (e.g. "prep %dDBSpell0%", "quickstrike %uDEQuickstrike%").
     // A spinner has no command of its own, so its value lives here until another widget consumes it.
     val values = remember { mutableStateMapOf<String, String>() }
+    // A checkbox's tick, kept apart from its substitution value above: nothing stops a box from
+    // carrying the same string for both states, and reading the tick back off [values] would then
+    // leave it permanently ticked and impossible to clear.
+    val checkedStates = remember { mutableStateMapOf<String, Boolean>() }
     val executeWidget: (String, String?) -> Unit = { cmd, echo ->
         onAction(WarlockAction.SendWidgetCommand(substitute(cmd, values), echo))
     }
@@ -134,10 +138,19 @@ fun PanelContent(
                     PanelButton(
                         onClick = {
                             // A close button sends its command first and dismisses the panel after,
-                            // which is the order the real client uses.
-                            data.cmd?.let { executeWidget(it, data.echo) }
-                            if (data.closesPanel && panelId != null) {
-                                onAction(WarlockAction.ClosePanel(panelId))
+                            // which is the order the real client uses. It goes as one action so the
+                            // two halves cannot be reordered on their way to the socket.
+                            val closes = panelId?.takeIf { data.closesPanel }
+                            if (closes != null) {
+                                onAction(
+                                    WarlockAction.ClosePanel(
+                                        id = closes,
+                                        command = data.cmd?.let { substitute(it, values) },
+                                        echo = data.echo,
+                                    ),
+                                )
+                            } else {
+                                data.cmd?.let { executeWidget(it, data.echo) }
                             }
                         },
                         modifier = Modifier.padding(2.dp),
@@ -181,19 +194,23 @@ fun PanelContent(
                 }
 
                 is PanelObject.CheckBox -> {
-                    // Seed/refresh the shared value from the server; local toggles override it until
-                    // the next update, the same rule the dropdown and spinner follow.
-                    LaunchedEffect(data.id, data.checked) {
+                    // Seed/refresh the tick and the shared value from the server; local toggles
+                    // override them until the next update, the same rule the dropdown and spinner
+                    // follow. Either wire value changing is a refresh too, or the value left behind
+                    // would be one the box no longer offers.
+                    LaunchedEffect(data.id, data.checked, data.checkedValue, data.uncheckedValue) {
+                        checkedStates[data.id] = data.checked
                         values[data.id] = if (data.checked) data.checkedValue else data.uncheckedValue
                     }
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Checkbox(
-                            checked = values[data.id] == data.checkedValue,
+                            checked = checkedStates[data.id] ?: data.checked,
                             // Toggling sends nothing: a checkbox only holds a value for another
                             // widget's command to pick up as `%<id>%`. Verified against the real
                             // client, which sends nothing on the click and the new value on the
                             // button that reads it.
                             onCheckedChange = { isChecked ->
+                                checkedStates[data.id] = isChecked
                                 values[data.id] = if (isChecked) data.checkedValue else data.uncheckedValue
                             },
                         )

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.LocalContentColor
@@ -54,6 +55,9 @@ import kotlin.io.encoding.Base64
 @Composable
 fun PanelContent(
     dataObjects: List<PanelObject>,
+    // The panel this content belongs to, or null when it is drawn as chrome (the status bar's
+    // vitals) rather than as a window - chrome has no panel for a close button to dismiss.
+    panelId: String?,
     onAction: (WarlockAction) -> Unit,
     style: StyleDefinition,
     modifier: Modifier = Modifier,
@@ -128,7 +132,14 @@ fun PanelContent(
                     val stateLayer = MaterialTheme.colorScheme.onPrimaryContainer
                     val borderBrush = SolidColor(MaterialTheme.colorScheme.outline)
                     PanelButton(
-                        onClick = { data.cmd?.let { executeWidget(it, data.echo) } },
+                        onClick = {
+                            // A close button sends its command first and dismisses the panel after,
+                            // which is the order the real client uses.
+                            data.cmd?.let { executeWidget(it, data.echo) }
+                            if (data.closesPanel && panelId != null) {
+                                onAction(WarlockAction.ClosePanel(panelId))
+                            }
+                        },
                         modifier = Modifier.padding(2.dp),
                         shape = MaterialTheme.shapes.extraSmall,
                         background = { isHovered, isPressed ->
@@ -162,6 +173,29 @@ fun PanelContent(
                         RadioButton(
                             selected = data.selected,
                             onClick = { data.cmd?.let(execute) },
+                        )
+                        data.text?.let {
+                            Text(it, style = MaterialTheme.typography.labelSmall, maxLines = 1)
+                        }
+                    }
+                }
+
+                is PanelObject.CheckBox -> {
+                    // Seed/refresh the shared value from the server; local toggles override it until
+                    // the next update, the same rule the dropdown and spinner follow.
+                    LaunchedEffect(data.id, data.checked) {
+                        values[data.id] = if (data.checked) data.checkedValue else data.uncheckedValue
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(
+                            checked = values[data.id] == data.checkedValue,
+                            // Toggling sends nothing: a checkbox only holds a value for another
+                            // widget's command to pick up as `%<id>%`. Verified against the real
+                            // client, which sends nothing on the click and the new value on the
+                            // button that reads it.
+                            onCheckedChange = { isChecked ->
+                                values[data.id] = if (isChecked) data.checkedValue else data.uncheckedValue
+                            },
                         )
                         data.text?.let {
                             Text(it, style = MaterialTheme.typography.labelSmall, maxLines = 1)

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContentPreviews.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContentPreviews.kt
@@ -167,6 +167,8 @@ private fun VitalBarsPreview() {
             )
         PanelContent(
             dataObjects = panelData,
+            // Drawn as status-bar chrome, not as a panel window.
+            panelId = null,
             modifier = Modifier.size(400.dp, 24.dp),
             onAction = {},
             style = StyleDefinition(),
@@ -461,6 +463,7 @@ private fun CombatPanelPreview() {
         )
     PanelContent(
         dataObjects = panelData,
+        panelId = "combat",
         modifier = Modifier.size(190.dp, 219.dp),
         onAction = {},
         style = StyleDefinition(),
@@ -594,6 +597,7 @@ private fun ExperiencePreview() {
         )
     PanelContent(
         dataObjects = panelData,
+        panelId = "expr",
         modifier = Modifier.size(190.dp, 200.dp),
         onAction = {},
         style = StyleDefinition(),

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/WindowView.kt
@@ -179,6 +179,7 @@ fun WindowView(
                 val dataObjects by data.panelData.objects.collectAsState()
                 PanelContent(
                     dataObjects = dataObjects,
+                    panelId = data.panelData.id,
                     modifier = Modifier.padding(8.dp),
                     onAction = onAction,
                     style = style,

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/PanelObject.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/PanelObject.kt
@@ -68,7 +68,11 @@ sealed class PanelObject {
         val echo: String?,
     ) : PanelObject()
 
-    // cmdButton
+    /**
+     * cmdButton, and closeButton when [closesPanel] is set. A close button is a command button that
+     * also dismisses the panel it sits in: the real client sends the command and then closes the
+     * panel (refusing, with an error of its own, when the panel is resident).
+     */
     data class Button(
         override val id: String,
         override val left: DataDistance?,
@@ -82,6 +86,31 @@ sealed class PanelObject {
         val value: String?,
         val cmd: String?,
         val echo: String?,
+        val closesPanel: Boolean = false,
+    ) : PanelObject()
+
+    /**
+     * checkBox: a toggle that sends nothing of its own. Its state is read by another widget, whose
+     * `cmd` names it as `%<id>%` and receives [checkedValue] or [uncheckedValue].
+     *
+     * Both values are required rather than nullable because the real client draws no checkbox at
+     * all unless the wire carried both `checked_value` and `unchecked_value` - a checkbox without
+     * them has nothing to contribute to a command, and Wrayth gives it neither pixels nor width.
+     */
+    data class CheckBox(
+        override val id: String,
+        override val left: DataDistance?,
+        override val top: DataDistance?,
+        override val width: DataDistance?,
+        override val height: DataDistance?,
+        override val align: String?,
+        override val topAnchor: String?,
+        override val leftAnchor: String?,
+        override val tooltip: String?,
+        val text: String?,
+        val checked: Boolean,
+        val checkedValue: String,
+        val uncheckedValue: String,
     ) : PanelObject()
 
     // dropDownBox: a selector. Picking an option runs [cmd] with `%<id>%` replaced by the option value.

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/WarlockAction.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/WarlockAction.kt
@@ -29,4 +29,10 @@ sealed class WarlockAction {
     data class OpenLink(
         val url: String,
     ) : WarlockAction()
+
+    // A closeButton dismissing the panel it sits in, named by the panel's id (which is also the
+    // window's name). The command it also carries arrives separately, as a SendWidgetCommand.
+    data class ClosePanel(
+        val id: String,
+    ) : WarlockAction()
 }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/WarlockAction.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/client/WarlockAction.kt
@@ -30,9 +30,13 @@ sealed class WarlockAction {
         val url: String,
     ) : WarlockAction()
 
-    // A closeButton dismissing the panel it sits in, named by the panel's id (which is also the
-    // window's name). The command it also carries arrives separately, as a SendWidgetCommand.
+    // A closeButton dismissing the panel it sits in, named by [id] (the panel's id, which is also
+    // the window's name). It carries its own [command] and [echo] rather than raising a separate
+    // SendWidgetCommand, because the real client sends the command and closes after: two actions
+    // would be two coroutines, and the panel's `_DBCLOSE` could reach the socket first.
     data class ClosePanel(
         val id: String,
+        val command: String?,
+        val echo: String?,
     ) : WarlockAction()
 }

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
@@ -10,9 +10,11 @@ import warlockfe.warlock3.wrayth.protocol.elements.AppHandler
 import warlockfe.warlock3.wrayth.protocol.elements.BHandler
 import warlockfe.warlock3.wrayth.protocol.elements.BackgroundHandler
 import warlockfe.warlock3.wrayth.protocol.elements.CastTimeHandler
+import warlockfe.warlock3.wrayth.protocol.elements.CheckBoxHandler
 import warlockfe.warlock3.wrayth.protocol.elements.ClearContainerHandler
 import warlockfe.warlock3.wrayth.protocol.elements.ClearStreamHandler
 import warlockfe.warlock3.wrayth.protocol.elements.CliHandler
+import warlockfe.warlock3.wrayth.protocol.elements.CloseButtonHandler
 import warlockfe.warlock3.wrayth.protocol.elements.CloseDialogHandler
 import warlockfe.warlock3.wrayth.protocol.elements.CmdButtonHandler
 import warlockfe.warlock3.wrayth.protocol.elements.CmdlistHandler
@@ -120,9 +122,11 @@ class WraythProtocolHandler {
             "b" to BHandler(),
             "background" to BackgroundHandler(),
             "castTime" to CastTimeHandler(),
+            "checkBox" to CheckBoxHandler(),
             "clearContainer" to ClearContainerHandler(),
             "clearStream" to ClearStreamHandler(),
             "cli" to CliHandler(),
+            "closeButton" to CloseButtonHandler(),
             "closeDialog" to CloseDialogHandler(),
             "cmdButton" to CmdButtonHandler(),
             "cmdlist" to CmdlistHandler(),
@@ -209,8 +213,6 @@ class WraythProtocolHandler {
             "vars" to IgnoredTagHandler(),
             "w" to IgnoredTagHandler(),
             // The rest arrive during play.
-            "closeButton" to IgnoredTagHandler(),
-            "checkBox" to IgnoredTagHandler(),
             "cmdtimestamp" to IgnoredTagHandler(),
             "command" to IgnoredTagHandler(),
             "deleteContainer" to IgnoredTagHandler(),

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/CheckBoxHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/CheckBoxHandler.kt
@@ -1,0 +1,40 @@
+package warlockfe.warlock3.wrayth.protocol.elements
+
+import warlockfe.warlock3.core.client.PanelObject
+import warlockfe.warlock3.wrayth.protocol.BaseElementListener
+import warlockfe.warlock3.wrayth.protocol.StartElement
+import warlockfe.warlock3.wrayth.protocol.WraythDialogObjectEvent
+import warlockfe.warlock3.wrayth.protocol.WraythEvent
+import warlockfe.warlock3.wrayth.util.parseDistance
+
+class CheckBoxHandler : BaseElementListener() {
+    override fun startElement(element: StartElement): WraythEvent? {
+        val id = element.attributes["id"] ?: return null
+        // A checkbox exists to hand a value to another widget's command, so one that carries no
+        // values has nothing to say. The real client agrees and draws nothing at all for it, not
+        // even an empty box, so it is dropped here rather than rendered as a dead toggle.
+        val checkedValue = element.attributes["checked_value"] ?: return null
+        val uncheckedValue = element.attributes["unchecked_value"] ?: return null
+        return WraythDialogObjectEvent(
+            PanelObject.CheckBox(
+                id = id,
+                text = element.attributes["text"],
+                // Presence, not value: the client ticks the box for `checked='off'` and
+                // `checked='false'` exactly as it does for `checked='true'`, and leaves it clear
+                // only when the attribute is absent entirely. Game data sends `checked=''` for a
+                // ticked box, which is why reading the value would invert half of them.
+                checked = element.attributes.containsKey("checked"),
+                checkedValue = checkedValue,
+                uncheckedValue = uncheckedValue,
+                tooltip = element.attributes["tooltip"],
+                left = element.attributes["left"]?.let { parseDistance(it) },
+                top = element.attributes["top"]?.let { parseDistance(it) },
+                width = element.attributes["width"]?.let { parseDistance(it) },
+                height = element.attributes["height"]?.let { parseDistance(it) },
+                align = element.attributes["align"],
+                topAnchor = element.attributes["anchor_top"],
+                leftAnchor = element.attributes["anchor_left"],
+            ),
+        )
+    }
+}

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/CloseButtonHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/CloseButtonHandler.kt
@@ -1,0 +1,35 @@
+package warlockfe.warlock3.wrayth.protocol.elements
+
+import warlockfe.warlock3.core.client.PanelObject
+import warlockfe.warlock3.wrayth.protocol.BaseElementListener
+import warlockfe.warlock3.wrayth.protocol.StartElement
+import warlockfe.warlock3.wrayth.protocol.WraythDialogObjectEvent
+import warlockfe.warlock3.wrayth.protocol.WraythEvent
+import warlockfe.warlock3.wrayth.util.parseDistance
+
+class CloseButtonHandler : BaseElementListener() {
+    override fun startElement(element: StartElement): WraythEvent? {
+        val id = element.attributes["id"] ?: return null
+        // The caption is the whole button: the real client draws nothing for a close button with no
+        // `value`, not even an empty frame at the size the wire asked for. There is no "Close"
+        // fallback.
+        if (element.attributes["value"] == null) return null
+        return WraythDialogObjectEvent(
+            PanelObject.Button(
+                id = id,
+                value = element.attributes["value"],
+                cmd = element.attributes["cmd"],
+                closesPanel = true,
+                tooltip = element.attributes["tooltip"],
+                echo = element.attributes["echo"],
+                left = element.attributes["left"]?.let { parseDistance(it) },
+                top = element.attributes["top"]?.let { parseDistance(it) },
+                width = element.attributes["width"]?.let { parseDistance(it) },
+                height = element.attributes["height"]?.let { parseDistance(it) },
+                align = element.attributes["align"],
+                topAnchor = element.attributes["anchor_top"],
+                leftAnchor = element.attributes["anchor_left"],
+            ),
+        )
+    }
+}

--- a/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
+++ b/wrayth/src/commonTest/kotlin/WraythProtocolHandlerTests.kt
@@ -9,6 +9,8 @@ import warlockfe.warlock3.wrayth.protocol.WraythUnhandledTagEvent
 import warlockfe.warlock3.wrayth.util.WraythDialogWindow
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class WraythProtocolHandlerTests {
     @Test
@@ -195,6 +197,81 @@ class WraythProtocolHandlerTests {
         // Wrayth's string-to-number conversion yields no horizontal bits here, so it draws left.
         // Real game data only ever sends numbers; this pins the edge to what the client does.
         assertEquals(PanelJustify.Left, parseLabelJustify("right"))
+    }
+
+    private fun panelObjects(line: String): List<PanelObject> =
+        WraythProtocolHandler()
+            .parseLine(line)
+            .filterIsInstance<WraythDialogObjectEvent>()
+            .mapNotNull { it.data }
+
+    @Test
+    fun checkBoxCarriesTheValueAnotherWidgetSubstitutes() {
+        // Straight off the wire, from a real combat panel.
+        val box =
+            parsePanelObject<PanelObject.CheckBox>(
+                "<checkBox id='chkBoxCmbtpnl12' checked_value=\"on\" unchecked_value=\"off\" checked=\"\" " +
+                    "text=\"quickstrike control group\" top='314' left='10' width='180' height='20' " +
+                    "skin='check' align='nw'/>",
+            )
+        assertEquals("chkBoxCmbtpnl12", box.id)
+        assertEquals("quickstrike control group", box.text)
+        assertEquals("on", box.checkedValue)
+        assertEquals("off", box.uncheckedValue)
+    }
+
+    @Test
+    fun checkBoxIsCheckedByThePresenceOfTheAttribute() {
+        // `checked` is presence-based, not a boolean: the real client ticks the box for every one of
+        // these and leaves it clear only when the attribute is absent. Read off the screen for each.
+        listOf("checked=''", "checked='off'", "checked='false'", "checked='0'", "checked='true'")
+            .forEach { attr ->
+                val box =
+                    parsePanelObject<PanelObject.CheckBox>(
+                        "<checkBox id='c' checked_value='on' unchecked_value='off' text='t' $attr/>",
+                    )
+                assertTrue(box.checked, "$attr should read as checked")
+            }
+        val absent =
+            parsePanelObject<PanelObject.CheckBox>(
+                "<checkBox id='c' checked_value='on' unchecked_value='off' text='t'/>",
+            )
+        assertFalse(absent.checked, "no attribute at all is the only unchecked state")
+    }
+
+    @Test
+    fun checkBoxWithoutBothValuesIsDropped() {
+        // The real client draws nothing for these - not an empty box, and no width either - because
+        // a checkbox with no values has nothing to hand the command that reads it.
+        listOf(
+            "<checkBox id='c' text='t' checked=''/>",
+            "<checkBox id='c' checked_value='on' text='t' checked=''/>",
+            "<checkBox id='c' unchecked_value='off' text='t' checked=''/>",
+        ).forEach { line ->
+            assertEquals(emptyList(), panelObjects(line), "should be dropped: $line")
+        }
+    }
+
+    @Test
+    fun closeButtonIsACommandButtonThatAlsoCloses() {
+        val button =
+            parsePanelObject<PanelObject.Button>("<closeButton id='b' value='Done' cmd='saybye'/>")
+        assertEquals("Done", button.value)
+        assertEquals("saybye", button.cmd)
+        assertTrue(button.closesPanel)
+        // A cmdButton is the same widget without the closing half.
+        val cmd = parsePanelObject<PanelObject.Button>("<cmdButton id='b' value='Go' cmd='go'/>")
+        assertFalse(cmd.closesPanel)
+    }
+
+    @Test
+    fun closeButtonWithoutACaptionIsDropped() {
+        // There is no "Close" fallback: the real client draws nothing at all for a close button with
+        // no value, even one given an explicit width and height.
+        assertEquals(
+            emptyList(),
+            panelObjects("<closeButton id='b' cmd='saybye' width='80' height='26'/>"),
+        )
     }
 
     @Test


### PR DESCRIPTION
Both were registered as `IgnoredTagHandler`, so a server-driven form using them rendered incomplete: the widgets were dropped, and a `cmdButton` reading them substituted nothing.

Semantics come from `wrayth-lab` rather than from a widget list, because the two disagree in three places.

### checkBox

**It renders only when both `checked_value` and `unchecked_value` are present.** Without them the real client draws nothing at all - no box, and no width either. This is why it first looked as though Wrayth had no checkbox support: my probes had neither attribute. `skin` and `align` turned out to be irrelevant, which I isolated separately.

**`checked` is presence-based, not a boolean.** The client ticks the box for `checked=''`, `checked='off'`, `checked='0'` and `checked='false'` alike, and leaves it clear only when the attribute is absent entirely:

```
checked=''       -> ticked        checked='false' -> ticked
checked='off'    -> ticked        checked='true'  -> ticked
checked='0'      -> ticked        (absent)        -> clear
```

Game data sends `checked=""` for a ticked box, so reading the value would invert half of them.

**Toggling sends nothing.** A checkbox only holds a value for another widget's command to pick up as `%<id>%`. Clicking one carrying a `cmd` left the socket silent, while a button beside it on `sent %cb%` received the toggled value:

```
unchecked -> sent OFF
checked   -> sent ON
```

### closeButton

A command button that also dismisses its panel, sending the command first. Its caption is `value`, with **no "Close" fallback** - one without a value draws nothing even given an explicit width and height. On a resident panel the real client refuses the close and reports `_error Cannot close a resident dialog (combat)`.

Closing routes through the same path as the window's own close button, so the panel is remembered hidden and the game cannot reopen it unasked. Panel content drawn as chrome (the status bar's vitals) passes a null panel id, having no panel to dismiss.

### Testing

Five tests covering both widgets and the two drop cases. Verified in our own client against the same fragments: both checkboxes match the real client's tick state (`toggleableState: "On"` / `"Off"`), the `Done` close button is present, and there is no node at all for the valueless one.

`check -PiosSkip=true -PlintSkip=true` is green.

### Note

While probing, `radio` renders nothing in the real client either - even with `checked_value`/`unchecked_value`. We already ship a radio renderer, so we draw a control the reference client never shows. Left alone here.

One of three panel branches in flight. Independent of `panel-update-in-place`. Shares `WraythProtocolHandlerTests.kt` with `dropdown-selected-option`, where both add tests at the same point - whichever merges second will need a trivial adjacent-insert resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive checkboxes with synchronized state and checked/unchecked values.
  * Added close buttons that execute their commands and dismiss the associated panel.
* **Bug Fixes**
  * Panels now close reliably without unexpectedly reopening.
  * Improved checkbox updates from server-provided changes.
  * Invalid checkbox and close-button elements are ignored.
* **Tests**
  * Added coverage for checkbox parsing, state synchronization, and panel-closing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->