### PR TITLE
Let a compDef placeholder take its style the way its neighbours do

### DIFF
--- a/utils/wrayth-lab/README.md
+++ b/utils/wrayth-lab/README.md
@@ -119,6 +119,28 @@ These are the non-obvious bits, kept here because they cost real time to find:
   need to know which mode the *game* is in, or to gate any particular tag on it: a tag
   that arrives while the parser is off is text, and a tag that arrives while it is on is
   a tag.
+- **`<compDef>` on the main stream is a live placeholder, and it keeps the style it was
+  defined under.** `<compDef id='x'/>` in ordinary main-stream text reserves a spot that a
+  later `<component id='x'>…</component>` fills **in place**, rewriting a line that has
+  already scrolled by. The styling travels with the placeholder, not with the content: a
+  `compDef` on a `<style id="roomName"/>` line shows its content on the room-name
+  background even though the `<component>` that filled it came from an unstyled line.
+  Two things that surprised us:
+  - **A `<component>` whose placeholder does not exist yet is not retained.** Send the
+    `<component>` first and the later `compDef` renders empty and stays empty; send it
+    again afterwards and the spot fills. So this is a push to live placeholders, not a
+    store the client reads from.
+  - **A `compDef` inside a pushed style span never fills at all.** Inside
+    `<pushBold/>…<popBold/>` or `<preset id='…'>…</preset>` the spot renders empty and
+    stays empty however many `<component>` tags follow, while an identical `compDef` on
+    a plain line, or on a `<style>` line, fills fine. Reproduced on a freshly started
+    client with no other state. No parse error is reported, so the line is accepted -
+    it just never updates.
+- **`<style>` is connection state, not per-stream state.** A `<style id="roomName"/>` set
+  between `<pushStream id='thoughts'/>` and `<popStream/>` is still in force for the next
+  line written to main. So a client wanting to match Wrayth keeps one current style for
+  the connection rather than one per stream, and lets it persist across lines until
+  another `<style>` or a prompt clears it.
 - **Skin names are matched case-insensitively.** A widget names a skin entry with
   `<skin name='...'>`, and the real server and the real skin disagree about case:
   GS4 sends `name='healthBar'` (and `manaBar`, `staminaBar`, `spiritBar`) while

--- a/utils/wrayth-lab/README.md
+++ b/utils/wrayth-lab/README.md
@@ -136,6 +136,10 @@ These are the non-obvious bits, kept here because they cost real time to find:
     a plain line, or on a `<style>` line, fills fine. Reproduced on a freshly started
     client with no other state. No parse error is reported, so the line is accepted -
     it just never updates.
+  - **A `compDef` counts as output for prompt handling, even rendering nothing.** Two
+    `<prompt>`s with nothing between them collapse to one, and two with a `compDef`
+    between them both draw - same as if ordinary text had been sent. Useful as a
+    three-way control when checking prompt behaviour: nothing / text / `compDef`.
 - **`<style>` is connection state, not per-stream state.** A `<style id="roomName"/>` set
   between `<pushStream id='thoughts'/>` and `<popStream/>` is still in force for the next
   line written to main. So a client wanting to match Wrayth keeps one current style for

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -518,17 +518,8 @@ class WraythClient(
             }
 
             is WraythComponentDefinitionEvent -> {
-                // Should not happen on main stream, so don't clear prompt
-                // The placeholder keeps the style it was defined under, and later content substituted
-                // into it renders with that - which is what Wrayth does: a compDef inside a
-                // `<style id="roomName"/>` line shows its content on the room-name background even
-                // when the `<component>` that fills it arrives from an unstyled line.
-                //
-                // No styles here: bufferText applies currentStyle and then the stack, the same order
-                // it uses for the text either side of this on the line. Naming the stack here as well
-                // put it ahead of currentStyle in a first-set-wins list, so a placeholder resolved a
-                // style conflict the opposite way from its own neighbours (and any action on a pushed
-                // style was pushed twice).
+                // bufferText styles this the way it styles the text either side of it on the line,
+                // and content substituted in later renders with that.
                 bufferText(
                     text =
                         StyledString(

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -519,14 +519,23 @@ class WraythClient(
 
             is WraythComponentDefinitionEvent -> {
                 // Should not happen on main stream, so don't clear prompt
-                // TODO: Should currentStyle be used here? is it per stream?
+                // The placeholder keeps the style it was defined under, and later content substituted
+                // into it renders with that - which is what Wrayth does: a compDef inside a
+                // `<style id="roomName"/>` line shows its content on the room-name background even
+                // when the `<component>` that fills it arrives from an unstyled line.
+                //
+                // No styles here: bufferText applies currentStyle and then the stack, the same order
+                // it uses for the text either side of this on the line. Naming the stack here as well
+                // put it ahead of currentStyle in a first-set-wins list, so a placeholder resolved a
+                // style conflict the opposite way from its own neighbours (and any action on a pushed
+                // style was pushed twice).
                 bufferText(
                     text =
                         StyledString(
                             persistentListOf(
                                 StyledStringVariable(
                                     name = event.id,
-                                    styles = styleStack.toPersistentList(),
+                                    styles = persistentListOf(),
                                 ),
                             ),
                         ),


### PR DESCRIPTION
Answers the TODO in `WraythClient.kt` — "Should currentStyle be used here? is it per stream?" — and fixes what answering it turned up. Both questions settled against the real client on `utils/wrayth-lab`, not by reading our parser.

## The answers

**Should `currentStyle` be used?** Yes, and we already were, in `bufferText`. Wrayth agrees on the principle: a `compDef` on a `<style id="roomName"/>` line shows its content on the room-name background *even though the `<component>` that filled it arrived from an unstyled line*. The style travels with the placeholder, not the content.

**Is it per stream?** No. A `<style id="roomName"/>` set between `<pushStream id='thoughts'/>` and `<popStream/>` was still in force for the next line written to main. The single connection-level field is right.

## The bug

`resolve()` is first-set-wins ("most-specific first"). Naming `styleStack` at the call site put the stack **ahead** of `currentStyle`, so a placeholder settled a style conflict the opposite way from the text either side of it on the same line.

Our client, same construction, before the fix:

| line sent | rendering |
|---|---|
| `<style id="roomName"/>Z conflict-styled <pushBold/>[<compDef id='q2'/>]<popBold/> Z` | `[QQQ2]` **bold-yellow**, neighbours room-name styled |
| `<style id="roomName"/>W ordinary <pushBold/>BOLDTEXT<popBold/> W` | `BOLDTEXT` room-name styled |

Ordinary text gives `currentStyle` precedence; the placeholder gave it to the stack. The stack was also being applied twice over — once from the call site, once from `bufferText` — so any action carried by a pushed style got its link annotation pushed twice.

Dropping the call-site list fixes both: `bufferText` supplies `currentStyle` then the stack, in the same order it uses for every other leaf. Re-running the probes after the change, the conflict case is the only thing that moves, onto the same footing as its neighbours — `[ONE]`, `[TWO]`, `[FOUR]` and `[QQQ1]` render exactly as before.

## Protocol findings, now in the lab README

Two that cost time and are worth not rediscovering:

- **A `<component>` whose placeholder doesn't exist yet is not retained.** Send it before the `compDef` and the spot renders empty and *stays* empty; send it again afterwards and it fills. It's a push to live placeholders, not a store the client reads from. This is why the first probe looked like `compDef` didn't work on main at all.
- **A `compDef` inside a pushed style span never fills.** Inside `<pushBold/>…<popBold/>` or `<preset id='…'>…</preset>` the spot stays empty however many `<component>` tags follow, while an identical `compDef` on a plain line, or on a `<style>` line, fills fine. Reproduced on a freshly started client with no other state, and `recv` reports no parse error, so the line is accepted — it just never updates. We don't share the quirk; we fill those.

## Testing

No regression test. The read/handle path is inline in `WraythClient.connect`, behind `CharacterRepository` and `LoggingRepository` — concrete classes over a config store and Room — so a client-level test means real scaffolding rather than a fake or two. Verification here is the before/after comparison on the bench, driving the same probe file through both builds.

`./gradlew check -PiosSkip=true -PlintSkip=true` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected styling for live component placeholders so they no longer incorrectly inherit surrounding text styles.
  - Preserved styling for surrounding text rendered around component placeholders, including text before and after placeholders.

- **Documentation**
  - Added guidance on component placeholder styling, ordering, prompt handling, and limitations within pushed style spans.
  - Documented how styles persist across streams and lines until replaced or cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->