### PR TITLE
Hold the line's text and its open component as one value

### DIFF
--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/LineBuffer.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/LineBuffer.kt
@@ -1,0 +1,68 @@
+package warlockfe.warlock3.wrayth.network
+
+import warlockfe.warlock3.core.text.StyledString
+
+/**
+ * The text being assembled for the line currently being parsed, and the component being assembled
+ * inside it, if any.
+ *
+ * A component's id and its content are one value here so they cannot get out of step. Two questions
+ * are asked of this state by different callers - where appended text goes, and whether the line may
+ * be flushed yet - and both answers turn on whether a component is open. Held apart, a caller could
+ * answer them differently, and text would accumulate somewhere nothing ever flushed.
+ */
+internal class LineBuffer {
+    private var line: StyledString? = null
+    private var component: OpenComponent? = null
+
+    private data class OpenComponent(
+        val id: String,
+        val text: StyledString,
+    )
+
+    /** Appends to the open component if there is one, and to the line otherwise. */
+    fun append(text: StyledString) {
+        val open = component
+        if (open != null) {
+            component = open.copy(text = open.text + text)
+        } else {
+            line = line?.plus(text) ?: text
+        }
+    }
+
+    /** Starts a component, so that [append] gathers its content instead of the line's. */
+    fun openComponent(id: String) {
+        component = OpenComponent(id, StyledString())
+    }
+
+    /**
+     * Ends the open component and hands back its id and content, or null when none was open - a
+     * closing tag with nothing to close.
+     */
+    fun closeComponent(): Pair<String, StyledString>? =
+        component?.let { open ->
+            component = null
+            open.id to open.text
+        }
+
+    /**
+     * Abandons a half-gathered component, for the events that end a line's parsing while one is
+     * still open - a prompt, or a switch to another stream. Its content is not wanted, but the
+     * buffer has to go back to gathering the line's own text.
+     */
+    fun discardComponent() {
+        component = null
+    }
+
+    /**
+     * Takes the line's text and empties the buffer, or returns null while a component is still
+     * open. An empty line comes back as an empty [StyledString] rather than null, because a blank
+     * line is still a line.
+     */
+    fun takeLine(): StyledString? {
+        if (component != null) return null
+        val text = line ?: StyledString()
+        line = null
+        return text
+    }
+}

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -196,8 +196,7 @@ class WraythClient(
 
     // Line state variables
     private var isPrompting = false
-    private var streamBuffer: StyledString? = null
-    private var elementBuffer: StyledString? = null
+    private val lineBuffer = LineBuffer()
 
     private val cliCache = mutableListOf<CmdDefinition>()
 
@@ -229,7 +228,6 @@ class WraythClient(
 
     private var dialogDataId: String? = null
     private val directions: HashSet<Direction> = hashSetOf()
-    private var componentId: String? = null
 
     private val _disconnected = MutableStateFlow(false)
     override val disconnected = _disconnected.asStateFlow()
@@ -363,7 +361,7 @@ class WraythClient(
             }
 
             is WraythStreamEvent -> {
-                componentId = null
+                lineBuffer.discardComponent()
                 flushBuffer(true)
                 currentStream = getStream(event.id ?: "main")
             }
@@ -425,7 +423,7 @@ class WraythClient(
             is WraythPromptEvent -> {
                 currentTypeAhead.update { max(0, it - 1) }
                 styleStack.clear()
-                componentId = null
+                lineBuffer.discardComponent()
                 currentStyle = null
                 currentStream = null
                 if (!isPrompting) {
@@ -531,31 +529,28 @@ class WraythClient(
                             ),
                         ),
                 )
-                componentId = event.id
-                elementBuffer = StyledString()
+                lineBuffer.openComponent(event.id)
             }
 
             is WraythComponentStartEvent -> {
-                componentId = event.id
-                elementBuffer = StyledString()
+                lineBuffer.openComponent(event.id)
             }
 
             WraythComponentEndEvent -> {
-                if (componentId != null) {
+                val closed = lineBuffer.closeComponent()
+                if (closed != null) {
+                    val (id, value) = closed
                     // Either replace the component in the map with the new value
                     //  or remove the component from the map (if we got an empty one)
                     componentsMutex.withLock {
                         components =
-                            if (elementBuffer?.substrings.isNullOrEmpty()) {
-                                components.removing(componentId!!)
+                            if (value.substrings.isEmpty()) {
+                                components.removing(id)
                             } else {
-                                components.putting(componentId!!, elementBuffer!!)
+                                components.putting(id, value)
                             }
                     }
-                    val newValue = elementBuffer ?: StyledString()
-                    windowRegistry.updateComponent(componentId!!, newValue)
-                    elementBuffer = null
-                    componentId = null
+                    windowRegistry.updateComponent(id, value)
                 } else {
                     // mismatched component tags?
                 }
@@ -805,11 +800,7 @@ class WraythClient(
         currentStyle?.let { styledText = styledText.applyStyle(it) }
         styleStack.forEach { styledText = styledText.applyStyle(it) }
         if (monospace) styledText = styledText.applyMonospace()
-        if (elementBuffer != null) {
-            elementBuffer = elementBuffer!!.plus(styledText)
-        } else {
-            streamBuffer = streamBuffer?.plus(styledText) ?: styledText
-        }
+        lineBuffer.append(styledText)
     }
 
     private suspend fun appendToStream(
@@ -855,13 +846,11 @@ class WraythClient(
         }
     }
 
-    // TODO: separate buffer into its own class
     private suspend fun flushBuffer(ignoreWhenBlank: Boolean) {
-        if (componentId == null) {
-            val styledText = streamBuffer ?: StyledString()
-            appendToStream(styledText, currentStream ?: getMainStream(), ignoreWhenBlank)
-            streamBuffer = null
-        }
+        // Null while a component is still open: its content is not the line's, and the line is not
+        // finished until the component that interrupted it closes.
+        val styledText = lineBuffer.takeLine() ?: return
+        appendToStream(styledText, currentStream ?: getMainStream(), ignoreWhenBlank)
     }
 
     override suspend fun sendCommand(line: String): SendCommandType =

--- a/wrayth/src/commonTest/kotlin/LineBufferTests.kt
+++ b/wrayth/src/commonTest/kotlin/LineBufferTests.kt
@@ -1,0 +1,113 @@
+import warlockfe.warlock3.core.text.StyledString
+import warlockfe.warlock3.wrayth.network.LineBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LineBufferTests {
+    private fun LineBuffer.append(text: String) = append(StyledString(text))
+
+    @Test
+    fun textAppendedWithNoComponentOpenBelongsToTheLine() {
+        val buffer = LineBuffer()
+
+        buffer.append("one ")
+        buffer.append("two")
+
+        assertEquals("one two", buffer.takeLine()?.toText())
+    }
+
+    @Test
+    fun takingTheLineEmptiesIt() {
+        val buffer = LineBuffer()
+        buffer.append("first line")
+        buffer.takeLine()
+
+        assertEquals("", buffer.takeLine()?.toText())
+    }
+
+    @Test
+    fun anEmptyLineIsStillALine() {
+        // A blank line renders as one, so the caller needs an empty string here rather than null -
+        // null is reserved for "a component is open, do not flush yet".
+        assertEquals("", LineBuffer().takeLine()?.toText())
+    }
+
+    @Test
+    fun textAppendedWhileAComponentIsOpenBelongsToTheComponent() {
+        val buffer = LineBuffer()
+
+        buffer.append("line ")
+        buffer.openComponent("room objs")
+        buffer.append("a dummy")
+
+        assertEquals("room objs" to "a dummy", buffer.closeComponent()?.let { it.first to it.second.toText() })
+        assertEquals("line ", buffer.takeLine()?.toText())
+    }
+
+    @Test
+    fun theLineCannotBeTakenWhileAComponentIsOpen() {
+        val buffer = LineBuffer()
+        buffer.append("line ")
+        buffer.openComponent("room objs")
+
+        assertNull(buffer.takeLine())
+    }
+
+    @Test
+    fun closingWithNothingOpenReportsNothing() {
+        assertNull(LineBuffer().closeComponent())
+    }
+
+    @Test
+    fun closingAComponentReturnsTheLineToGatheringItsOwnText() {
+        val buffer = LineBuffer()
+        buffer.append("before ")
+        buffer.openComponent("room objs")
+        buffer.append("a dummy")
+        buffer.closeComponent()
+
+        buffer.append("after")
+
+        assertEquals("before after", buffer.takeLine()?.toText())
+    }
+
+    @Test
+    fun discardingAComponentReturnsTheLineToGatheringItsOwnText() {
+        // The case a prompt or a stream switch hits: a component is open and its content is
+        // abandoned. Whatever comes next is the line's again, and the line has to stay flushable -
+        // when these came apart, every later line went somewhere nothing flushed and the stream
+        // fell permanently silent.
+        val buffer = LineBuffer()
+        buffer.openComponent("room objs")
+        buffer.append("abandoned")
+
+        buffer.discardComponent()
+        buffer.append("after the prompt")
+
+        assertEquals("after the prompt", buffer.takeLine()?.toText())
+    }
+
+    @Test
+    fun aDiscardedComponentIsNotReportedByAClosingTagThatFollows() {
+        val buffer = LineBuffer()
+        buffer.openComponent("room objs")
+        buffer.append("abandoned")
+        buffer.discardComponent()
+
+        assertNull(buffer.closeComponent())
+    }
+
+    @Test
+    fun openingAComponentDoesNotCarryThePreviousOnesText() {
+        val buffer = LineBuffer()
+        buffer.openComponent("first")
+        buffer.append("first content")
+        buffer.closeComponent()
+
+        buffer.openComponent("second")
+        buffer.append("second content")
+
+        assertEquals("second content", buffer.closeComponent()?.second?.toText())
+    }
+}


### PR DESCRIPTION
Answers the `// TODO: separate buffer into its own class` above `flushBuffer`. Yes — but the reason turned out to be stronger than tidiness: the invariant a class would enforce is already broken, and breaking it takes the main window out for the rest of the session.

## What was wrong

Three fields had to agree and nothing made them:

- `bufferText` routed on `elementBuffer != null`
- `flushBuffer` gated on `componentId == null`
- two handlers cleared **`componentId` alone** — `WraythStreamEvent` and `WraythPromptEvent`

Once those two disagree they never re-converge. Every later line accumulates into an element buffer nothing flushes, `streamBuffer` stays null, and `flushBuffer` cheerfully flushes nothing.

Driven through the client on the bench:

```
BEFORE visible
<component id='x'>foo<prompt time="...">&gt;</prompt>bar</component>
AFTER-A does this appear?
AFTER-B does this appear?
AFTER-C does this appear?
```

`BEFORE` renders. **A, B and C never appear, and nothing appears ever again.** After the fix all three render, and `bar` lands on the line instead of vanishing.

Two honest limits on the severity. It needs a reset event *inside* a component on one line, which is malformed — no real server sends that. And an unterminated `<component>` spanning a line does **not** trigger it, because `handleContent` rule #5 closes open tags at end of line; I checked that case first and it was clean. What makes it worth fixing anyway is that `WraythProtocolHandler` carries five numbered rules for malformed tags precisely because malformed input turns up, and going permanently blind is a poor way to meet it.

## The change

`LineBuffer` holds the line's text and the open component as one value, so the id and its content cannot come apart. The operations are the ones that actually exist — `append`, `openComponent`, `closeComponent`, `discardComponent`, `takeLine` — and both `closeComponent` and `discardComponent` end with the line gathering its own text again, which is what the old pair of assignments was reaching for and only half did.

Two things it deliberately does not do:

- **It doesn't own the flush.** `flushBuffer` needs `currentStream`, the windows map, `isPrompting` and logging; the class returns the text and lets the client place it, or half the client comes with it.
- **`takeLine()` returns an empty `StyledString`, not null, for an empty line** — a blank line is still a line. Null is reserved for "a component is open, don't flush yet", which is the old `componentId == null` guard.

## Testing

10 tests over the contract, including the discard path that the prompt and stream handlers take. Plus the bench sequence above, and a check that ordinary rendering is unchanged — a `<compDef>` placeholder still fills from a later `<component>`.

`./gradlew check -PiosSkip=true -PlintSkip=true` passes.

**Performance:** A/B'd against the same tree without this commit using `:compose:streamNetworkBenchmark` (2 connections, 20k lines, 7 interleaved rounds each). No measurable difference — median 853.6ms vs 830.4ms, but run-to-run stdev is ~110ms and the paired per-round deltas swing ±245ms with a mean of +4ms, so the harness cannot resolve a difference this small. That matches what the code says it should be: the line path allocates exactly as before, and only appends *inside* a component allocate one extra short-lived object, on a path that already allocates a `StyledString` per append.

Note this benchmark only became meaningful again with #288 — before that it ran the client in raw mode start to finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed text and styled components.
  * Prevented incomplete component content from being displayed as a finished line.
  * Preserved blank lines and ensured discarded components no longer appear.
  * Improved recovery when components are closed or interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->