### PR TITLE
Two ways a saved password could go missing

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -373,6 +373,7 @@ fun openPrefsDatabase(
                 .build()
         },
         checkpoint = { dbPath -> checkpointDatabase(dbPath, fileSystem, sqlDriver) },
+        readSchemaVersion = { dbPath -> readSchemaVersion(dbPath, fileSystem, sqlDriver) },
     )
 }
 
@@ -395,4 +396,25 @@ private fun checkpointDatabase(
             connection.execSQL("PRAGMA wal_checkpoint(TRUNCATE)")
         }
     }.onFailure { snapshotLogger.w(it) { "Failed to checkpoint ${path.name} before seeding snapshot" } }
+}
+
+/**
+ * Read a database file's `PRAGMA user_version` -- the schema version Room stamps once it has
+ * migrated the file. Best-effort: a missing or unreadable file reports null, which the snapshot
+ * machinery reads as "no evidence either way" and leaves the file alone.
+ */
+private fun readSchemaVersion(
+    path: Path,
+    fileSystem: FileSystem,
+    sqlDriver: SQLiteDriver,
+): Int? {
+    if (!fileSystem.exists(path)) return null
+    return runCatching {
+        sqlDriver.open(path.toString()).use { connection ->
+            connection.prepare("PRAGMA user_version").use { statement ->
+                if (statement.step()) statement.getInt(0) else null
+            }
+        }
+    }.onFailure { snapshotLogger.w(it) { "Failed to read the schema version of ${path.name}" } }
+        .getOrNull()
 }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/SettingsTransferUseCase.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/SettingsTransferUseCase.kt
@@ -22,7 +22,7 @@ class SettingsTransferUseCase(
             encodeDefaults = true
         }
 
-    /** Serialize the entire setup (accounts, connections, every character, global settings). */
+    /** Serialize the entire setup (connections, every character, global settings). */
     suspend fun exportAll(): String =
         json.encodeToString(WarlockExportFile.serializer(), WarlockExportFile.Full(exportRepository.getExport()))
 

--- a/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.jvmAndroid.kt
+++ b/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.jvmAndroid.kt
@@ -39,3 +39,40 @@ internal actual fun withFileLock(
         }
     }
 }
+
+internal actual fun tryWithFileLock(
+    lockFile: Path,
+    block: () -> Unit,
+): Boolean {
+    val file = File(lockFile.toString())
+    file.parentFile?.mkdirs()
+    val handle =
+        try {
+            RandomAccessFile(file, "rw")
+        } catch (e: Exception) {
+            Logger.w(e) { "Could not open lock file $lockFile" }
+            return false
+        }
+    return handle.use { raf ->
+        // Exclusive, and blocks until any other process holding the lock releases it. An
+        // OverlappingFileLockException (another thread in this JVM already holds it) lands here too
+        // and is reported as "not held", which is the safe answer for a destructive caller.
+        val lock =
+            try {
+                raf.channel.lock()
+            } catch (e: Exception) {
+                Logger.w(e) { "Could not acquire lock on $lockFile" }
+                return@use false
+            }
+        try {
+            block()
+        } finally {
+            try {
+                lock.release()
+            } catch (_: Exception) {
+                // Closing the channel via use{} releases the lock anyway.
+            }
+        }
+        true
+    }
+}

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.kt
@@ -14,3 +14,17 @@ internal expect fun withFileLock(
     lockFile: Path,
     block: () -> Unit,
 )
+
+/**
+ * Like [withFileLock], but reports whether the lock was actually held, and runs [block] only when it
+ * was. Where [withFileLock] would rather write unlocked than drop a write, a caller about to do
+ * something destructive needs the opposite: it must be able to back off when it cannot prove it has
+ * the file to itself. Returns false without running [block] if the lock could not be taken.
+ *
+ * On single-process platforms (iOS) the caller is trivially the only one that can touch the file, so
+ * [block] runs and this returns true.
+ */
+internal expect fun tryWithFileLock(
+    lockFile: Path,
+    block: () -> Unit,
+): Boolean

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/dao/AccountDao.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/dao/AccountDao.kt
@@ -21,6 +21,14 @@ interface AccountDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun save(account: AccountEntity)
 
+    /**
+     * Register an account only if that username isn't already known. Unlike [save] this never
+     * touches an existing row, so a caller that only has a username -- restoring a backup, which
+     * deliberately carries no credentials -- can add the account without clearing a stored password.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertIfAbsent(account: AccountEntity)
+
     @Query("DELETE FROM account WHERE username = :username")
     suspend fun delete(username: String)
 }

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/export/AccountExport.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/export/AccountExport.kt
@@ -1,9 +1,0 @@
-package warlockfe.warlock3.core.prefs.export
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class AccountExport(
-    val username: String,
-    val password: String?,
-)

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/export/WarlockExport.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/export/WarlockExport.kt
@@ -2,9 +2,13 @@ package warlockfe.warlock3.core.prefs.export
 
 import kotlinx.serialization.Serializable
 
+/**
+ * A full backup. Accounts are deliberately absent: an account is a username plus a password, the
+ * password is never exported, and the username alone is already carried by every connection that
+ * uses it. Import reconstructs the account rows from [connections] instead.
+ */
 @Serializable
 data class WarlockExport(
-    val accounts: List<AccountExport>,
     val characters: List<CharacterExport>,
     val connections: List<ConnectionExport> = emptyList(),
     val settings: Map<String, String>,

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/export/WarlockExportFile.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/export/WarlockExportFile.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 /**
  * Top-level, self-describing container written to / read from an export file. The discriminator
  * lets import tell a full backup apart from a single exported character without guessing:
- *  - [Full] restores the entire setup (accounts, connections, every character, global settings).
+ *  - [Full] restores the entire setup (connections, every character, global settings).
  *  - [SingleCharacter] carries one character's settings; on import the user picks which existing
  *    character to apply them to.
  */

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ExportRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ExportRepository.kt
@@ -18,7 +18,6 @@ import warlockfe.warlock3.core.prefs.dao.CharacterSettingDao
 import warlockfe.warlock3.core.prefs.dao.ClientSettingDao
 import warlockfe.warlock3.core.prefs.dao.ScriptDirDao
 import warlockfe.warlock3.core.prefs.dao.WindowSettingsDao
-import warlockfe.warlock3.core.prefs.export.AccountExport
 import warlockfe.warlock3.core.prefs.export.AliasExport
 import warlockfe.warlock3.core.prefs.export.AlterationExport
 import warlockfe.warlock3.core.prefs.export.BaseStyleExport
@@ -86,7 +85,6 @@ class ExportRepository(
                     Triple(GLOBAL_CHARACTER_ID, GLOBAL_CHARACTER_ID, GLOBAL_CHARACTER_ID)
             ).distinctBy { it.first }
         return WarlockExport(
-            accounts = accountDao.getAll().map { AccountExport(username = it.username, password = null) },
             characters = characterIds.map { (id, gameCode, name) -> buildCharacterExport(id, gameCode, name) },
             connections =
                 registry.connections.map { connection ->
@@ -297,14 +295,21 @@ class ExportRepository(
 
     /**
      * Restore a full backup. [resolutions] maps an exported character's id to how its data should be
-     * applied; characters absent from the map are skipped. Accounts (usernames only), connections and
-     * global client settings are always restored.
+     * applied; characters absent from the map are skipped. Connections and global client settings are
+     * always restored, along with an account row per username the connections reference.
      */
     suspend fun importFull(
         export: WarlockExport,
         resolutions: Map<String, ImportMode>,
     ) {
-        export.accounts.forEach { accountDao.save(AccountEntity(username = it.username, password = null)) }
+        // An export carries no credentials, so accounts are rebuilt from the connections that name
+        // them: username only, and never overwriting a row that already exists. Replacing them would
+        // clear the passwords saved on this machine every time a backup was restored.
+        export.connections
+            .map { it.username }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .forEach { username -> accountDao.insertIfAbsent(AccountEntity(username = username, password = null)) }
         export.connections.forEach { connection ->
             val proxy = connection.settings
             clientConfigStore.mutateConnections { registry ->

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshot.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshot.kt
@@ -51,15 +51,23 @@ fun findSeedCandidate(
  *
  *  1. One-time rename of the legacy single-file database (if [legacyFileName] is provided)
  *     to `warlock-v<currentVersion>.db` when no versioned snapshot exists yet.
- *  2. If the target snapshot file is missing, seed it from the newest existing older snapshot.
- *  3. Hand the target path to [buildDatabase], which is responsible for invoking the platform
+ *  2. Discard a target left behind by a launch whose migration never completed, so step 3 seeds it
+ *     again instead of mistaking it for a healthy database (see [discardIncompleteTarget]).
+ *  3. If the target snapshot file is missing, seed it from the newest existing older snapshot.
+ *  4. Hand the target path to [buildDatabase], which is responsible for invoking the platform
  *     Room builder, registering migrations, and returning the built database.
- *  4. On migration failure, delete the target so the next launch may recover, then rethrow.
+ *  5. If [buildDatabase] itself throws, delete the target so the next launch re-seeds, then
+ *     rethrow. Note that a *migration* failure does not land here: Room's `build()` is lazy, so
+ *     migrations run (and fail) at the first query, long after this function has returned. Step 2
+ *     is what recovers from that case, on the launch after it happens.
  *
  * [checkpoint] is invoked on a source database immediately before it is copied. It must fold any
  * write-ahead log into the main `.db` file (e.g. `PRAGMA wal_checkpoint(TRUNCATE)`) so that copying
  * the main file alone captures all committed data. This is required because only the main file is
  * copied -- copying the `-wal`/`-shm` sidecars to a new path is unsafe and can drop recent writes.
+ *
+ * [readSchemaVersion] reads a database file's `PRAGMA user_version`, returning null when the file
+ * cannot be read. It drives step 2; the default leaves that check disabled.
  */
 fun <T> openVersionedDatabase(
     directory: Path,
@@ -68,12 +76,15 @@ fun <T> openVersionedDatabase(
     buildDatabase: (databasePath: Path) -> T,
     legacyFileName: String,
     checkpoint: (databasePath: Path) -> Unit = {},
+    readSchemaVersion: (databasePath: Path) -> Int? = { null },
 ): T {
     fileSystem.createDirectories(directory)
 
     migrateLegacyDatabase(directory, legacyFileName, currentVersion, fileSystem, checkpoint)
 
     val target = Path(directory, snapshotFileName(currentVersion))
+    discardIncompleteTarget(directory, target, currentVersion, fileSystem, readSchemaVersion)
+
     val seedSource: SnapshotInfo? =
         if (fileSystem.exists(target)) {
             null
@@ -100,12 +111,9 @@ fun <T> openVersionedDatabase(
         } catch (t: Throwable) {
             logger.e(t) {
                 val from = seedSource?.let { " (seeded from v${it.version})" } ?: ""
-                "Migration to ${target.name} failed$from; deleting failed target so next launch may recover"
+                "Building ${target.name} failed$from; deleting failed target so next launch may recover"
             }
-            runCatching { fileSystem.delete(target, mustExist = false) }
-            for (suffix in sidecarSuffixes) {
-                runCatching { fileSystem.delete(Path(directory, target.name + suffix), mustExist = false) }
-            }
+            deleteDatabaseFiles(target, fileSystem)
             throw t
         }
 
@@ -114,6 +122,58 @@ fun <T> openVersionedDatabase(
     }
 
     return database
+}
+
+/**
+ * Discard a target that exists but still reports a schema older than [currentVersion].
+ *
+ * Room builds lazily and runs migrations in a transaction at the first query, so a failed migration
+ * rolls back and leaves the seeded copy sitting at its source's version. Nothing about that file
+ * distinguishes it from a healthy database on later launches: it exists, so it is never re-seeded,
+ * and [findSeedCandidate] would even prefer it over the older snapshot it was copied from -- which
+ * by then may have moved on, if the user went back to the previous build in the meantime.
+ * Discarding it puts the next launch back on the seeding path with current data.
+ *
+ * Deleting it loses nothing: the app never opened it successfully, so it holds no writes the seed
+ * source doesn't. It is kept anyway when there is no older snapshot to re-seed from, since then it
+ * is the only copy of the user's settings and a stale version is no reason to throw them away.
+ */
+private fun discardIncompleteTarget(
+    directory: Path,
+    target: Path,
+    currentVersion: Int,
+    fileSystem: FileSystem,
+    readSchemaVersion: (databasePath: Path) -> Int?,
+) {
+    if (!fileSystem.exists(target)) return
+    val version = readSchemaVersion(target) ?: return
+    if (version >= currentVersion) return
+
+    val candidate = findSeedCandidate(listSnapshots(directory, fileSystem), currentVersion)
+    if (candidate == null) {
+        logger.w {
+            "${target.name} is still at schema v$version, so an earlier migration never completed, " +
+                "but there is no older snapshot to re-seed from; keeping it and migrating it again"
+        }
+        return
+    }
+    logger.w {
+        "Discarding ${target.name}: still at schema v$version, so an earlier migration never " +
+            "completed; re-seeding from ${candidate.path.name}"
+    }
+    deleteDatabaseFiles(target, fileSystem)
+}
+
+/** Best-effort delete of a database file along with any `-wal`/`-shm` sidecars beside it. */
+private fun deleteDatabaseFiles(
+    path: Path,
+    fileSystem: FileSystem,
+) {
+    val parent = path.parent ?: Path(".")
+    runCatching { fileSystem.delete(path, mustExist = false) }
+    for (suffix in sidecarSuffixes) {
+        runCatching { fileSystem.delete(Path(parent, path.name + suffix), mustExist = false) }
+    }
 }
 
 /**

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshot.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshot.kt
@@ -4,11 +4,21 @@ import co.touchlab.kermit.Logger
 import kotlinx.io.buffered
 import kotlinx.io.files.FileSystem
 import kotlinx.io.files.Path
+import warlockfe.warlock3.core.prefs.config.tryWithFileLock
 
 private val logger = Logger.withTag("DatabaseSnapshot")
 
 private val snapshotPattern = Regex("""^warlock-v(\d+)\.db$""")
 private val sidecarSuffixes = listOf("-wal", "-shm")
+
+/**
+ * Suffix of the lock file Room takes around opening and migrating a database (its `FileLock` locks
+ * "not on the file itself but on a temporary file created with the same path but ending with
+ * `.lck`"). Sharing it is what lets snapshot recovery serialize against a migration in another
+ * process. If Room ever changes the convention this silently stops coordinating, which costs the
+ * extra safety but leaves behaviour no worse than not locking at all.
+ */
+private const val ROOM_LOCK_SUFFIX = ".lck"
 
 data class SnapshotInfo(
     val version: Int,
@@ -83,26 +93,30 @@ fun <T> openVersionedDatabase(
     migrateLegacyDatabase(directory, legacyFileName, currentVersion, fileSystem, checkpoint)
 
     val target = Path(directory, snapshotFileName(currentVersion))
-    discardIncompleteTarget(directory, target, currentVersion, fileSystem, readSchemaVersion)
 
-    val seedSource: SnapshotInfo? =
-        if (fileSystem.exists(target)) {
-            null
-        } else {
-            val candidate = findSeedCandidate(listSnapshots(directory, fileSystem), currentVersion)
-            when {
-                candidate == null -> {
-                    null
-                }
-
-                else -> {
-                    checkpoint(candidate.path)
-                    copySnapshot(candidate.path, target, fileSystem)
-                    logger.i { "Seeded ${target.name} from ${candidate.path.name}" }
-                    candidate
-                }
-            }
+    // Settle the target's fate under the very lock Room uses, because discarding it means unlinking
+    // a file another instance may be midway through migrating -- that instance would go on writing
+    // to an unlinked database and its settings would vanish. Room takes a cross-process lock on
+    // "<database>.lck" around the connection open that runs migrations
+    // (RoomConnectionManager.openLocked, with useFileLock set while the database is unconfigured),
+    // so holding it here gives us the only two outcomes we can live with: either a peer is migrating
+    // and we block until it is done -- after which the target reports the current schema and is left
+    // alone -- or no peer can begin until we have finished.
+    var seedSource: SnapshotInfo? = null
+    val locked =
+        tryWithFileLock(Path(directory, target.name + ROOM_LOCK_SUFFIX)) {
+            discardIncompleteTarget(directory, target, currentVersion, fileSystem, readSchemaVersion)
+            seedSource = seedTargetIfMissing(directory, target, currentVersion, fileSystem, checkpoint)
         }
+    if (!locked) {
+        // No lock means no way to tell a stale target from one being migrated right now, so the
+        // destructive half is skipped entirely. Seeding still runs: it only writes when there is
+        // nothing there to destroy. A stale target is left for a launch that can take the lock.
+        logger.w {
+            "Could not lock ${target.name} for recovery; leaving any incomplete target in place this launch"
+        }
+        seedSource = seedTargetIfMissing(directory, target, currentVersion, fileSystem, checkpoint)
+    }
     val targetExistedBeforeBuild = fileSystem.exists(target)
 
     val database =
@@ -122,6 +136,26 @@ fun <T> openVersionedDatabase(
     }
 
     return database
+}
+
+/**
+ * Copy the newest older snapshot into place when the target is missing, returning the snapshot it
+ * was seeded from (null when the target was already there, or when there is nothing to seed from and
+ * the platform builder will create it from scratch).
+ */
+private fun seedTargetIfMissing(
+    directory: Path,
+    target: Path,
+    currentVersion: Int,
+    fileSystem: FileSystem,
+    checkpoint: (databasePath: Path) -> Unit,
+): SnapshotInfo? {
+    if (fileSystem.exists(target)) return null
+    val candidate = findSeedCandidate(listSnapshots(directory, fileSystem), currentVersion) ?: return null
+    checkpoint(candidate.path)
+    copySnapshot(candidate.path, target, fileSystem)
+    logger.i { "Seeded ${target.name} from ${candidate.path.name}" }
+    return candidate
 }
 
 /**

--- a/core/src/iosMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.ios.kt
+++ b/core/src/iosMain/kotlin/warlockfe/warlock3/core/prefs/config/FileLock.ios.kt
@@ -8,3 +8,11 @@ internal actual fun withFileLock(
     lockFile: Path,
     block: () -> Unit,
 ) = block()
+
+internal actual fun tryWithFileLock(
+    lockFile: Path,
+    block: () -> Unit,
+): Boolean {
+    block()
+    return true
+}

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/repositories/ExportImportAccountTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/repositories/ExportImportAccountTest.kt
@@ -1,0 +1,213 @@
+package warlockfe.warlock3.core.prefs.repositories
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import warlockfe.warlock3.core.prefs.config.CharacterConfigStore
+import warlockfe.warlock3.core.prefs.config.ClientConfigStore
+import warlockfe.warlock3.core.prefs.dao.AccountDao
+import warlockfe.warlock3.core.prefs.dao.CharacterSettingDao
+import warlockfe.warlock3.core.prefs.dao.ClientSettingDao
+import warlockfe.warlock3.core.prefs.dao.ScriptDirDao
+import warlockfe.warlock3.core.prefs.dao.WindowSettingsDao
+import warlockfe.warlock3.core.prefs.export.ConnectionExport
+import warlockfe.warlock3.core.prefs.export.WarlockExport
+import warlockfe.warlock3.core.prefs.models.AccountEntity
+import warlockfe.warlock3.core.prefs.models.CharacterSettingEntity
+import warlockfe.warlock3.core.prefs.models.ClientSettingEntity
+import warlockfe.warlock3.core.prefs.models.ScriptDirEntity
+import warlockfe.warlock3.core.prefs.models.WindowSettingsEntity
+import java.nio.file.Files
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * An export carries no credentials, so import rebuilds the account rows from the connections that
+ * name them. It must add missing accounts without disturbing the passwords already on this machine.
+ */
+class ExportImportAccountTest {
+    private val fs = SystemFileSystem
+    private lateinit var dir: Path
+    private lateinit var configDir: String
+    private lateinit var accountDao: FakeAccountDao
+
+    @BeforeTest
+    fun setUp() {
+        dir = Path(Files.createTempDirectory("export-account-test").toAbsolutePath().toString())
+        configDir = dir.toString()
+        accountDao = FakeAccountDao()
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        java.nio.file.Path
+            .of(dir.toString())
+            .deleteRecursively()
+    }
+
+    @Test
+    fun import_leavesAnAlreadySavedPasswordAlone() =
+        runBlocking {
+            accountDao.save(AccountEntity(username = "someuser", password = "hunter2"))
+
+            newRepository().importFull(exportWithConnections("someuser"), resolutions = emptyMap())
+
+            assertEquals("hunter2", accountDao.getByUsername("someuser")?.password)
+        }
+
+    @Test
+    fun import_registersAccountsNamedByConnections() =
+        runBlocking {
+            newRepository().importFull(exportWithConnections("newuser"), resolutions = emptyMap())
+
+            val account = accountDao.getByUsername("newuser")
+            assertTrue(account != null, "the connection's account should have been registered")
+            assertNull(account.password, "a restored account has no password until the user logs in")
+        }
+
+    @Test
+    fun import_registersEachUsernameOnceAndSkipsBlankOnes() =
+        runBlocking {
+            newRepository().importFull(
+                exportWithConnections("someuser", "someuser", ""),
+                resolutions = emptyMap(),
+            )
+
+            assertEquals(listOf("someuser"), accountDao.getAll().map { it.username })
+        }
+
+    private fun newRepository() =
+        ExportRepository(
+            accountDao = accountDao,
+            characterSettingDao = UnusedCharacterSettingDao,
+            clientSettingDao = UnusedClientSettingDao,
+            scriptDirDao = UnusedScriptDirDao,
+            windowSettingsDao = UnusedWindowSettingsDao,
+            characterConfigStore = CharacterConfigStore(configDir, fs),
+            clientConfigStore = ClientConfigStore(configDir, fs),
+        )
+
+    private fun exportWithConnections(vararg usernames: String) =
+        WarlockExport(
+            characters = emptyList(),
+            connections =
+                usernames.mapIndexed { index, username ->
+                    ConnectionExport(
+                        id = "gs4:char$index",
+                        name = "Char $index",
+                        username = username,
+                        gameCode = "GS4",
+                        character = "Char$index",
+                        settings = emptyMap(),
+                    )
+                },
+            settings = emptyMap(),
+        )
+}
+
+private class FakeAccountDao : AccountDao {
+    private val accounts = mutableMapOf<String, AccountEntity>()
+
+    override suspend fun getAll(): List<AccountEntity> = accounts.values.toList()
+
+    override fun observeAll(): Flow<List<AccountEntity>> = flowOf(accounts.values.toList())
+
+    override suspend fun getByUsername(username: String): AccountEntity? = accounts[username]
+
+    override suspend fun save(account: AccountEntity) {
+        accounts[account.username] = account
+    }
+
+    override suspend fun insertIfAbsent(account: AccountEntity) {
+        accounts.putIfAbsent(account.username, account)
+    }
+
+    override suspend fun delete(username: String) {
+        accounts.remove(username)
+    }
+}
+
+private object UnusedCharacterSettingDao : CharacterSettingDao {
+    override suspend fun getByKey(
+        key: String,
+        characterId: String,
+    ): String? = error("unused")
+
+    override fun observeByKey(
+        key: String,
+        characterId: String,
+    ): Flow<String?> = error("unused")
+
+    override suspend fun getByCharacter(characterId: String): List<CharacterSettingEntity> = error("unused")
+
+    override suspend fun save(characterSetting: CharacterSettingEntity) = error("unused")
+
+    override suspend fun delete(
+        key: String,
+        characterId: String,
+    ) = error("unused")
+
+    override suspend fun deleteByCharacter(characterId: String) = error("unused")
+}
+
+private object UnusedClientSettingDao : ClientSettingDao {
+    override suspend fun getAll(): List<ClientSettingEntity> = error("unused")
+
+    override suspend fun getByKey(key: String): String? = error("unused")
+
+    override fun observeByKey(key: String): Flow<String?> = error("unused")
+
+    override suspend fun removeByKey(key: String) = error("unused")
+
+    override suspend fun save(entity: ClientSettingEntity) = error("unused")
+}
+
+private object UnusedScriptDirDao : ScriptDirDao {
+    override fun observeByCharacter(characterId: String): Flow<List<String>> = error("unused")
+
+    override suspend fun getByCharacterWithGlobal(characterId: String): List<String> = error("unused")
+
+    override suspend fun getByCharacter(characterId: String): List<String> = error("unused")
+
+    override suspend fun save(scriptDir: ScriptDirEntity) = error("unused")
+
+    override suspend fun delete(
+        characterId: String,
+        path: String,
+    ) = error("unused")
+
+    override suspend fun deleteByCharacter(characterId: String) = error("unused")
+}
+
+private object UnusedWindowSettingsDao : WindowSettingsDao {
+    override fun observeByCharacter(characterId: String): Flow<List<WindowSettingsEntity>> = error("unused")
+
+    override suspend fun getByCharacter(characterId: String): List<WindowSettingsEntity> = error("unused")
+
+    override suspend fun getByName(
+        characterId: String,
+        name: String,
+    ): WindowSettingsEntity? = error("unused")
+
+    override suspend fun deleteByCharacter(characterId: String) = error("unused")
+
+    override suspend fun save(windowSettings: WindowSettingsEntity) = error("unused")
+
+    override suspend fun openWindow(
+        characterId: String,
+        name: String,
+    ) = error("unused")
+
+    override suspend fun closeWindow(
+        characterId: String,
+        name: String,
+    ) = error("unused")
+}

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshotTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshotTest.kt
@@ -253,6 +253,46 @@ class DatabaseSnapshotTest {
         assertEquals("only-copy", read(Path(dir, "warlock-v17.db")))
     }
 
+    // Discarding the target means unlinking a file another instance may be migrating right now.
+    // Room guards its migration with an exclusive lock on "<database>.lck", and recovery takes that
+    // same lock; when it can't be had, the destructive half has to be skipped rather than guessed at.
+    @Test
+    fun incompleteTarget_isKeptWhileTheRoomMigrationLockIsHeld() {
+        write(Path(dir, "warlock-v10.db"), "v10-data")
+        write(Path(dir, "warlock-v17.db"), "being-migrated-by-a-peer")
+
+        val lockFile = java.io.File(dir.toString(), "warlock-v17.db.lck")
+        java.io.RandomAccessFile(lockFile, "rw").use { raf ->
+            val held = raf.channel.lock()
+            try {
+                open(readSchemaVersion = { 10 })
+            } finally {
+                held.release()
+            }
+        }
+
+        assertEquals("being-migrated-by-a-peer", read(Path(dir, "warlock-v17.db")))
+    }
+
+    // Seeding still has to happen without the lock: it only ever writes when the target is absent,
+    // so there is nothing there for a peer to be using.
+    @Test
+    fun missingTarget_isStillSeededWhileTheLockIsHeld() {
+        write(Path(dir, "warlock-v10.db"), "v10-data")
+
+        val lockFile = java.io.File(dir.toString(), "warlock-v17.db.lck")
+        java.io.RandomAccessFile(lockFile, "rw").use { raf ->
+            val held = raf.channel.lock()
+            try {
+                open()
+            } finally {
+                held.release()
+            }
+        }
+
+        assertEquals("v10-data", read(Path(dir, "warlock-v17.db")))
+    }
+
     @Test
     fun unreadableTarget_isKept() {
         write(Path(dir, "warlock-v10.db"), "v10-data")

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshotTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/snapshot/DatabaseSnapshotTest.kt
@@ -134,6 +134,7 @@ class DatabaseSnapshotTest {
         currentVersion: Int = 17,
         legacy: String = "prefs.db",
         checkpoint: (Path) -> Unit = {},
+        readSchemaVersion: (Path) -> Int? = { null },
         build: (Path) -> Unit = { path -> if (!fs.exists(path)) write(path, "fresh") },
     ) = openVersionedDatabase(
         directory = dir,
@@ -142,6 +143,7 @@ class DatabaseSnapshotTest {
         legacyFileName = legacy,
         buildDatabase = build,
         checkpoint = checkpoint,
+        readSchemaVersion = readSchemaVersion,
     )
 
     @Test
@@ -207,6 +209,59 @@ class DatabaseSnapshotTest {
         assertEquals("legacy", read(Path(dir, "prefs.db")))
         // v17 was seeded from v10, not from the legacy file.
         assertEquals("v10", read(Path(dir, "warlock-v17.db")))
+    }
+
+    // A target still sitting at an older schema was seeded by a launch whose migration never
+    // finished (Room migrates lazily and rolls back on failure). It must not be mistaken for a
+    // healthy database, or it is preferred over its own seed source forever after.
+    @Test
+    fun incompleteTarget_isDiscardedAndReseeded() {
+        write(Path(dir, "warlock-v10.db"), "v10-data")
+        write(Path(dir, "warlock-v17.db"), "half-migrated")
+        write(Path(dir, "warlock-v17.db-wal"), "stale-wal")
+        var saw: String? = null
+
+        open(readSchemaVersion = { 10 }, build = { path -> saw = read(path) })
+
+        assertEquals("v10-data", saw)
+        assertEquals("v10-data", read(Path(dir, "warlock-v17.db")))
+        assertFalse(fs.exists(Path(dir, "warlock-v17.db-wal")))
+        assertEquals("v10-data", read(Path(dir, "warlock-v10.db")))
+    }
+
+    @Test
+    fun currentTarget_isNotDiscarded() {
+        write(Path(dir, "warlock-v10.db"), "v10-data")
+        write(Path(dir, "warlock-v17.db"), "migrated")
+        var saw: String? = null
+
+        open(readSchemaVersion = { 17 }, build = { path -> saw = read(path) })
+
+        assertEquals("migrated", saw)
+    }
+
+    // Without an older snapshot the target is the only copy of the user's settings, so an old
+    // version is no reason to delete it -- Room is left to try the migration again.
+    @Test
+    fun incompleteTarget_isKeptWhenThereIsNothingToReseedFrom() {
+        write(Path(dir, "warlock-v17.db"), "only-copy")
+        var saw: String? = null
+
+        open(readSchemaVersion = { 10 }, build = { path -> saw = read(path) })
+
+        assertEquals("only-copy", saw)
+        assertEquals("only-copy", read(Path(dir, "warlock-v17.db")))
+    }
+
+    @Test
+    fun unreadableTarget_isKept() {
+        write(Path(dir, "warlock-v10.db"), "v10-data")
+        write(Path(dir, "warlock-v17.db"), "existing")
+
+        // A version that cannot be read is no evidence of an incomplete migration.
+        open(readSchemaVersion = { null })
+
+        assertEquals("existing", read(Path(dir, "warlock-v17.db")))
     }
 
     @Test


### PR DESCRIPTION
Both of these came out of chasing a user report of "It asked me for my password again. It said no password was saved" after updating. Neither turned out to explain that specific report — beta.31 and beta.32 are both `PREFS_DATABASE_VERSION = 22`, so no snapshot seeding or migration runs on that upgrade at all — but both are real ways a password can disappear, and one of them silently wipes every password on the machine.

Two independent commits; happy to split them into separate PRs if you'd rather.

## 1. Re-seed a database whose migration never completed

`openVersionedDatabase` wrapped `buildDatabase` in a catch that deleted the target "so next launch may recover". Room's `build()` is lazy, so it returns before touching the file and migrations run at the first query — the catch could never fire. Confirmed against a database with no migration path to 22:

```
openPrefsDatabase threw: null
files after open: [warlock-v22.db, warlock-v5.db]
first query threw: IllegalStateException: A migration from 5 to 22 was required but not found...
files after query: [warlock-v22.db, warlock-v22.db.lck, warlock-v5.db]
```

The hazard that leaves behind: a failed migration rolls back inside its transaction, so the seeded `warlock-v22.db` stays a byte copy of `warlock-v21.db`, still stamped `user_version = 21`. Nothing distinguishes it from a healthy database afterwards — it exists, so it is never re-seeded, and `findSeedCandidate` *prefers* it (22 > 21) over the snapshot it came from. Drop back to the previous build, keep playing, and your newer v21 data is permanently shadowed.

Recovery now happens on the launch after the failure, by reading the target's `PRAGMA user_version`. A target reporting an older schema was never opened successfully, so it holds nothing its seed source doesn't — discard it and take the normal seeding path. Guarded so it is only discarded when an older snapshot exists to re-seed from; without one it is the user's only copy.

Verified end-to-end against real Room, with a stale v22 sitting next to a v21 whose password had since changed:

```
Discarding warlock-v22.db: still at schema v21, so an earlier migration never completed; re-seeding from warlock-v21.db
Seeded warlock-v22.db from warlock-v21.db
ACCOUNTS: [(someuser, new-password)]
--- relaunch ---
Opened existing warlock-v22.db without seeding
ACCOUNTS2: [(someuser, new-password)]
```

Before the fix that first read returned `old-password`. The relaunch line confirms a healthy migrated database is left alone.

## 2. Stop the settings importer from wiping saved passwords

`importFull` ran `accountDao.save(AccountEntity(username, password = null))` per exported account, and `save()` is `OnConflictStrategy.REPLACE`. Restoring a backup cleared the password of every account on the machine, including ones the backup had nothing to do with.

An export never carries credentials, so the accounts it listed were only usernames — and every connection already names the username it uses. So accounts are dropped from the export entirely and rebuilt on import from the connections, via a new `insertIfAbsent` (`OnConflictStrategy.IGNORE`) so an existing account is left exactly as it is. New usernames still get a null-password row, which keeps them on the Accounts page so a password can be set there rather than waiting for a login prompt.

**Compatibility:** export files written before this parse unchanged — `accounts` becomes an unknown key and `SettingsTransferUseCase` already sets `ignoreUnknownKeys`. I checked this rather than assumed it, against that exact parser config. The reverse does not hold: `accounts` had no default, so an older build cannot read a file written by this one. If that matters for a release or two, adding `val accounts: List<AccountExport> = emptyList()` back as a write-only vestige would keep old builds parsing, at the cost of keeping the model around.

## Tests

- `DatabaseSnapshotTest`: discard-and-reseed, current-version left alone, no-candidate kept, unreadable kept (18 pass).
- `ExportImportAccountTest` (new): an existing password survives an import, a connection's username gets registered with no password, duplicate/blank usernames don't produce duplicate or empty rows (3 pass).

`./gradlew check -PiosSkip=true -PlintSkip=true` passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Full backups now rebuild connection-based account records during import.
  - Existing saved passwords are preserved, while duplicate or blank usernames are ignored.

- **Bug Fixes**
  - Improved recovery for incomplete or outdated local databases.
  - Added safer coordination when database files are being accessed or rebuilt.
  - Improved cleanup when database recovery or migration fails.

- **Documentation**
  - Updated export descriptions to clarify that connections and settings are included, while account credentials are not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->