### PR TITLE
Tabs along the top, and a mark for windows busy out of sight

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
@@ -8,8 +8,10 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
@@ -37,6 +39,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
@@ -46,6 +49,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import warlockfe.warlock3.compose.ui.window.StreamWindowData
 import warlockfe.warlock3.compose.ui.window.WindowUiState
 import warlockfe.warlock3.core.window.WindowLocation
 import kotlin.time.Duration.Companion.seconds
@@ -185,6 +189,7 @@ fun rememberGameDockState(
     viewModel: GameViewModel,
     trailingActions: @Composable (state: DockState, window: OpenGameWindow) -> Unit,
     windowContent: @Composable (window: OpenGameWindow) -> Unit,
+    tabActions: @Composable (window: OpenGameWindow, hasUnreadText: Boolean) -> Unit = { _, _ -> },
 ): DockState {
     val main by viewModel.mainWindowUiState.collectAsState()
     val windows by viewModel.windowUiStates.collectAsState()
@@ -212,6 +217,7 @@ fun rememberGameDockState(
 
     val currentTrailingActions by rememberUpdatedState(trailingActions)
     val currentWindowContent by rememberUpdatedState(windowContent)
+    val currentTabActions by rememberUpdatedState(tabActions)
 
     val state =
         remember {
@@ -286,6 +292,13 @@ fun rememberGameDockState(
                 // tab is selected, which is the window they would have acted on anyway.
                 tabStripActions = {
                     windowsByName[name]?.let { currentTrailingActions(state, it) }
+                },
+                // Drawn inside the tab itself, for every tab rather than just the selected one:
+                // this is where a window that is out of sight says it has something to show.
+                tabActions = {
+                    windowsByName[name]?.let { window ->
+                        currentTabActions(window, rememberHasUnreadText(state, window))
+                    }
                 },
                 content = {
                     windowsByName[name]?.let { currentWindowContent(it) }
@@ -500,6 +513,71 @@ internal fun closeEmptyDetachedWindows(state: DockState) {
         .filter { window -> window.root?.dockableIds().isNullOrEmpty() }
         .forEach { state.closeWindow(it.id) }
 }
+
+/**
+ * Whether [window] has had text arrive while it was hidden behind another tab.
+ *
+ * The flag latches: it goes true on the first line that lands while the tab is in the background and
+ * stays true until the tab is shown again. That is what keeps a busy stream off the tab strip - the
+ * collector runs in a coroutine rather than as a composition read, so a window taking a hundred
+ * lines a second recomposes the strip once, when the flag first flips, rather than once a line.
+ *
+ * A window that is on screen is never unread, whether it is a lone pane, one of several in a split,
+ * or the selected tab of a group: the user can see it, so there is nothing to announce. Only a
+ * stream can be unread; a panel is a fixed layout of widgets with no text arriving behind it.
+ */
+@Composable
+internal fun rememberHasUnreadText(
+    state: DockState,
+    window: OpenGameWindow,
+): Boolean {
+    val stream = (window.uiState.data as? StreamWindowData)?.stream ?: return false
+    val hidden = isHiddenTab(state, window.name)
+    var unread by remember(stream) { mutableStateOf(false) }
+    LaunchedEffect(stream, hidden) {
+        if (!hidden) {
+            // On screen: anything that arrived while it was hidden has now been seen.
+            unread = false
+            return@LaunchedEffect
+        }
+        stream.lines
+            .map { lines -> lines.lastOrNull()?.serialNumber }
+            .distinctUntilChanged()
+            // The buffer as it stands when the tab goes into the background is not news; only what
+            // arrives after that is.
+            .drop(1)
+            .collect { unread = true }
+    }
+    return unread
+}
+
+/**
+ * Whether [name] is a tab with another tab in front of it - open, but with nothing of it on screen.
+ *
+ * Only a tab group can hide a window. A window sharing a split has neighbours but is still visible,
+ * and a lone one plainly is, so neither counts.
+ */
+internal fun isHiddenTab(
+    state: DockState,
+    name: String,
+): Boolean {
+    val id = DockableId(name)
+    val root =
+        state.layout.windows
+            .firstNotNullOfOrNull { window ->
+                (window.maximized?.savedRoot ?: window.root)?.takeIf { it.containsDockable(id) }
+            } ?: return false
+    val tabs = root.tabsContaining(id) ?: return false
+    return tabs.selectedTab.dockableId != id
+}
+
+/** The tab group [id] is in, or null when it is not tabbed with anything. */
+private fun DockNode.tabsContaining(id: DockableId): DockNode.Tabs? =
+    when (this) {
+        is DockNode.Tabs -> takeIf { tabs.any { tab -> tab.dockableId == id } }
+        is DockNode.Split -> first.tabsContaining(id) ?: second.tabsContaining(id)
+        is DockNode.Leaf, is DockNode.Anchor -> null
+    }
 
 /**
  * Tears [name] off into its own OS window. A no-op where the platform has no floating windows, or

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
@@ -21,6 +21,7 @@ import com.seanproctor.docking.model.DockRegion
 import com.seanproctor.docking.model.DockableId
 import com.seanproctor.docking.model.DockableOptions
 import com.seanproctor.docking.model.SplitOrientation
+import com.seanproctor.docking.model.TabPreference
 import com.seanproctor.docking.model.WindowId
 import com.seanproctor.docking.persistence.DockingPersistence
 import com.seanproctor.docking.persistence.captureLayout
@@ -224,6 +225,12 @@ fun rememberGameDockState(
                     DockingSettings(
                         collapsedAnchorThickness = EMPTY_AREA_STRIP,
                         emptyAnchorVisibility = EmptyAnchorVisibility.WhileDragging,
+                        // Tabbed windows put their tabs along the top, in place of the title bar
+                        // rather than under the window: with the strip there, each tab already
+                        // names its window, and a title bar above it would say the same thing
+                        // twice. Top rather than TopAlways, so a window on its own keeps an
+                        // ordinary title bar and only a group of them shows tabs at all.
+                        defaultTabPreference = TabPreference.Top,
                     ),
                 initialLayout = gameDockLayout(),
             )
@@ -272,6 +279,12 @@ fun rememberGameDockState(
                     true
                 },
                 trailingActions = {
+                    windowsByName[name]?.let { currentTrailingActions(state, it) }
+                },
+                // A tabbed window has no title bar to carry them (the strip replaces it), so the
+                // strip carries the same buttons instead - drawn at its trailing edge for whichever
+                // tab is selected, which is the window they would have acted on anyway.
+                tabStripActions = {
                     windowsByName[name]?.let { currentTrailingActions(state, it) }
                 },
                 content = {

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameDocking.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameDocking.kt
@@ -23,6 +23,7 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.jewel.ui.component.Text
 import warlockfe.warlock3.compose.desktop.ui.window.DesktopWindowView
 import warlockfe.warlock3.compose.generated.resources.Res
+import warlockfe.warlock3.compose.generated.resources.circle_filled
 import warlockfe.warlock3.compose.generated.resources.close
 import warlockfe.warlock3.compose.ui.game.GameViewModel
 import warlockfe.warlock3.compose.ui.game.OpenGameWindow
@@ -66,6 +67,24 @@ internal fun DesktopDockedWindow(
         handledScrollEvent = viewModel::handledScrollEvent,
         showHeader = false,
         clearStream = { viewModel.clearStream(window.name) },
+    )
+}
+
+/**
+ * The dot on a tab whose window has taken text since it was last on screen.
+ *
+ * Drawn inside the tab, beside its title, and only while the window is hidden behind another tab -
+ * a window you can see needs no telling. Small and dim on purpose: it marks a window as worth a
+ * look, and several of them at once should still read as a tab strip rather than an alarm.
+ */
+@Composable
+internal fun DesktopTabActivityDot(hasUnreadText: Boolean) {
+    if (!hasUnreadText) return
+    Image(
+        modifier = Modifier.padding(start = 6.dp).size(7.dp),
+        painter = painterResource(Res.drawable.circle_filled),
+        colorFilter = ColorFilter.tint(gameChrome.accentSubtle),
+        contentDescription = "New text",
     )
 }
 

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameDocking.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameDocking.kt
@@ -2,6 +2,7 @@ package warlockfe.warlock3.compose.desktop.ui.game
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -79,13 +80,19 @@ internal fun DesktopDockedWindow(
  */
 @Composable
 internal fun DesktopTabActivityDot(hasUnreadText: Boolean) {
-    if (!hasUnreadText) return
-    Image(
-        modifier = Modifier.padding(start = 6.dp).size(7.dp),
-        painter = painterResource(Res.drawable.circle_filled),
-        colorFilter = ColorFilter.tint(gameChrome.accentSubtle),
-        contentDescription = "New text",
-    )
+    // The slot is held open whether or not the dot is in it. A tab that grew when its window took
+    // text would shove the rest of the strip sideways, and the tab someone was reaching for would
+    // slide out from under the pointer exactly when a window started being busy.
+    Box(Modifier.padding(start = 6.dp).size(7.dp)) {
+        if (hasUnreadText) {
+            Image(
+                modifier = Modifier.fillMaxSize(),
+                painter = painterResource(Res.drawable.circle_filled),
+                colorFilter = ColorFilter.tint(gameChrome.accentSubtle),
+                contentDescription = "New text",
+            )
+        }
+    }
 }
 
 /**

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
@@ -214,11 +214,18 @@ fun DesktopGameView(
                             DesktopDockedWindow(viewModel = viewModel, window = window)
                         }
                     }
+                val tabActions =
+                    remember {
+                        @Composable { _: OpenGameWindow, hasUnreadText: Boolean ->
+                            DesktopTabActivityDot(hasUnreadText)
+                        }
+                    }
                 val dockState =
                     rememberGameDockState(
                         viewModel = viewModel,
                         trailingActions = trailingActions,
                         windowContent = windowContent,
+                        tabActions = tabActions,
                     )
                 // Detached windows are opened from the application scope, which is above everything
                 // here; hand the state up so Main can host them. Cleared on the way out so a game


### PR DESCRIPTION
Two related changes to how tabbed game windows read, plus a fix to the second one.

## Tabs replace the title bar (`2bba01a9`)

A tabbed window carried both a title bar *and* a strip of tabs beneath the body, which says the same thing twice — the selected tab already names the window it shows. Moving the strip to the top drops the title bar with it: compose-docking's rule (ModernDocking's before it) is that a tabbed dockable keeps its title bar only when the tabs are somewhere else.

This is `DockingSettings.defaultTabPreference`, which was defaulting to `Bottom`. Set to `Top` — **not** `TopAlways`, so a window on its own is not a tab group and keeps an ordinary title bar; only two or more stacked together show tabs at all.

Losing the title bar would otherwise take the window menu and close button with it, leaving a tabbed window with no way to reach its settings or close it. They're registered as tab-strip actions too, drawn at the trailing edge for whichever tab is selected — the window they always acted on.

## A mark for windows busy out of sight (`02d01ae4`)

A window tabbed behind another is open but invisible, and gave no sign when something arrived in it. Background tabs now carry a small dot once text lands in them, and lose it when brought to the front.

Only a tab can be hidden this way: a window sharing a split has neighbours but is still on screen, and a lone one plainly is, so neither is ever marked. Nor is a panel — a fixed layout of widgets with no text arriving behind it.

**The flag latches rather than tracking a count**, which is what keeps it off the hot path: the collector runs in a coroutine instead of as a composition read, so a window taking a hundred lines a second recomposes the strip *once*, when the flag first flips, rather than once a line.

The dot is the platform's to draw — the bridge decides which windows have something unseen and hands that down. Desktop draws the same filled circle the window sidebar already uses. Mobile passes nothing and is unchanged, so `LargeGameView` can opt in later.

## Holding the slot open (`dd8f4d54`)

Caught in review: the dot was drawn only when there was something to announce, so a tab grew by the dot's width the moment its window took text, shoving every tab to its right along with it — a tab someone was reaching for would slide out from under the pointer exactly when a window started being busy.

Measured on the strip before fixing: content ran to column 125 without the dot and 138 with it. The slot is now always laid out and only its contents come and go; the tabs occupy identical columns either way.

## Testing

`./gradlew check -PiosSkip=true -PlintSkip=true` passes.

Verified in the running app against a replayed session fed through a FIFO, so text could be sent *after* the tabs were arranged: tabs sit at the top with no title bar, the `...`/`×` are on the strip and follow the selected tab, clicking a tab switches content, a dot appears on a hidden tab when text lands in it, and clearing happens on selecting the tab.

Independent of the pending compose-docking 0.2.1 work — still on the released 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added activity indicators to game tabs when hidden streams contain unread text.
  - Unread indicators clear automatically when the corresponding tab becomes visible.
  - Added support for customizable actions in the game tab strip.
  - Added default tab preferences for the game docking interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->