### PR TITLE
Wait for a mode tag before parsing, and stop announcing a chat mode we do not have

### DIFF
--- a/utils/wrayth-lab/README.md
+++ b/utils/wrayth-lab/README.md
@@ -98,6 +98,13 @@ These are the non-obvious bits, kept here because they cost real time to find:
   that client is configured for, `ON` or `OFF`, and arrives after the settings upload;
   it is the empty command above that unblocks the connection. What a real server does
   with the value is not something the bench can answer - its server is a stub.
+- **`<mode>` chooses the parser, and the default is raw.** With `mode` left out of the
+  bootstrap entirely, Wrayth prints what arrives as plain text: tags show up literally
+  on screen, `<pushBold/>` and friends do nothing, and the vitals and stream windows
+  never appear. Send `<mode id="GAME"/>` at any later point and it switches to the XML
+  parser mid-stream, from that tag on. `<mode id="CMGR"/>` switches back - the raw mode
+  is what character creation and book reading run in. So a client starts in raw mode and
+  waits to be told otherwise, which is why ours does too.
 - **Skin names are matched case-insensitively.** A widget names a skin entry with
   `<skin name='...'>`, and the real server and the real skin disagree about case:
   GS4 sends `name='healthBar'` (and `manaBar`, `staminaBar`, `spiritBar`) while

--- a/utils/wrayth-lab/README.md
+++ b/utils/wrayth-lab/README.md
@@ -84,16 +84,25 @@ These are the non-obvious bits, kept here because they cost real time to find:
   handshake lines (the key, then
   `/FE:WRAYTH /VERSION:1.0.1.28 /P:WIN_UNKNOWN /XML`). With chat mode on, a
   typed command arrives as `<c>'look at dummy`.
-- **The empty command Wrayth sends answers `settingsInfo`, and only in game mode.**
-  A connection hangs until the client sends an empty command, and the handshake runs:
-  the key, then `/FE:WRAYTH /VERSION:... /XML`, then - once the server has sent
-  `<mode id="GAME"/>` and `<settingsInfo .../>` - a burst of `<c>`, the client's whole
-  settings upload as `<db><settings>...`, and `<c>_STATE CHATMODE ON`. Narrowed by
-  feeding elements one at a time against an empty bootstrap: `mode` alone gets nothing
-  back, `settingsInfo` alone gets nothing back, `settingsInfo` after `mode` gets the
-  burst, and a `settingsInfo` that arrived before game mode is dropped rather than
-  remembered - sending `mode` afterwards does not make up for it, though re-sending
-  `settingsInfo` then does. `playerId` is not involved.
+- **The empty command Wrayth sends answers `settingsInfo`.** A connection hangs until
+  the client sends an empty command, and the handshake runs: the key, then
+  `/FE:WRAYTH /VERSION:... /XML`, then - once the server has sent `<settingsInfo .../>`
+  to a client whose parser is on - a burst of `<c>`, the client's whole settings upload
+  as `<db><settings>...`, and `<c>_STATE CHATMODE ON`. Narrowed by feeding elements one
+  at a time against an empty bootstrap: `mode` alone gets nothing back, `settingsInfo`
+  alone gets nothing back, `settingsInfo` after `mode` gets the burst. `playerId` is not
+  involved.
+
+  The "after `mode`" part is not an ordering rule of its own, and it is worth being
+  precise about, because reading one into it invites a client to track game mode and
+  gate on it for no reason. `settingsInfo` sent before any `<mode>` is not queued,
+  dropped, or refused - it is **never parsed**, because the parser is not on yet. The
+  screenshot is unambiguous: the tag lands in the Story window as literal text,
+  `<settingsInfo space_not_found="0" crc="0" instance="DR"/>`, the same as any other
+  raw-mode text. Sending `mode` afterwards does not make up for it because there is
+  nothing to make up for; re-sending `settingsInfo` works because that copy is the
+  first one the parser ever sees. See the `<mode>` note below - it is the whole
+  mechanism.
 - **`_STATE CHATMODE` is a report, not a handshake step.** It carries whichever mode
   that client is configured for, `ON` or `OFF`, and arrives after the settings upload;
   it is the empty command above that unblocks the connection. What a real server does
@@ -105,6 +114,11 @@ These are the non-obvious bits, kept here because they cost real time to find:
   parser mid-stream, from that tag on. `<mode id="CMGR"/>` switches back - the raw mode
   is what character creation and book reading run in. So a client starts in raw mode and
   waits to be told otherwise, which is why ours does too.
+
+  This one bit of state explains the handshake note above on its own. A client has no
+  need to know which mode the *game* is in, or to gate any particular tag on it: a tag
+  that arrives while the parser is off is text, and a tag that arrives while it is on is
+  a tag.
 - **Skin names are matched case-insensitively.** A widget names a skin entry with
   `<skin name='...'>`, and the real server and the real skin disagree about case:
   GS4 sends `name='healthBar'` (and `manaBar`, `staminaBar`, `spiritBar`) while

--- a/utils/wrayth-lab/README.md
+++ b/utils/wrayth-lab/README.md
@@ -84,6 +84,20 @@ These are the non-obvious bits, kept here because they cost real time to find:
   handshake lines (the key, then
   `/FE:WRAYTH /VERSION:1.0.1.28 /P:WIN_UNKNOWN /XML`). With chat mode on, a
   typed command arrives as `<c>'look at dummy`.
+- **The empty command Wrayth sends answers `settingsInfo`, and only in game mode.**
+  A connection hangs until the client sends an empty command, and the handshake runs:
+  the key, then `/FE:WRAYTH /VERSION:... /XML`, then - once the server has sent
+  `<mode id="GAME"/>` and `<settingsInfo .../>` - a burst of `<c>`, the client's whole
+  settings upload as `<db><settings>...`, and `<c>_STATE CHATMODE ON`. Narrowed by
+  feeding elements one at a time against an empty bootstrap: `mode` alone gets nothing
+  back, `settingsInfo` alone gets nothing back, `settingsInfo` after `mode` gets the
+  burst, and a `settingsInfo` that arrived before game mode is dropped rather than
+  remembered - sending `mode` afterwards does not make up for it, though re-sending
+  `settingsInfo` then does. `playerId` is not involved.
+- **`_STATE CHATMODE` is a report, not a handshake step.** It carries whichever mode
+  that client is configured for, `ON` or `OFF`, and arrives after the settings upload;
+  it is the empty command above that unblocks the connection. What a real server does
+  with the value is not something the bench can answer - its server is a stub.
 - **Skin names are matched case-insensitively.** A widget names a skin entry with
   `<skin name='...'>`, and the real server and the real skin disagree about case:
   GS4 sends `name='healthBar'` (and `manaBar`, `staminaBar`, `spiritBar`) while

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -215,8 +215,9 @@ class WraythClient(
     // sends <mode id="GAME"/> before anything else, so the raw reader below hands straight over.
     private var parseText = false
 
-    // Half a line left over when raw mode handed back to the parser mid-line.
-    private var pendingLine = ""
+    // Read from the socket but not consumed yet: what a read in raw mode took past the <mode> tag
+    // that ended it. Both branches of the read loop drain this before reading any more.
+    private var pendingText = ""
 
     private var currentStream: TextStream? = null
 
@@ -297,47 +298,47 @@ class WraythClient(
                 try {
                     if (parseText) {
                         // This is the standard wrayth parser
-                        val rest: String? = socket.readLine()
-                        if (rest == null) {
+                        val line: String?
+                        if (pendingText.contains('\n')) {
+                            // Whole lines the handover left behind, taken one at a time.
+                            line = pendingText.substringBefore('\n').removeSuffix("\r")
+                            pendingText = pendingText.substringAfter('\n')
+                        } else {
+                            // What is left of it is half a line, since a raw read stops on
+                            // whatever bytes had arrived rather than on a newline. The socket
+                            // has the rest.
+                            val rest = socket.readLine()
+                            line = rest?.let { pendingText + it }
+                            pendingText = ""
+                        }
+                        if (line == null) {
                             // Connection closed by server
                             disconnected()
                             break
                         }
-                        // A handover out of raw mode can leave half a line behind, since it reads
-                        // whatever bytes had arrived rather than up to a newline.
-                        val line = pendingLine + rest
-                        pendingLine = ""
                         logComplete { line }
                         debug(line)
                         val events = protocolHandler.parseLine(line)
                         events.forEach { handleEvent(it) }
                     } else {
                         // This is the strange mode to read books and create characters
-                        val text = socket.readAvailable()
+                        // A mode tag can hand back partway through the buffer, and what is left
+                        // of it is raw text again - ahead of anything still on the socket.
+                        val text =
+                            if (pendingText.isNotEmpty()) {
+                                pendingText.also { pendingText = "" }
+                            } else {
+                                socket.readAvailable()
+                            }
                         // check for <mode> tag
                         val sections = text.split(modeRegex, limit = 2)
                         if (sections.size > 1) {
                             rawPrint(sections[0])
                             parseText = true
-                            // Everything from the tag on is protocol, and there may be several
-                            // lines of it in the same read. Put each through the parser the loop
-                            // above uses - events and all, which this used to throw away - and
-                            // leave any half line for the next read to finish.
-                            val lines = sections[1].split(newLinePattern)
-                            var index = 0
-                            while (index < lines.lastIndex && parseText) {
-                                val line = lines[index]
-                                logComplete { line }
-                                debug(line)
-                                protocolHandler.parseLine(line).forEach { handleEvent(it) }
-                                index++
-                            }
-                            if (parseText) {
-                                pendingLine = lines.last()
-                            } else {
-                                // A mode tag handed straight back before the chunk ran out.
-                                rawPrint(lines.drop(index).joinToString("\n"))
-                            }
+                            // Everything from the tag on is protocol. Buffer it for the branch
+                            // above rather than parsing it here: it may hold several lines, and
+                            // the read can stop mid-line, in which case the next one finishes it.
+                            pendingText = sections[1]
                         } else {
                             rawPrint(text)
                         }

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -331,14 +331,14 @@ class WraythClient(
                                 socket.readAvailable()
                             }
                         // check for <mode> tag
-                        val sections = text.split(modeRegex, limit = 2)
-                        if (sections.size > 1) {
-                            rawPrint(sections[0])
+                        val modeStart = text.indexOf("<mode")
+                        if (modeStart >= 0) {
+                            rawPrint(text.substring(0, modeStart))
                             parseText = true
                             // Everything from the tag on is protocol. Buffer it for the branch
                             // above rather than parsing it here: it may hold several lines, and
                             // the read can stop mid-line, in which case the next one finishes it.
-                            pendingText = sections[1]
+                            pendingText = text.substring(modeStart)
                         } else {
                             rawPrint(text)
                         }
@@ -1072,10 +1072,6 @@ class WraythClient(
             .replace("@", cmdNoun ?: "")
             .replace("#", cmdId?.let { "#$it" } ?: "")
             .replace("%", eventNoun ?: "")
-
-    companion object {
-        private val modeRegex = Regex("(?=<mode)")
-    }
 }
 
 val TextStream?.isMainStream

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -448,11 +448,8 @@ class WraythClient(
 
                 // We don't actually handle server settings
 
-                // Not 100% where this belongs. connections hang until and empty command is sent
-                // This must be in response to either mode, playerId, or settingsInfo, so
-                // we put it here until someone discovers something else
+                // The connection hangs until an empty command is sent, matches Wrayth
                 sendCommandDirect("")
-                sendCommandDirect("_STATE CHATMODE OFF")
             }
 
             is WraythDialogDataEvent -> {
@@ -466,13 +463,6 @@ class WraythClient(
             }
 
             is WraythDialogObjectEvent -> {
-                // TODO: record this data somewhere
-                // val data = event.data
-                // if (data is PanelObject.ProgressBar) {
-                //    _properties.value = _properties.value +
-                // (data.id to data.value.value.toString()) +
-                //            ((data.id + "text") to (data.text ?: ""))
-                // }
                 dialogDataId?.let {
                     windowRegistry.getOrCreatePanel(it).setObject(event.data)
                 }

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -211,7 +211,12 @@ class WraythClient(
 
     private val cachedMenuItems = mutableListOf<WarlockMenuItem>()
 
-    private var parseText = true
+    // Starts off, as Wrayth's does: the protocol is not on until a <mode> tag turns it on. A server
+    // sends <mode id="GAME"/> before anything else, so the raw reader below hands straight over.
+    private var parseText = false
+
+    // Half a line left over when raw mode handed back to the parser mid-line.
+    private var pendingLine = ""
 
     private var currentStream: TextStream? = null
 
@@ -292,12 +297,16 @@ class WraythClient(
                 try {
                     if (parseText) {
                         // This is the standard wrayth parser
-                        val line: String? = socket.readLine()
-                        if (line == null) {
+                        val rest: String? = socket.readLine()
+                        if (rest == null) {
                             // Connection closed by server
                             disconnected()
                             break
                         }
+                        // A handover out of raw mode can leave half a line behind, since it reads
+                        // whatever bytes had arrived rather than up to a newline.
+                        val line = pendingLine + rest
+                        pendingLine = ""
                         logComplete { line }
                         debug(line)
                         val events = protocolHandler.parseLine(line)
@@ -310,7 +319,25 @@ class WraythClient(
                         if (sections.size > 1) {
                             rawPrint(sections[0])
                             parseText = true
-                            protocolHandler.parseLine(sections[1])
+                            // Everything from the tag on is protocol, and there may be several
+                            // lines of it in the same read. Put each through the parser the loop
+                            // above uses - events and all, which this used to throw away - and
+                            // leave any half line for the next read to finish.
+                            val lines = sections[1].split(newLinePattern)
+                            var index = 0
+                            while (index < lines.lastIndex && parseText) {
+                                val line = lines[index]
+                                logComplete { line }
+                                debug(line)
+                                protocolHandler.parseLine(line).forEach { handleEvent(it) }
+                                index++
+                            }
+                            if (parseText) {
+                                pendingLine = lines.last()
+                            } else {
+                                // A mode tag handed straight back before the chunk ran out.
+                                rawPrint(lines.drop(index).joinToString("\n"))
+                            }
                         } else {
                             rawPrint(text)
                         }


### PR DESCRIPTION
Two things Wrayth does that we didn't: it waits for a `<mode>` tag before parsing anything, and it doesn't announce a chat mode it hasn't got.

## Starting in raw mode

`<mode>` chooses the parser, and the default is raw. With `mode` left out of the bootstrap entirely, Wrayth prints what arrives as plain text — tags render literally, `<pushBold/>` does nothing, no vitals, no stream windows. Send `<mode id="GAME"/>` later and it switches mid-stream, from that tag on. `<mode id="CMGR"/>` switches back; that's the mode character creation and book reading run in.

We already handled the switch back, but started out with `parseText = true` — so anything a server sent ahead of the mode tag was parsed as protocol. Now it starts `false`.

Flipping it exposed two bugs in the handover out of raw mode, which until now only ran on the way out of character creation with a quiet stream:

- **the parsed events were discarded.** `protocolHandler.parseLine(sections[1])`, return value ignored. With the bootstrap arriving in that first chunk, none of it reached the client: no windows, no vitals, title stuck on "Loading...".
- **the rest of the read went to a *line* parser in one piece**, however many lines it held — and a read ending mid-line lost the remainder.

Both are gone. One buffer now: the raw branch stashes everything from the tag on, and the parser branch takes it a line at a time before reading any more from the socket, so the parse-and-handle block exists once instead of twice. A `<mode id="CMGR"/>` partway through that buffer hands back with the remainder intact, because the raw branch drains the same buffer — that used to need its own bookkeeping.

Verified against the lab, controlling exactly where each read stops (`send --raw`):

| single read | result |
|---|---|
| raw text, `<mode id="GAME"/>`, two whole protocol lines, then a line cut mid-attribute | raw text printed, protocol applied, half-line held; title updated only once the rest arrived in a later read |
| raw, `GAME`, protocol, `CMGR`, raw again — all in one read | each part landed in the right mode |
| the normal bootstrap | renders as before |

## `_STATE CHATMODE OFF`

We sent it to match Wrayth. It doesn't match Wrayth: the real client reports **whichever mode that client is configured for**, `ON` or `OFF`, and reports it *after* its settings upload rather than as a step the server waits on. We have no such mode, and it's the empty command that unblocks the connection — so there's nothing for us to say.

## What the empty command answers

The old comment:

> Not 100% where this belongs. connections hang until and empty command is sent. This must be in response to either mode, playerId, or settingsInfo, so we put it here until someone discovers something else.

It's `settingsInfo`, so the existing placement was right all along. Narrowed with `utils/wrayth-lab` by feeding Wrayth elements one at a time against an empty bootstrap:

| sent | client's reply |
|---|---|
| nothing | key + `/FE:` info only |
| `<mode id="GAME"/>` alone | nothing |
| `<settingsInfo>` alone, parser never turned on | nothing — the tag is printed as literal text |
| `<mode>` then `<settingsInfo>` | `<c>`, the settings upload, `_STATE CHATMODE ON` |

There is no separate ordering rule here, and the README now says so explicitly. A `settingsInfo` sent before any `<mode>` isn't queued, dropped, or refused — it is never *parsed*, because the parser isn't on. Re-sending it works because that copy is the first one the parser ever sees. It's the same one bit of state as the section above, seen from the socket instead of the screen.

**One boundary:** what a real server does with the `CHATMODE` value isn't something the bench can answer — its server is a stub. Since Wrayth reports both values depending on how it's configured, a server has to cope with either; that a server also copes with a client that never reports is an inference, not a verified fact.

## Also in here

A commented-out block above the dialog-object handler, proposing to record progress bar values into client properties. It's been sitting unexecuted and the panel state keeps that data now. Unrelated to the handshake — easy to split out if you'd rather.

`./gradlew check -PiosSkip=true -PlintSkip=true` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection initialization so settings are requested only after XML parsing is enabled.
  - Prevented premature settings messages from being displayed or processed incorrectly.
  - Preserved complete protocol events when switching between raw and XML parsing modes.
  - Continued updating panel information during the connection handshake.

- **Documentation**
  - Clarified handshake behavior, settings uploads, and chat-mode reporting.
  - Documented raw-mode defaults and transitions to XML parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
