### PR TITLE
Show an unhandled tag once, when debug output is on

### DIFF
--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WraythClient.kt
@@ -1,6 +1,7 @@
 package warlockfe.warlock3.wrayth.network
 
 import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
 import com.eygraber.uri.Uri
 import kotlinx.collections.immutable.mutate
 import kotlinx.collections.immutable.persistentListOf
@@ -673,7 +674,17 @@ class WraythClient(
             }
 
             is WraythUnhandledTagEvent -> {
-                // debug("Unhandled tag: ${event.tag}")
+                // Once per tag name, and only when debug output is on: a tag we do not handle is
+                // usually harmless, but it is the first thing to look for when something the game
+                // sent did not show up, and it is invisible from inside the game otherwise.
+                if (event.firstSighting && logger.config.minSeverity <= Severity.Debug) {
+                    getMainStream().appendLine(
+                        StyledString(
+                            "unhandled tag: <${event.tag}>",
+                            WarlockStyle.Error,
+                        ),
+                    )
+                }
             }
 
             is WraythParseErrorEvent -> {

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythEvent.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythEvent.kt
@@ -158,6 +158,10 @@ data class WraythParseErrorEvent(
 
 data class WraythUnhandledTagEvent(
     val tag: String,
+    // True the once, for the first sighting of this tag name. The parser is already counting them,
+    // and already goes quiet past a few hundred distinct names, so a second tally here would only be
+    // a chance to disagree with it.
+    val firstSighting: Boolean = false,
 ) : WraythEvent
 
 data object WraythUpdateVerbsEvent : WraythEvent

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/protocol/WraythProtocolHandler.kt
@@ -88,8 +88,8 @@ class WraythProtocolHandler {
      * something is generating names rather than sending a vocabulary, and neither the warnings nor
      * the set are any use at that point.
      */
-    private fun warnOnUnknownTag(tagName: String) {
-        if (tagName in unknownReported) return
+    private fun warnOnUnknownTag(tagName: String): Boolean {
+        if (tagName in unknownReported) return false
         if (unknownReported.size >= MAX_UNKNOWN_TAGS_REPORTED) {
             if (!unknownOverflowReported) {
                 unknownOverflowReported = true
@@ -98,7 +98,7 @@ class WraythProtocolHandler {
                         "Something is generating tag names rather than sending a fixed set."
                 }
             }
-            return
+            return false
         }
         unknownReported.add(tagName)
         val miscased = elementListeners.keys.firstOrNull { it.equals(tagName, ignoreCase = true) }
@@ -107,6 +107,7 @@ class WraythProtocolHandler {
         } else {
             logger.w { "Ignoring <$tagName>: no handler for it. Add one, or an IgnoredTagHandler if it carries nothing we use." }
         }
+        return true
     }
 
     private val elementListeners: Map<String, ElementListener> =
@@ -219,6 +220,7 @@ class WraythProtocolHandler {
             "module" to IgnoredTagHandler(),
             "objectives" to IgnoredTagHandler(),
             "playerID" to IgnoredTagHandler(),
+            "pulse" to IgnoredTagHandler(),
             "roommeta" to IgnoredTagHandler(),
             "sep" to IgnoredTagHandler(),
             "switchQuickBar" to IgnoredTagHandler(),
@@ -272,8 +274,8 @@ class WraythProtocolHandler {
                             events.add(it)
                         }
                     } else {
-                        warnOnUnknownTag(tagName)
-                        events.add(WraythUnhandledTagEvent(content.name))
+                        val firstSighting = warnOnUnknownTag(tagName)
+                        events.add(WraythUnhandledTagEvent(content.name, firstSighting))
                     }
                 }
 

--- a/wrayth/src/commonTest/kotlin/WraythUnknownTagTests.kt
+++ b/wrayth/src/commonTest/kotlin/WraythUnknownTagTests.kt
@@ -1,0 +1,76 @@
+import co.touchlab.kermit.Severity
+import warlockfe.warlock3.wrayth.protocol.WraythEvent
+import warlockfe.warlock3.wrayth.protocol.WraythProtocolHandler
+import warlockfe.warlock3.wrayth.protocol.WraythUnhandledTagEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WraythUnknownTagTests {
+    private fun unhandled(events: List<WraythEvent>) = events.filterIsInstance<WraythUnhandledTagEvent>()
+
+    @Test
+    fun anUnknownTagIsReportedAsAFirstSighting() {
+        val events = WraythProtocolHandler().parseLine("<neverSeenBefore/>")
+
+        assertEquals(listOf(WraythUnhandledTagEvent("neverSeenBefore", firstSighting = true)), unhandled(events))
+    }
+
+    @Test
+    fun theSameTagIsOnlyAFirstSightingOnce() {
+        // The handler still reports the tag every time, so nothing downstream has to guess whether a
+        // tag it did not act on was seen; only the once carries the flag that surfaces it.
+        val handler = WraythProtocolHandler()
+
+        val first = unhandled(handler.parseLine("<neverSeenBefore/>")).single()
+        val second = unhandled(handler.parseLine("<neverSeenBefore/>")).single()
+        val third = unhandled(handler.parseLine("<neverSeenBefore/>")).single()
+
+        assertTrue(first.firstSighting)
+        assertEquals(listOf(false, false), listOf(second.firstSighting, third.firstSighting))
+        assertEquals("neverSeenBefore", third.tag)
+    }
+
+    @Test
+    fun eachDistinctTagGetsItsOwnFirstSighting() {
+        val handler = WraythProtocolHandler()
+
+        val a = unhandled(handler.parseLine("<alpha/>")).single()
+        val b = unhandled(handler.parseLine("<beta/>")).single()
+        val aAgain = unhandled(handler.parseLine("<alpha/>")).single()
+
+        assertTrue(a.firstSighting)
+        assertTrue(b.firstSighting)
+        assertTrue(!aAgain.firstSighting)
+    }
+
+    @Test
+    fun pulseIsIgnoredRatherThanUnhandled() {
+        val events = WraythProtocolHandler().parseLine("<pulse/>")
+
+        assertEquals(emptyList(), unhandled(events))
+    }
+
+    @Test
+    fun aTagGeneratorCannotKeepAnnouncingItself() {
+        // Past the reporting cap the parser goes quiet, so a server sending a fresh tag name every
+        // line cannot fill the stream with them.
+        val handler = WraythProtocolHandler()
+        repeat(256) { handler.parseLine("<generated$it/>") }
+
+        val beyondTheCap = unhandled(handler.parseLine("<generated999/>")).single()
+
+        assertTrue(!beyondTheCap.firstSighting)
+    }
+
+    @Test
+    fun debugIsMoreVerboseThanInfo() {
+        // WraythClient shows unhandled tags when `minSeverity <= Severity.Debug`. That reads either
+        // way round at a glance, and getting it backwards would show them only in the builds meant
+        // not to, so pin which direction is which.
+        assertTrue(Severity.Debug <= Severity.Debug)
+        assertTrue(Severity.Verbose <= Severity.Debug)
+        assertTrue(Severity.Info > Severity.Debug)
+        assertTrue(Severity.Warn > Severity.Debug)
+    }
+}


### PR DESCRIPTION
Two small things: `pulse` joins the ignored tags, and an unknown tag now says so on screen once, when debug output is on.

## Unknown tags were invisible from inside the game

`warnOnUnknownTag` already logs each new one and the client handler was a commented-out `// debug(...)`. The log is not where anyone is looking when something the game sent failed to appear — and from inside the game there was nothing to see at all.

With debug output on (`-d`, or any dev build, which is how `isDev` already sets Kermit's min severity) the **first sighting of each tag name** now prints to the main stream in the error style:

```
before the unknown tags
unhandled tag: <neverSeenBefore>     <- red, once
text after it
second time, should be silent
third time, should be silent
pulse should be silent
unhandled tag: <alsoUnknown>         <- red, its own first sighting
a different tag, should report once
```

## The flag comes from the parser, not a second tally

`WraythUnhandledTagEvent` now carries `firstSighting`, set by `warnOnUnknownTag`, which was already returning early for names it had seen. It also already goes quiet past `MAX_UNKNOWN_TAGS_REPORTED` (256) distinct names, so a server generating tag names per line cannot flood the stream — that cap now covers the on-screen message for free.

Keeping a separate set in `WraythClient` would have been a second source of truth for the same question, with its own chance to disagree about the cap.

The event is still emitted every time, so nothing downstream has to guess whether a tag it ignored was seen; only the flag is once.

## Testing

6 tests: first sighting, repeats not, each distinct name getting its own, `pulse` ignored rather than unhandled, and the cap suppressing the flag beyond 256 names.

Verified in the app against the bench with `-d`, which is the screenshot transcribed above.

**One gap, stated rather than papered over:** the debug-*off* path is not reachable from a dev build, because `isDev` forces debug on, and forcing a non-dev version to test it would trip Sentry initialisation. So what is covered instead is the direction of the `minSeverity <= Severity.Debug` comparison — the part that could invert silently and show these only in the builds meant not to.

`./gradlew check -PiosSkip=true -PlintSkip=true` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of previously unknown protocol tags.
  * Prevented repeated reports for the same tag.
  * Ignored expected `pulse` messages.
  * Limited unknown-tag reporting to avoid excessive announcements.
  * Added clearer debug-level error messages for newly encountered tags.

* **Tests**
  * Added coverage for first-time, repeated, and distinct unknown tags.
  * Verified reporting limits, ignored messages, and debug severity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->