### PR TITLE
Give a window joining an area its share of it, not half its neighbour

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
@@ -580,21 +580,37 @@ internal fun defaultPlacement(
         // Region and proportion are ignored for an anchor target: the placeholder names the slot.
         return DockPlacement(DockTarget.Anchor(anchor), DockRegion.Center, BAND_PROPORTION)
     }
-    val neighbor =
+    val neighbors =
         if (tree != null) {
-            openWindows.keys.lastOrNull { other ->
+            openWindows.keys.filter { other ->
                 other != name && other != MAIN_WINDOW_NAME && currentAnchorOf(tree, other) == anchor
             }
         } else {
-            null
+            emptyList()
         }
-    if (neighbor != null) {
+    if (tree != null && neighbors.isNotEmpty()) {
         val region =
             when (anchor) {
                 LEFT_ANCHOR, RIGHT_ANCHOR -> DockRegion.South
                 else -> DockRegion.East
             }
-        return DockPlacement(DockTarget.OnDockable(DockableId(neighbor)), region, 0.5f)
+        // One of N, where N counts the area's windows once this one has joined them. The library
+        // reads a proportion as the newcomer's share, so splitting the area as a whole hands it
+        // exactly that and leaves the rest of the area to divide what remains in the ratio it
+        // already had - which is what makes a column of windows opened this way come out even, and
+        // what keeps a column the user has since adjusted in the proportions they chose.
+        //
+        // Splitting the area's *last window* instead is what made the first window twice the size
+        // of the second, four times the third, and so on: each newcomer halved whatever it landed
+        // on rather than taking a share of the whole.
+        val share = 1f / (neighbors.size + 1)
+        val areaNode = tree.smallestNodeHolding(neighbors.map { DockableId(it) }.toSet())
+        if (areaNode != null) {
+            return DockPlacement(DockTarget.OnNode(mainWindow.id, areaNode.id), region, share)
+        }
+        // The area is scattered rather than sitting in a subtree of its own, so there is nothing to
+        // split as a whole. Stack on the last of them, still at the newcomer's proper share.
+        return DockPlacement(DockTarget.OnDockable(DockableId(neighbors.last())), region, share)
     }
     // Nothing in the area yet: open it with a split directly off the main text window (or the
     // window root when main is somehow absent, which the next reconcile pass heals).
@@ -711,3 +727,25 @@ private fun DockNode.dockableIds(): List<DockableId> =
     }
 
 internal fun DockNode.containsDockable(id: DockableId): Boolean = id in dockableIds()
+
+/**
+ * The smallest subtree holding exactly [ids] and nothing else, or null when no such subtree exists.
+ *
+ * This is how an area is addressed as a unit. The windows of an area normally sit together in one
+ * subtree - the left column is a subtree, the band above main is a subtree - so the newcomer can
+ * split that, take its share of the whole, and leave the windows already there dividing the rest
+ * between them as before.
+ *
+ * Exactly, because a subtree holding the area *and* something else is not the area: splitting the
+ * node that holds both a side column and the main text window would put the newcomer alongside the
+ * whole screen rather than in the column it asked for. A layout dragged into that shape has no area
+ * to split and the caller stacks instead.
+ */
+private fun DockNode.smallestNodeHolding(ids: Set<DockableId>): DockNode? {
+    if (ids.isEmpty() || !ids.all { containsDockable(it) }) return null
+    if (this is DockNode.Split) {
+        first.smallestNodeHolding(ids)?.let { return it }
+        second.smallestNodeHolding(ids)?.let { return it }
+    }
+    return takeIf { dockableIds().toSet() == ids }
+}

--- a/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
+++ b/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
@@ -2,6 +2,7 @@ package warlockfe.warlock3.compose.ui.game
 
 import androidx.compose.runtime.mutableStateOf
 import com.seanproctor.docking.model.AnchorId
+import com.seanproctor.docking.model.DockNode
 import com.seanproctor.docking.model.DockRegion
 import com.seanproctor.docking.model.DockableId
 import com.seanproctor.docking.model.DockableOptions
@@ -16,6 +17,7 @@ import warlockfe.warlock3.compose.ui.window.WindowUiState
 import warlockfe.warlock3.core.window.WindowInfo
 import warlockfe.warlock3.core.window.WindowLocation
 import warlockfe.warlock3.core.window.WindowType
+import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -152,8 +154,88 @@ class GameDockingTest {
                 layout = state.layout,
                 openWindows = windows,
             )
-        assertEquals(DockTarget.OnDockable(DockableId("thoughts")), second.target)
         assertEquals(DockRegion.South, second.region)
+        register(state)("logons", WindowLocation.LEFT.anchor)
+        state.dock(DockableId("logons"), second.target, second.region, second.proportion)
+        assertEquals(
+            DockRegion.South,
+            relativeRegion(state.layout.mainWindow.root!!, DockableId("logons"), DockableId("thoughts")),
+            "the second window of an area stacks below the first",
+        )
+    }
+
+    // Each window's share of the layout, multiplied down the split proportions.
+    private fun shares(
+        node: DockNode,
+        weight: Float = 1f,
+    ): Map<DockableId, Float> =
+        when (node) {
+            is DockNode.Leaf -> {
+                mapOf(node.dockableId to weight)
+            }
+
+            is DockNode.Tabs -> {
+                node.tabs.associate { it.dockableId to weight }
+            }
+
+            is DockNode.Anchor -> {
+                emptyMap()
+            }
+
+            is DockNode.Split -> {
+                shares(node.first, weight * node.proportion) +
+                    shares(node.second, weight * (1f - node.proportion))
+            }
+        }
+
+    // The game opens a character's windows one after another on connect. Each one takes a share of
+    // the area rather than half of whichever window opened last, so what the user ends up looking at
+    // is an evenly divided column - not one window at half the height, the next at a quarter, the
+    // next at an eighth.
+    @Test
+    fun windowsOpeningIntoAnAreaEndUpTheSameSize() {
+        val state = newState()
+        val registerWindow = register(state)
+        val column = listOf("thoughts", "logons", "deaths", "arrivals")
+        val opened = mutableListOf(MAIN_WINDOW_NAME to WindowLocation.CENTER)
+        column.forEach { name ->
+            opened += name to WindowLocation.LEFT
+            reconcile(state, openWindows(*opened.toTypedArray()), registerWindow)
+        }
+
+        val shares = shares(state.layout.mainWindow.root!!)
+        val sizes = column.map { shares.getValue(DockableId(it)) }
+        sizes.forEach { size ->
+            assertTrue(
+                abs(size - sizes.first()) < 0.001f,
+                "every window in the column should be the same size, got ${column.zip(sizes)}",
+            )
+        }
+    }
+
+    // The rule the sizes come from: a window joining an area takes one Nth of it, N counting the
+    // area's windows once it has joined.
+    @Test
+    fun aWindowJoiningAnAreaTakesOneNthOfIt() {
+        val state = newState()
+        val registerWindow = register(state)
+        val opened = mutableListOf(MAIN_WINDOW_NAME to WindowLocation.CENTER)
+        listOf("thoughts", "logons", "deaths").forEachIndexed { index, name ->
+            val joining = openWindows(*(opened + (name to WindowLocation.LEFT)).toTypedArray())
+            val placement =
+                defaultPlacement(
+                    name = name,
+                    location = WindowLocation.LEFT,
+                    layout = state.layout,
+                    openWindows = joining,
+                )
+            // The first fills the area's empty slot outright; the rest take a share of it.
+            if (index > 0) {
+                assertEquals(1f / (index + 1), placement.proportion, "window ${index + 1} of the column")
+            }
+            opened += name to WindowLocation.LEFT
+            reconcile(state, openWindows(*opened.toTypedArray()), registerWindow)
+        }
     }
 
     @Test
@@ -351,8 +433,14 @@ class GameDockingTest {
                         "combat" to WindowLocation.RIGHT,
                     ),
             )
-        assertEquals(DockTarget.OnDockable(DockableId("inv")), second.target)
         assertEquals(DockRegion.South, second.region)
+        registerWindow("combat", WindowLocation.RIGHT.anchor)
+        state.dock(DockableId("combat"), second.target, second.region, second.proportion)
+        assertEquals(
+            DockRegion.South,
+            relativeRegion(state.layout.mainWindow.root!!, DockableId("combat"), DockableId("inv")),
+            "the second right-column window stacks below the first",
+        )
     }
 
     @Test


### PR DESCRIPTION
Fixes the 50% / 25% / 12.5% cascade when the game opens a character's windows on connect.

## The cause

A window opening into an area split whichever window opened *last*, taking half of it. So the first window kept half the column, the second a quarter, the third an eighth — the first window enormous and the last a sliver, in an order that has nothing to do with what the character actually wants to look at.

## The fix

The newcomer now splits the **area as a whole** and takes `1/N` of it, N counting the area's windows once it has joined.

The library reads a proportion as the newcomer's share, so this falls out neatly: the windows already there divide what remains *in the ratio they already had*. Open four windows into a column and they come out at a quarter each; open one into a column the user has since adjusted and their proportions survive it, all shrinking by the same factor. That last part is why this is better than rebalancing everything to equal after each insert — that would clobber a manual resize.

An area is addressed by the smallest subtree holding **exactly** its windows. Exactly, because a subtree holding the area *and* something else is not the area — splitting the node that holds both a side column and the main text window would put the newcomer alongside the whole screen. A layout dragged into a shape with no such subtree has no area to split, and falls back to stacking on the last window, still at the newcomer's proper share.

## Testing

`./gradlew check -PiosSkip=true -PlintSkip=true` passes.

Two new tests, both confirmed to fail on the old behaviour and pass on the new:

- `windowsOpeningIntoAnAreaEndUpTheSameSize` — opens four windows into a column one at a time, as the game does, and asserts every one ends up the same size. Sizes are computed by multiplying down the split proportions, so it checks the actual geometry rather than the placement call.
- `aWindowJoiningAnAreaTakesOneNthOfIt` — pins the rule itself: the second window takes 1/2, the third 1/3.

Two existing tests changed. They asserted the *mechanism* (`DockTarget.OnDockable(thoughts)`) rather than the result, and the target is now a node rather than a dockable while the effect is unchanged. They now assert the newcomer lands below its neighbour, which is what they were really about, and hold either way.

Independent of #280 and of the pending compose-docking 0.2.1 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window docking when multiple windows share the same anchor area.
  * New windows now receive equal space when joining an evenly divided area.
  * Preserved stacking behavior for windows arranged across separate areas.
  * Updated right-column docking layouts for more consistent sizing.

* **Tests**
  * Added coverage for equal-size and one-over-N window layouts.
  * Expanded docking scenarios to verify calculated placement and proportions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->