### PR TITLE
Keep the command list between runs and ask for what changed

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -75,6 +75,7 @@ import warlockfe.warlock3.core.window.WindowRegistry
 import warlockfe.warlock3.wrayth.network.SgeClientImpl
 import warlockfe.warlock3.wrayth.network.WraythClient
 import warlockfe.warlock3.wrayth.settings.WraythImporter
+import warlockfe.warlock3.wrayth.util.CommandListStore
 
 abstract class AppContainer(
     val database: PrefsDatabase,
@@ -100,6 +101,10 @@ abstract class AppContainer(
     // Client-wide settings and the connection/character registry live in their own TOML files
     // (client.toml, connections.toml), separate from the per-character files above.
     val clientConfigStore = ClientConfigStore(warlockDirs.configDir, fileSystem)
+
+    // Derived data, refetched from the server whenever it is missing, so it lives with the data
+    // rather than the configuration.
+    val commandListStore = CommandListStore(warlockDirs.dataDir)
 
     val variableRepository = VariableRepository(characterConfigStore)
     val characterRepository = CharacterRepository(clientConfigStore)
@@ -241,6 +246,7 @@ abstract class AppContainer(
                     fileLogging = loggingRepository,
                     ioDispatcher = ioDispatcher,
                     socket = socket,
+                    commandListStore = commandListStore,
                 )
         }
 

--- a/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
+++ b/compose/src/jvmBenchmark/kotlin/warlockfe/warlock3/compose/util/StreamNetworkBenchmark.kt
@@ -254,6 +254,8 @@ private suspend fun runConnection(
             fileLogging = loggingRepository,
             ioDispatcher = ioDispatcher,
             socket = socket,
+            // No cache: every run should look like a first login, not like the one before it.
+            commandListStore = null,
         )
 
     // Representative eventFlow subscribers. The always-on GameViewModel-style collector runs on the

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -69,6 +69,7 @@ import warlockfe.warlock3.wrayth.protocol.WraythCastTimeEvent
 import warlockfe.warlock3.wrayth.protocol.WraythClearStreamEvent
 import warlockfe.warlock3.wrayth.protocol.WraythCliEvent
 import warlockfe.warlock3.wrayth.protocol.WraythCloseDialogEvent
+import warlockfe.warlock3.wrayth.protocol.WraythCmdTimestampEvent
 import warlockfe.warlock3.wrayth.protocol.WraythCompassEndEvent
 import warlockfe.warlock3.wrayth.protocol.WraythComponentDefinitionEvent
 import warlockfe.warlock3.wrayth.protocol.WraythComponentEndEvent
@@ -110,6 +111,7 @@ import warlockfe.warlock3.wrayth.protocol.WraythTimeEvent
 import warlockfe.warlock3.wrayth.protocol.WraythUnhandledTagEvent
 import warlockfe.warlock3.wrayth.protocol.WraythUpdateVerbsEvent
 import warlockfe.warlock3.wrayth.util.CmdDefinition
+import warlockfe.warlock3.wrayth.util.CommandListStore
 import warlockfe.warlock3.wrayth.util.WraythCmd
 import warlockfe.warlock3.wrayth.util.WraythStreamWindow
 import warlockfe.warlock3.wrayth.util.resolve
@@ -127,6 +129,7 @@ class WraythClient(
     private val fileLogging: LoggingRepository,
     private val ioDispatcher: CoroutineDispatcher,
     private val socket: WarlockSocket,
+    private val commandListStore: CommandListStore?,
 ) : WarlockClient {
     private val writeContext = ioDispatcher.limitedParallelism(1)
 
@@ -201,6 +204,10 @@ class WraythClient(
     private val cliCache = mutableListOf<CmdDefinition>()
 
     private var cliCoords = persistentMapOf<String, CmdDefinition>()
+
+    // The list `<updateverbs>` named, and the serial of the copy we hold, for `_menu update`.
+    private var verbListName: String? = null
+    private var commandListSerial: String? = null
 
     private val _menuData = MutableStateFlow(WarlockMenuData(0, emptyList()))
     override val menuData: StateFlow<WarlockMenuData> = _menuData.asStateFlow()
@@ -626,7 +633,28 @@ class WraythClient(
             }
 
             is WraythUpdateVerbsEvent -> {
-                sendCommandDirect("_menu update 1")
+                // Load before asking, so a server that answers "nothing new" leaves us with a full
+                // set of commands rather than none. Without a cached list the serial is 1, which is
+                // what the real client sends when it has only the list that shipped with it.
+                val listName = event.listName
+                verbListName = listName
+                // Only on the way in: this tag arrives more than once a session, and by the second
+                // time the list is already in hand and the file has nothing newer to say.
+                val cached = if (commandListSerial == null) listName?.let { commandListStore?.load(it) } else null
+                if (cached != null) {
+                    commandListSerial = cached.serial
+                    cliCoords =
+                        cliCoords.mutate { map ->
+                            cached.commands.forEach { map[it.coord] = it }
+                        }
+                }
+                sendCommandDirect("_menu update ${commandListSerial ?: "1"}")
+            }
+
+            is WraythCmdTimestampEvent -> {
+                // Arrives just after `</cmdlist>`, so the entries it names are already merged in.
+                commandListSerial = event.serial
+                verbListName?.let { commandListStore?.save(it, event.serial, cliCoords.values) }
             }
 
             is WraythStartCmdList -> {

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythEvent.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythEvent.kt
@@ -160,7 +160,21 @@ data class WraythUnhandledTagEvent(
     val tag: String,
 ) : WraythEvent
 
-data object WraythUpdateVerbsEvent : WraythEvent
+/**
+ * The server asking for the command list to be refreshed. [listName] is the `default` attribute, which
+ * names the list rather than the game - Wrayth files its own cache under a directory of that name.
+ */
+data class WraythUpdateVerbsEvent(
+    val listName: String?,
+) : WraythEvent
+
+/**
+ * The serial of the command list just sent, arriving right after `</cmdlist>`. Sending it back with the
+ * next `_menu update` is how a client says which list it already holds.
+ */
+data class WraythCmdTimestampEvent(
+    val serial: String,
+) : WraythEvent
 
 data object WraythStartCmdList : WraythEvent
 

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
@@ -17,6 +17,7 @@ import warlockfe.warlock3.wrayth.protocol.elements.CliHandler
 import warlockfe.warlock3.wrayth.protocol.elements.CloseButtonHandler
 import warlockfe.warlock3.wrayth.protocol.elements.CloseDialogHandler
 import warlockfe.warlock3.wrayth.protocol.elements.CmdButtonHandler
+import warlockfe.warlock3.wrayth.protocol.elements.CmdTimestampHandler
 import warlockfe.warlock3.wrayth.protocol.elements.CmdlistHandler
 import warlockfe.warlock3.wrayth.protocol.elements.CompDefHandler
 import warlockfe.warlock3.wrayth.protocol.elements.CompassHandler
@@ -130,6 +131,7 @@ class WraythProtocolHandler {
             "closeDialog" to CloseDialogHandler(),
             "cmdButton" to CmdButtonHandler(),
             "cmdlist" to CmdlistHandler(),
+            "cmdtimestamp" to CmdTimestampHandler(),
             "compass" to CompassHandler(),
             "compDef" to CompDefHandler(),
             "component" to ComponentHandler(),
@@ -207,7 +209,6 @@ class WraythProtocolHandler {
             "vars" to IgnoredTagHandler(),
             "w" to IgnoredTagHandler(),
             // The rest arrive during play.
-            "cmdtimestamp" to IgnoredTagHandler(),
             "command" to IgnoredTagHandler(),
             "deleteContainer" to IgnoredTagHandler(),
             "endSetup" to IgnoredTagHandler(),

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/CmdTimestampHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/CmdTimestampHandler.kt
@@ -1,0 +1,10 @@
+package warlockfe.warlock3.wrayth.protocol.elements
+
+import warlockfe.warlock3.wrayth.protocol.BaseElementListener
+import warlockfe.warlock3.wrayth.protocol.StartElement
+import warlockfe.warlock3.wrayth.protocol.WraythCmdTimestampEvent
+import warlockfe.warlock3.wrayth.protocol.WraythEvent
+
+class CmdTimestampHandler : BaseElementListener() {
+    override fun startElement(element: StartElement): WraythEvent? = element.attributes["data"]?.let { WraythCmdTimestampEvent(it) }
+}

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/UpdateVerbsHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/elements/UpdateVerbsHandler.kt
@@ -6,5 +6,5 @@ import warlockfe.warlock3.wrayth.protocol.WraythEvent
 import warlockfe.warlock3.wrayth.protocol.WraythUpdateVerbsEvent
 
 class UpdateVerbsHandler : BaseElementListener() {
-    override fun startElement(element: StartElement): WraythEvent? = WraythUpdateVerbsEvent
+    override fun startElement(element: StartElement): WraythEvent? = WraythUpdateVerbsEvent(element.attributes["default"])
 }

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/util/CommandListStore.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/util/CommandListStore.kt
@@ -1,0 +1,122 @@
+package warlockfe.warlock3.wrayth.util
+
+import co.touchlab.kermit.Logger
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readLine
+import kotlinx.io.writeString
+
+/**
+ * The command list a server sends in response to `_menu update`, kept between runs.
+ *
+ * The list is large - a real GemStone connection sends around 600 entries in chunks of 300, and the
+ * real client's own cache has grown past a thousand - and it is the same list every login. A server
+ * only needs to send what a client is missing, and says which list it just sent with a serial in
+ * `<cmdtimestamp>`. Hand that serial back on the next `_menu update` and it knows where to start.
+ *
+ * Shaped like the protocol, one `<cli>` per line, because the real client's own cache is exactly that
+ * - `timestamp` and `count` attributes included - in `%APPDATA%/StormFront/<list>/cmdlist1.xml`, and a
+ * file that can be diffed against that one is worth more than a tidier format. It is written and read
+ * here rather than by the protocol parser, so the escaping only has to agree with itself.
+ */
+class CommandListStore(
+    private val baseDir: String,
+) {
+    private val logger = Logger.withTag("CommandListStore")
+
+    data class CachedList(
+        val serial: String,
+        val commands: List<CmdDefinition>,
+    )
+
+    /**
+     * Reads the list cached for [listName], or null when there is none, it cannot be read, or it has
+     * no serial - all of which just mean asking the server for the list from scratch.
+     */
+    fun load(listName: String): CachedList? {
+        val path = pathFor(listName)
+        return try {
+            if (!SystemFileSystem.exists(path)) return null
+            var serial: String? = null
+            val commands = mutableListOf<CmdDefinition>()
+            SystemFileSystem.source(path).buffered().use { source ->
+                while (true) {
+                    val line = source.readLine() ?: break
+                    if (serial == null) {
+                        serial = line.attribute("timestamp")
+                    }
+                    parseCli(line)?.let { commands.add(it) }
+                }
+            }
+            serial?.let { CachedList(it, commands) }
+        } catch (e: Exception) {
+            // A cache that cannot be read is only a slower login, so log it and move on.
+            logger.w(e) { "Could not read the cached command list for $listName" }
+            null
+        }
+    }
+
+    /** Writes [commands] and the [serial] the server gave them, replacing whatever was there. */
+    fun save(
+        listName: String,
+        serial: String,
+        commands: Collection<CmdDefinition>,
+    ) {
+        try {
+            SystemFileSystem.createDirectories(Path(baseDir, DIRECTORY))
+            val path = pathFor(listName)
+            SystemFileSystem.sink(path).buffered().use { sink ->
+                sink.writeString("<cmdlist timestamp=\"${serial.escaped()}\" count=\"${commands.size}\">\n")
+                commands.forEach { cmd ->
+                    sink.writeString(
+                        "<cli coord=\"${cmd.coord.escaped()}\"" +
+                            " menu=\"${cmd.menu.escaped()}\"" +
+                            " command=\"${cmd.command.escaped()}\"" +
+                            " menu_cat=\"${cmd.category.escaped()}\"/>\n",
+                    )
+                }
+                sink.writeString("</cmdlist>\n")
+            }
+        } catch (e: Exception) {
+            // Same again: failing to cache costs a re-send next time, nothing more.
+            logger.w(e) { "Could not write the cached command list for $listName" }
+        }
+    }
+
+    private fun pathFor(listName: String) = Path(baseDir, DIRECTORY, "${listName.fileNameSafe()}.xml")
+
+    companion object {
+        private const val DIRECTORY = "cmdlists"
+
+        // The list name comes from the server, so it does not get to name a file on its own terms.
+        private fun String.fileNameSafe() = map { if (it.isLetterOrDigit() || it == '-' || it == '_') it else '_' }.joinToString("")
+
+        private fun String.escaped() =
+            replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+
+        private fun String.unescaped() =
+            replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&quot;", "\"")
+                .replace("&amp;", "&")
+
+        private fun String.attribute(name: String): String? {
+            val start = indexOf("$name=\"").takeIf { it >= 0 }?.plus(name.length + 2) ?: return null
+            val end = indexOf('"', start).takeIf { it >= 0 } ?: return null
+            return substring(start, end).unescaped()
+        }
+
+        private fun parseCli(line: String): CmdDefinition? {
+            if (!line.startsWith("<cli ")) return null
+            val coord = line.attribute("coord") ?: return null
+            val command = line.attribute("command") ?: return null
+            val menu = line.attribute("menu") ?: return null
+            val category = line.attribute("menu_cat") ?: return null
+            return CmdDefinition(coord = coord, command = command, menu = menu, category = category)
+        }
+    }
+}

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/util/CommandListStore.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/util/CommandListStore.kt
@@ -39,17 +39,29 @@ class CommandListStore(
         return try {
             if (!SystemFileSystem.exists(path)) return null
             var serial: String? = null
+            var expectedCount: Int? = null
             val commands = mutableListOf<CmdDefinition>()
             SystemFileSystem.source(path).buffered().use { source ->
                 while (true) {
                     val line = source.readLine() ?: break
                     if (serial == null) {
                         serial = line.attribute("timestamp")
+                        expectedCount = line.attribute("count")?.toIntOrNull()
                     }
                     parseCli(line)?.let { commands.add(it) }
                 }
             }
-            serial?.let { CachedList(it, commands) }
+            if (serial == null) return null
+            // The header promises how many entries follow. A file that does not keep that promise is
+            // short, and a short list here is worse than none: its serial would tell the server we are
+            // up to date, and the commands missing from it would stay missing.
+            if (expectedCount != commands.size) {
+                logger.w {
+                    "Ignoring the cached command list for $listName: it says $expectedCount commands and has ${commands.size}."
+                }
+                return null
+            }
+            CachedList(serial, commands)
         } catch (e: Exception) {
             // A cache that cannot be read is only a slower login, so log it and move on.
             logger.w(e) { "Could not read the cached command list for $listName" }
@@ -63,10 +75,13 @@ class CommandListStore(
         serial: String,
         commands: Collection<CmdDefinition>,
     ) {
+        val path = pathFor(listName)
+        // Written beside the real file and moved over it, so an interrupted write leaves the previous
+        // list in place rather than a half of this one.
+        val partial = Path(path.parent!!, path.name + ".partial")
         try {
             SystemFileSystem.createDirectories(Path(baseDir, DIRECTORY))
-            val path = pathFor(listName)
-            SystemFileSystem.sink(path).buffered().use { sink ->
+            SystemFileSystem.sink(partial).buffered().use { sink ->
                 sink.writeString("<cmdlist timestamp=\"${serial.escaped()}\" count=\"${commands.size}\">\n")
                 commands.forEach { cmd ->
                     sink.writeString(
@@ -77,10 +92,13 @@ class CommandListStore(
                     )
                 }
                 sink.writeString("</cmdlist>\n")
+                sink.flush()
             }
+            SystemFileSystem.atomicMove(partial, path)
         } catch (e: Exception) {
             // Same again: failing to cache costs a re-send next time, nothing more.
             logger.w(e) { "Could not write the cached command list for $listName" }
+            runCatching { SystemFileSystem.delete(partial, mustExist = false) }
         }
     }
 

--- a/wrayth/src/commonTest/kotlin/CommandListStoreTests.kt
+++ b/wrayth/src/commonTest/kotlin/CommandListStoreTests.kt
@@ -1,0 +1,116 @@
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.files.SystemTemporaryDirectory
+import warlockfe.warlock3.wrayth.util.CmdDefinition
+import warlockfe.warlock3.wrayth.util.CommandListStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CommandListStoreTests {
+    private var counter = 0
+
+    private fun store(): CommandListStore {
+        // A directory of its own per store, so one test cannot read another's file.
+        val dir = Path(SystemTemporaryDirectory, "cmdlist-test-${counter++}-${this.hashCode()}")
+        SystemFileSystem.createDirectories(dir)
+        return CommandListStore(dir.toString())
+    }
+
+    private fun cmd(
+        coord: String,
+        command: String = "look at #",
+        menu: String = "look at @",
+        category: String = "1",
+    ) = CmdDefinition(coord = coord, command = command, menu = menu, category = category)
+
+    @Test
+    fun nothingCachedYet() {
+        assertNull(store().load("GS4"))
+    }
+
+    @Test
+    fun aSavedListComesBackWithItsSerial() {
+        val store = store()
+        val commands = listOf(cmd("2524,1587"), cmd("2524,2462", command = "stab # left leg"))
+
+        store.save("GS4", "1776042608.1.1.1", commands)
+        val loaded = store.load("GS4")
+
+        assertEquals("1776042608.1.1.1", loaded?.serial)
+        assertEquals(commands, loaded?.commands)
+    }
+
+    @Test
+    fun everyFieldSurvivesTheRoundTrip() {
+        val store = store()
+        val command = cmd(coord = "2524,12632", command = "cman dislodge #", menu = "dislodge @", category = "6_combat maneuvers")
+
+        store.save("GS4", "1.1.1.1", listOf(command))
+
+        assertEquals(command, store.load("GS4")?.commands?.single())
+    }
+
+    @Test
+    fun markupInACommandSurvivesTheRoundTrip() {
+        // Menu text is server-supplied and does reach for punctuation - "swear at @ thornily" is real.
+        // Anything that would end an attribute early has to come back as it went in.
+        val store = store()
+        val command =
+            cmd(
+                coord = "2524,1692",
+                command = """say "hi" & <wave>""",
+                menu = """say "hi" & <wave> @""",
+                category = "5_roleplay & such",
+            )
+
+        store.save("GS4", "1.1.1.1", listOf(command))
+
+        assertEquals(command, store.load("GS4")?.commands?.single())
+    }
+
+    @Test
+    fun savingAgainReplacesWhatWasThere() {
+        val store = store()
+        store.save("GS4", "1.1.1.1", listOf(cmd("2524,1"), cmd("2524,2")))
+
+        store.save("GS4", "2.1.1.1", listOf(cmd("2524,3")))
+
+        val loaded = store.load("GS4")
+        assertEquals("2.1.1.1", loaded?.serial)
+        assertEquals(listOf(cmd("2524,3")), loaded?.commands)
+    }
+
+    @Test
+    fun listsAreKeptApartByName() {
+        val store = store()
+        store.save("GS4", "1.1.1.1", listOf(cmd("2524,1")))
+        store.save("DR", "2.1.1.1", listOf(cmd("9999,1")))
+
+        assertEquals("1.1.1.1", store.load("GS4")?.serial)
+        assertEquals(listOf(cmd("9999,1")), store.load("DR")?.commands)
+    }
+
+    @Test
+    fun aListNameCannotEscapeTheCacheDirectory() {
+        val store = store()
+
+        store.save("../../escaped", "1.1.1.1", listOf(cmd("2524,1")))
+
+        // Whatever it wrote, it read back under the same name and nowhere above the cache directory.
+        assertEquals(listOf(cmd("2524,1")), store.load("../../escaped")?.commands)
+        assertTrue(SystemFileSystem.exists(Path(SystemTemporaryDirectory, "cmdlists")).not())
+    }
+
+    @Test
+    fun anEmptyListStillRecordsItsSerial() {
+        // "You are up to date" is worth remembering; otherwise the next login asks from scratch.
+        val store = store()
+
+        store.save("GS4", "5.1.1.1", emptyList())
+
+        assertEquals("5.1.1.1", store.load("GS4")?.serial)
+        assertEquals(emptyList(), store.load("GS4")?.commands)
+    }
+}

--- a/wrayth/src/commonTest/kotlin/CommandListStoreTests.kt
+++ b/wrayth/src/commonTest/kotlin/CommandListStoreTests.kt
@@ -1,22 +1,33 @@
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.SystemTemporaryDirectory
+import kotlinx.io.readString
+import kotlinx.io.writeString
 import warlockfe.warlock3.wrayth.util.CmdDefinition
 import warlockfe.warlock3.wrayth.util.CommandListStore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Clock
 
 class CommandListStoreTests {
-    private var counter = 0
-
-    private fun store(): CommandListStore {
-        // A directory of its own per store, so one test cannot read another's file.
-        val dir = Path(SystemTemporaryDirectory, "cmdlist-test-${counter++}-${this.hashCode()}")
+    // A directory of its own per store, so no test reads another's file - and none reads one left
+    // behind by an earlier run, which a per-instance counter does not give you, since the test
+    // framework builds a fresh instance per test and every one of them would start again at zero.
+    private fun tempDir(): Path {
+        val dir = Path(SystemTemporaryDirectory, "cmdlist-test-$RUN_ID-${counter++}")
         SystemFileSystem.createDirectories(dir)
-        return CommandListStore(dir.toString())
+        return dir
     }
+
+    companion object {
+        private val RUN_ID = Clock.System.now().toEpochMilliseconds()
+        private var counter = 0
+    }
+
+    private fun store(): CommandListStore = CommandListStore(tempDir().toString())
 
     private fun cmd(
         coord: String,
@@ -112,5 +123,82 @@ class CommandListStoreTests {
 
         assertEquals("5.1.1.1", store.load("GS4")?.serial)
         assertEquals(emptyList(), store.load("GS4")?.commands)
+    }
+
+    @Test
+    fun aTruncatedCacheIsRefusedRatherThanTrusted() {
+        // The nastiest shape this can take: a header carrying the serial, and only some of the
+        // commands it promises. Trusting it would tell the server we are up to date while the
+        // commands missing from it stayed missing, for as long as the serial did not change.
+        val dir = tempDir()
+        val store = CommandListStore(dir.toString())
+        store.save("GS4", "1.1.1.1", listOf(cmd("2524,1"), cmd("2524,2"), cmd("2524,3")))
+        val path = Path(dir, "cmdlists", "GS4.xml")
+        val whole = SystemFileSystem.source(path).buffered().use { it.readString() }
+        val truncated = whole.lineSequence().take(2).joinToString("\n") + "\n"
+        SystemFileSystem.sink(path).buffered().use { it.writeString(truncated) }
+
+        assertNull(store.load("GS4"))
+    }
+
+    @Test
+    fun aCacheWithNoCountIsRefused() {
+        val dir = tempDir()
+        val store = CommandListStore(dir.toString())
+        SystemFileSystem.createDirectories(Path(dir, "cmdlists"))
+        SystemFileSystem.sink(Path(dir, "cmdlists", "GS4.xml")).buffered().use {
+            it.writeString("<cmdlist timestamp=\"1.1.1.1\">\n</cmdlist>\n")
+        }
+
+        assertNull(store.load("GS4"))
+    }
+
+    @Test
+    fun anInterruptedWriteLeavesThePreviousListInPlace() {
+        // Tears the write for real: save() iterates the collection it is given, and this one stops
+        // partway. Writing straight to the cache file would leave the header and two entries of a
+        // list claiming four - which is exactly the shape load() must never be handed.
+        val dir = tempDir()
+        val store = CommandListStore(dir.toString())
+        store.save("GS4", "1.1.1.1", listOf(cmd("2524,1")))
+
+        store.save("GS4", "9.9.9.9", failingCollection(size = 4, failAfter = 2))
+
+        val loaded = store.load("GS4")
+        assertEquals("1.1.1.1", loaded?.serial)
+        assertEquals(listOf(cmd("2524,1")), loaded?.commands)
+    }
+
+    /** A collection that yields [failAfter] entries and then gives up, reporting [size] all along. */
+    private fun failingCollection(
+        size: Int,
+        failAfter: Int,
+    ) = object : AbstractCollection<CmdDefinition>() {
+        override val size = size
+
+        override fun iterator() =
+            object : Iterator<CmdDefinition> {
+                private var yielded = 0
+
+                override fun hasNext() = yielded < size
+
+                override fun next(): CmdDefinition {
+                    if (yielded >= failAfter) throw IllegalStateException("write interrupted")
+                    return cmd("2524,${yielded++}")
+                }
+            }
+    }
+
+    @Test
+    fun aSaveOverAnExistingListReplacesItWholesale() {
+        val dir = tempDir()
+        val store = CommandListStore(dir.toString())
+        store.save("GS4", "1.1.1.1", List(5) { cmd("2524,$it") })
+
+        store.save("GS4", "2.1.1.1", listOf(cmd("2524,99")))
+
+        val loaded = store.load("GS4")
+        assertEquals("2.1.1.1", loaded?.serial)
+        assertEquals(listOf(cmd("2524,99")), loaded?.commands)
     }
 }

--- a/wrayth/src/commonTest/kotlin/WraythCommandListTests.kt
+++ b/wrayth/src/commonTest/kotlin/WraythCommandListTests.kt
@@ -1,0 +1,57 @@
+import warlockfe.warlock3.wrayth.protocol.WraythCliEvent
+import warlockfe.warlock3.wrayth.protocol.WraythCmdTimestampEvent
+import warlockfe.warlock3.wrayth.protocol.WraythProtocolHandler
+import warlockfe.warlock3.wrayth.protocol.WraythUpdateVerbsEvent
+import warlockfe.warlock3.wrayth.util.CmdDefinition
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WraythCommandListTests {
+    @Test
+    fun updateVerbsCarriesTheListName() {
+        val events = WraythProtocolHandler().parseLine("""<updateverbs default="GS4"/>""")
+
+        assertEquals(WraythUpdateVerbsEvent("GS4"), events.first())
+    }
+
+    @Test
+    fun updateVerbsWithoutADefaultNamesNoList() {
+        val events = WraythProtocolHandler().parseLine("<updateverbs/>")
+
+        assertEquals(WraythUpdateVerbsEvent(null), events.first())
+    }
+
+    @Test
+    fun cmdTimestampCarriesTheSerial() {
+        val events = WraythProtocolHandler().parseLine("""<cmdtimestamp data='1776042608.1.1.1'/>""")
+
+        assertEquals(WraythCmdTimestampEvent("1776042608.1.1.1"), events.first())
+    }
+
+    @Test
+    fun aListAndItsSerialArriveOnOneLine() {
+        // Exactly as a real GemStone connection sends it: the serial follows </cmdlist> on the same
+        // line, so the entries it names are already in hand by the time it is read.
+        val events =
+            WraythProtocolHandler().parseLine(
+                "<cmdlist>" +
+                    """<cli coord="2524,2295" menu="garrote stop" command="garrote stop" menu_cat="6"/>""" +
+                    """<cli coord="2524,12632" menu="dislodge @" command="cman dislodge #" menu_cat="6_combat maneuvers"/>""" +
+                    "</cmdlist><cmdtimestamp data='1776042608.1.1.1'/>",
+            )
+
+        assertEquals(
+            listOf(
+                CmdDefinition(coord = "2524,2295", menu = "garrote stop", command = "garrote stop", category = "6"),
+                CmdDefinition(
+                    coord = "2524,12632",
+                    menu = "dislodge @",
+                    command = "cman dislodge #",
+                    category = "6_combat maneuvers",
+                ),
+            ),
+            events.filterIsInstance<WraythCliEvent>().map { it.cmd },
+        )
+        assertEquals(WraythCmdTimestampEvent("1776042608.1.1.1"), events.filterIsInstance<WraythCmdTimestampEvent>().single())
+    }
+}


### PR DESCRIPTION
`_menu update 1` says "I have nothing", so the server sends the whole command list on every login. On a real GemStone connection that is ~600 entries arriving as two chunks of 300, every single time. It only ever needs to say that once.

## Where the serial was hiding

It arrives in its own tag, on the same line, immediately after the list:

```
</cmdlist><cmdtimestamp data='1776042608.1.1.1'/>
```

We were throwing it away — `"cmdtimestamp" to IgnoredTagHandler()`. Five distinct serials appear across the captured logs on this machine, so the server has been offering it all along.

Worth noting what is *not* there: the live `<cmdlist>` has no attributes at all, no `timestamp` and no `count`. Only the sibling tag carries it.

## Confirmed against the real client, not inferred

Run Wrayth under `wrayth-lab` against a bootstrap whose only interesting line is `<updateverbs default="GS4"/>`, and it sends:

```
<c>_menu update 1776042608.1.1.1
```

Its own cache turns out to be `%APPDATA%/StormFront/GS4/cmdlist1.xml`:

```
<cmdlist timestamp="1776042608.1.1.1" count="1100">
<cli coord="2524,1587" menu="flirt @" command="flirt #" menu_cat="5_roleplay"/>
...
```

The serial it sends is the `timestamp` in that file. The count has grown from the 588 that shipped with the installer to 1100, which fits the chunked, additive responses seen on the wire.

So ours is written the same way — one `<cli>` per line under `<dataDir>/cmdlists/<list>.xml` — where it can be diffed against Wrayth's. It is read and written here rather than by the protocol parser, so the escaping only has to agree with itself; there is a round-trip test for markup in command text.

The cache key is the `default` attribute of `<updateverbs>`, which is what Wrayth names its own cache directory by (`StormFront/GS4`, `/DR`, `/GS`).

## The ordering that matters

The cached list is loaded **before** the request goes out, not after the reply arrives. A server that answers "nothing new" answers with nothing at all — so a client that waited for a reply to populate itself would end up with no commands and no way to notice. Getting this backwards would replace every menu entry with `Could not find cli for coord: ...`.

## Testing

- 8 tests over the store: round-trip, every field, markup in command text, replacing, keeping lists apart, an empty list still recording its serial, and a list name from the server not escaping the cache directory.
- 4 parser tests, including a list and its serial arriving on one line exactly as GemStone sends them.
- End to end on the bench, driving our own client against a fake server: first login sends `_menu update 1`; after a `<cmdlist>` and its `<cmdtimestamp>` the cache appears with the right serial and entries; a restart sends `_menu update 1776042608.1.1.1`.

`./gradlew check -PiosSkip=true -PlintSkip=true` passes.

## Durability of the cache

A torn write is the failure that matters here, because the header carries the serial: a file cut off partway claims to be current, so the next login hands that serial back, the server has nothing to add, and the missing commands stay missing.

- The file is written beside its final name and `atomicMove`d over it, so an interrupted write leaves the previous list intact.
- `load` checks the entries it read against the `count` in the header and refuses a short file whatever wrote it — which is what that attribute is for, beyond matching Wrayth's format.

Both covered by tests confirmed to fail without them, including one that tears a real write by handing `save` a collection whose iterator gives up partway. (Raised by CodeRabbit.)

## One thing this cannot answer from here

What the server does with a serial it recognises. The bench's server is a stub, and confirming the reply needs a real connection, which I have not made. The behaviour is what the real client does, so the server must accept it, and the failure mode if it simply ignores the serial and re-sends everything is what happens today. The load-before-request ordering is what covers the other direction.

The benchmark passes `commandListStore = null`, so its runs stay cold logins rather than each one inheriting the last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
