### PR TITLE
Let a skin size a progress bar, over the panel font setting

### DIFF
--- a/compose/skin/skin.json
+++ b/compose/skin/skin.json
@@ -17,6 +17,7 @@
   "HealthBar": {
     "children": {
       "health": {
+        "fontSize": 11,
         "top": 0,
         "left": 0,
         "color": "#FFFFFF",
@@ -39,6 +40,7 @@
   "ManaBar": {
     "children": {
       "mana": {
+        "fontSize": 11,
         "top": 0,
         "left": 0,
         "color": "#FFFFFF",
@@ -50,6 +52,7 @@
   "StaminaBar": {
     "children": {
       "stamina": {
+        "fontSize": 11,
         "top": 0,
         "left": 0,
         "color": "#FFFFFF",
@@ -61,6 +64,7 @@
   "SpiritBar": {
     "children": {
       "spirit": {
+        "fontSize": 11,
         "top": 0,
         "left": 0,
         "color": "#FFFFFF",
@@ -72,6 +76,7 @@
   "ConcentrationBar": {
     "children": {
       "concentration": {
+        "fontSize": 11,
         "color": "#FFFFFF",
         "bar": { "light": "#109A88", "dark": "#22C7AE" },
         "background": { "light": "#C6C6BE", "dark": "#2C2F34" }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/PanelTextStyle.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/PanelTextStyle.kt
@@ -1,9 +1,12 @@
 package warlockfe.warlock3.compose.util
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import warlockfe.warlock3.compose.model.SkinObject
 import warlockfe.warlock3.core.text.FontConfig
+import warlockfe.warlock3.core.util.getIgnoringCase
 
 /**
  * Merges a [FontConfig] over this style: each field the config leaves null keeps the style's own, so
@@ -22,3 +25,33 @@ fun TextStyle.withFont(font: FontConfig?): TextStyle =
             fontWeight = font.weight?.let { FontWeight(it) } ?: fontWeight,
         )
     }
+
+/** The font a skin sets for a progress bar, read from the ambient skin. Null when it sets none. */
+@Composable
+fun progressBarSkinFont(skinObject: SkinObject?): FontConfig? = progressBarSkinFont(skinObject, LocalSkin.current)
+
+/**
+ * The font a skin sets for a progress bar: what the skin says for this particular bar, falling back
+ * field by field to its shared `progressBar` entry, so a skin can size all its bars in one place and
+ * still say something different about one of them.
+ *
+ * This sits above the panel font setting and below the user's own font for the bar. A skin that sizes
+ * a bar has laid out the slot it sits in - the vital bars live in a fixed-height row - so the panel
+ * font, which is a preference about panel text in general, should not burst it. The user asking for a
+ * font on this bar in particular is the last word, over the skin included: they can see what they are
+ * changing.
+ *
+ * Field by field, matching how [withFont] merges: a skin that sets only a size keeps the family and
+ * weight it would otherwise have had.
+ */
+internal fun progressBarSkinFont(
+    skinObject: SkinObject?,
+    skin: Map<String, SkinObject>,
+): FontConfig? {
+    val shared = skin.getIgnoringCase("progressBar")
+    return FontConfig(
+        family = skinObject?.fontFamily ?: shared?.fontFamily,
+        size = skinObject?.fontSize ?: shared?.fontSize,
+        weight = skinObject?.fontWeight ?: shared?.fontWeight,
+    ).takeUnless { it.isEmpty() }
+}

--- a/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/util/ProgressBarSkinFontTest.kt
+++ b/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/util/ProgressBarSkinFontTest.kt
@@ -27,6 +27,20 @@ class ProgressBarSkinFontTest {
         )
     }
 
+    // Skins and the server disagree about case and always have - the game asks for `healthBar`
+    // while the skin calls it `HealthBar`, and the real client skins it anyway - so the shared entry
+    // is found whatever case it is written in.
+    @Test
+    fun theSharedEntryIsFoundWhateverCaseItIsWrittenIn() {
+        assertEquals(
+            FontConfig(family = "Shared", size = 9f, weight = 400),
+            progressBarSkinFont(
+                skinObject = SkinObject(),
+                skin = mapOf("PrOgReSsBaR" to SkinObject(fontFamily = "Shared", fontSize = 9f, fontWeight = 400)),
+            ),
+        )
+    }
+
     // And still say something different about one of them.
     @Test
     fun theBarsOwnEntryWinsOverTheSharedOne() {

--- a/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/util/ProgressBarSkinFontTest.kt
+++ b/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/util/ProgressBarSkinFontTest.kt
@@ -1,0 +1,58 @@
+package warlockfe.warlock3.compose.util
+
+import warlockfe.warlock3.compose.model.SkinObject
+import warlockfe.warlock3.core.text.FontConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ProgressBarSkinFontTest {
+    private val shared =
+        mapOf(
+            "progressBar" to SkinObject(fontFamily = "Shared", fontSize = 9f, fontWeight = 400),
+        )
+
+    @Test
+    fun aSkinThatSaysNothingContributesNoFont() {
+        assertNull(progressBarSkinFont(skinObject = null, skin = emptyMap()))
+        assertNull(progressBarSkinFont(skinObject = SkinObject(), skin = emptyMap()))
+    }
+
+    // A skin can size every bar in one place.
+    @Test
+    fun theSharedEntryAppliesToABarThatSaysNothingItself() {
+        assertEquals(
+            FontConfig(family = "Shared", size = 9f, weight = 400),
+            progressBarSkinFont(skinObject = SkinObject(), skin = shared),
+        )
+    }
+
+    // And still say something different about one of them.
+    @Test
+    fun theBarsOwnEntryWinsOverTheSharedOne() {
+        assertEquals(
+            FontConfig(family = "Own", size = 11f, weight = 700),
+            progressBarSkinFont(
+                skinObject = SkinObject(fontFamily = "Own", fontSize = 11f, fontWeight = 700),
+                skin = shared,
+            ),
+        )
+    }
+
+    // Field by field, matching how withFont merges: a bar that only resizes keeps the rest.
+    @Test
+    fun aBarThatSetsOnlyASizeKeepsTheSharedFamilyAndWeight() {
+        assertEquals(
+            FontConfig(family = "Shared", size = 11f, weight = 400),
+            progressBarSkinFont(skinObject = SkinObject(fontSize = 11f), skin = shared),
+        )
+    }
+
+    @Test
+    fun aBarsEntryAloneIsEnoughWithNoSharedEntry() {
+        assertEquals(
+            FontConfig(size = 11f),
+            progressBarSkinFont(skinObject = SkinObject(fontSize = 11f), skin = emptyMap()),
+        )
+    }
+}

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/window/DesktopPanelContent.kt
@@ -52,6 +52,7 @@ import warlockfe.warlock3.compose.util.LocalPanelTextStyle
 import warlockfe.warlock3.compose.util.LocalSkin
 import warlockfe.warlock3.compose.util.LocalStyleMap
 import warlockfe.warlock3.compose.util.getColorGroup
+import warlockfe.warlock3.compose.util.progressBarSkinFont
 import warlockfe.warlock3.compose.util.toAlignment
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.compose.util.withFont
@@ -337,16 +338,19 @@ private fun ProgressBarWithColorMenu(
     val barColor = setting?.barColor ?: WarlockColor.Unspecified
     val backgroundColor = setting?.backgroundColor ?: WarlockColor.Unspecified
     val textColor = setting?.textColor ?: WarlockColor.Unspecified
-    // Merge this bar's saved font override (if any) over the panel style, so a bar the user has not
-    // touched still follows the panel font.
+    // Three layers over the panel style, least specific first: what the skin says about this bar,
+    // then this bar's saved font override. A bar nobody has skinned or touched still follows the
+    // panel font.
     val style =
-        LocalPanelTextStyle.current.withFont(
-            FontConfig(
-                family = setting?.fontFamily,
-                size = setting?.fontSize,
-                weight = setting?.fontWeight,
-            ).takeUnless { it.isEmpty() },
-        )
+        LocalPanelTextStyle.current
+            .withFont(progressBarSkinFont(skinObject))
+            .withFont(
+                FontConfig(
+                    family = setting?.fontFamily,
+                    size = setting?.fontSize,
+                    weight = setting?.fontWeight,
+                ).takeUnless { it.isEmpty() },
+            )
 
     var editingTarget by remember { mutableStateOf<ProgressBarColorTarget?>(null) }
     var editingFont by remember { mutableStateOf(false) }

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/window/PanelContent.kt
@@ -45,6 +45,7 @@ import warlockfe.warlock3.compose.util.LocalPanelTextStyle
 import warlockfe.warlock3.compose.util.LocalSkin
 import warlockfe.warlock3.compose.util.LocalStyleMap
 import warlockfe.warlock3.compose.util.getColorGroup
+import warlockfe.warlock3.compose.util.progressBarSkinFont
 import warlockfe.warlock3.compose.util.toAlignment
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.compose.util.withFont
@@ -347,14 +348,19 @@ private fun ProgressBarWithColorMenu(
     val textColor = setting?.textColor ?: WarlockColor.Unspecified
     // Merge this bar's saved font override (if any) over the panel style, so a bar the user has not
     // touched still follows the panel font.
+    // Three layers over the panel style, least specific first: what the skin says about this bar,
+    // then this bar's saved font override. A bar nobody has skinned or touched still follows the
+    // panel font.
     val style =
-        LocalPanelTextStyle.current.withFont(
-            FontConfig(
-                family = setting?.fontFamily,
-                size = setting?.fontSize,
-                weight = setting?.fontWeight,
-            ).takeUnless { it.isEmpty() },
-        )
+        LocalPanelTextStyle.current
+            .withFont(progressBarSkinFont(skinObject))
+            .withFont(
+                FontConfig(
+                    family = setting?.fontFamily,
+                    size = setting?.fontSize,
+                    weight = setting?.fontWeight,
+                ).takeUnless { it.isEmpty() },
+            )
 
     var menuOpen by remember { mutableStateOf(false) }
     var editingTarget by remember { mutableStateOf<ProgressBarColorTarget?>(null) }


### PR DESCRIPTION
A skin could say what colour a progress bar is but not what size its label is, so every bar took the panel font — a preference about panel text in general — and a skin that had laid out a bar to fit a particular slot had no say in whether the text would fit it.

## Precedence

Skin fonts now sit between the panel font setting and the user's own font for the bar:

| | |
|---|---|
| user's font for this bar | wins over everything — they can see what they're changing |
| **the skin** | new; wins over the panel font, because a skin that sizes a bar knows the slot it laid out |
| panel font setting | a general preference about panel text |
| platform compact base | |

Resolved **field by field**, matching how `withFont` already merges, so a skin setting only a size keeps the family and weight it would otherwise have had. And taken from the bar's own skin entry before the shared `progressBar` entry — a skin can size all its bars in one place and still say something different about one of them.

The `fontFamily`/`fontSize`/`fontWeight` fields have been on `SkinObject` all along, accepted and ignored.

## The minivitals

Given 11sp in the bundled skin, which is what wanted saying in the first place. They sit in a fixed-height row drawn as chrome rather than as a window, so they never took the panel font at all and were stuck at the 9sp base.

The skin change is five lines — `fontSize` on `HealthBar > health` and its four siblings, which is how the skin already addresses those bars (a bar's entry is a child of `<id>Bar` keyed by its id). `HealthBar2 > health2` is deliberately untouched.

## Testing

`./gradlew check -PiosSkip=true -PlintSkip=true` passes.

`ProgressBarSkinFontTest` covers the resolver: nothing set contributes nothing, the shared entry applies to a bar that says nothing itself, the bar's own entry wins over the shared one, a bar setting only a size keeps the rest, and a bar's entry alone works with no shared entry. The resolver is a pure function over the skin map with a thin composable wrapper, so this is testable without a composition.

Verified in the running app with a `location='statBar'` minivitals panel. A/B against the skin entry removed shows the labels visibly larger with it, confirming the skin value — not the base — is what's driving the size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added skin-based font styling for health, mana, stamina, spirit, and concentration bars.
  * Progress-bar text now supports shared defaults, individual bar overrides, and field-level customization.
  * Set the default progress-bar text size to 11 for improved readability.
  * Applied consistent font resolution across desktop and mobile interfaces.

* **Bug Fixes**
  * Improved progress-bar text styling by correctly combining panel, skin, and saved customization settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->