### PR TITLE
Rewrite the iOS sockets on Network.framework

### DIFF
--- a/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
+++ b/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
@@ -1,281 +1,416 @@
-@file:Suppress("DEPRECATION")
-@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, ExperimentalAtomicApi::class)
+@file:OptIn(ExperimentalForeignApi::class, ExperimentalAtomicApi::class)
 
 package warlockfe.warlock3.wrayth.util
 
+import co.touchlab.kermit.Logger
 import io.ktor.network.selector.SelectorManager
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readAvailable
 import io.ktor.utils.io.writeFully
 import kotlinx.cinterop.COpaquePointer
-import kotlinx.cinterop.CPointer
-import kotlinx.cinterop.CPointerVar
-import kotlinx.cinterop.StableRef
-import kotlinx.cinterop.ULongVar
+import kotlinx.cinterop.COpaquePointerVar
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.allocArrayOf
-import kotlinx.cinterop.asStableRef
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.nativeHeap
-import kotlinx.cinterop.pointed
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.reinterpret
-import kotlinx.cinterop.staticCFunction
 import kotlinx.cinterop.usePinned
 import kotlinx.cinterop.value
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import platform.CoreFoundation.CFArrayCreate
 import platform.CoreFoundation.CFArrayRef
 import platform.CoreFoundation.CFDataCreate
 import platform.CoreFoundation.CFErrorRefVar
 import platform.CoreFoundation.CFRelease
 import platform.CoreFoundation.kCFTypeArrayCallBacks
-import platform.Security.SSLClose
-import platform.Security.SSLConnectionRef
-import platform.Security.SSLConnectionType
-import platform.Security.SSLContextRef
-import platform.Security.SSLCopyPeerTrust
-import platform.Security.SSLCreateContext
-import platform.Security.SSLHandshake
-import platform.Security.SSLProtocolSide
-import platform.Security.SSLRead
-import platform.Security.SSLSetConnection
-import platform.Security.SSLSetIOFuncs
-import platform.Security.SSLSetPeerDomainName
-import platform.Security.SSLSetSessionOption
-import platform.Security.SSLWrite
+import platform.Network.nw_connection_cancel
+import platform.Network.nw_connection_create
+import platform.Network.nw_connection_receive
+import platform.Network.nw_connection_send
+import platform.Network.nw_connection_set_queue
+import platform.Network.nw_connection_set_state_changed_handler
+import platform.Network.nw_connection_start
+import platform.Network.nw_connection_state_cancelled
+import platform.Network.nw_connection_state_failed
+import platform.Network.nw_connection_state_ready
+import platform.Network.nw_connection_t
+import platform.Network.nw_content_context_create
+import platform.Network.nw_content_context_t
+import platform.Network.nw_endpoint_create_host
+import platform.Network.nw_error_domain_dns
+import platform.Network.nw_error_domain_posix
+import platform.Network.nw_error_domain_tls
+import platform.Network.nw_error_get_error_code
+import platform.Network.nw_error_get_error_domain
+import platform.Network.nw_error_t
+import platform.Network.nw_parameters_configure_protocol_block_t
+import platform.Network.nw_parameters_copy_default_protocol_stack
+import platform.Network.nw_parameters_create
+import platform.Network.nw_protocol_options_t
+import platform.Network.nw_protocol_stack_prepend_application_protocol
+import platform.Network.nw_protocol_stack_set_transport_protocol
+import platform.Network.nw_tcp_create_options
+import platform.Network.nw_tls_copy_sec_protocol_options
+import platform.Network.nw_tls_create_options
 import platform.Security.SecCertificateCreateWithData
 import platform.Security.SecCertificateRef
 import platform.Security.SecPolicyCreateBasicX509
 import platform.Security.SecPolicyRef
 import platform.Security.SecTrustEvaluateWithError
-import platform.Security.SecTrustRefVar
 import platform.Security.SecTrustSetAnchorCertificates
 import platform.Security.SecTrustSetAnchorCertificatesOnly
 import platform.Security.SecTrustSetPolicies
-import platform.Security.errSSLClosedAbort
-import platform.Security.errSSLClosedGraceful
-import platform.Security.errSSLPeerAuthCompleted
-import platform.Security.errSSLWouldBlock
-import platform.Security.errSecSuccess
-import platform.Security.kSSLSessionOptionBreakOnServerAuth
-import platform.posix.AF_INET
-import platform.posix.EAGAIN
-import platform.posix.EWOULDBLOCK
-import platform.posix.IPPROTO_TCP
-import platform.posix.SHUT_RDWR
-import platform.posix.SOCK_STREAM
-import platform.posix.addrinfo
-import platform.posix.close
-import platform.posix.connect
-import platform.posix.errno
-import platform.posix.freeaddrinfo
-import platform.posix.getaddrinfo
-import platform.posix.read
-import platform.posix.shutdown
-import platform.posix.socket
-import platform.posix.write
+import platform.Security.sec_protocol_options_set_tls_server_name
+import platform.Security.sec_protocol_options_set_verify_block
+import platform.Security.sec_trust_copy_ref
+import platform.Security.sec_trust_t
+import platform.darwin.dispatch_data_create
+import platform.darwin.dispatch_data_create_map
+import platform.darwin.dispatch_data_t
+import platform.darwin.dispatch_queue_create
+import platform.darwin.dispatch_queue_t
+import platform.posix.memcpy
+import platform.posix.size_tVar
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
-// SSL I/O callbacks are static (no captures); socket fd is stored via SSLSetConnection as a stable ref.
+/**
+ * iOS sockets on Network.framework.
+ *
+ * This replaces a hand-rolled SecureTransport implementation that drove a raw BSD socket with
+ * blocking read()/write() on background coroutines. That version was deprecated by Apple, and its
+ * teardown was the hard part: the SSL context, the stable ref its IO callbacks read the descriptor
+ * from, and the descriptor itself all had to be released in the right order, only after two jobs
+ * parked inside blocking native calls had actually finished.
+ *
+ * Network.framework removes that whole category of problem. `nw_connection_t` and friends are
+ * Objective-C objects, so Kotlin/Native's runtime owns their lifetime -- there is nothing to
+ * CFRelease. Cancellation is asynchronous by design, and both IO paths are callbacks bridged
+ * straight into coroutines, so nothing blocks a thread waiting on the network.
+ *
+ * Certificate pinning keeps the previous semantics exactly: the pinned certificate is added as an
+ * anchor, system anchors remain trusted, and hostname checking is off because the Simutronics CA
+ * certificate carries no subject alternative name for the game host.
+ */
+private val logger = Logger.withTag("SocketHelpers")
 
-private val sslReadCallback =
-    staticCFunction {
-        connection: SSLConnectionRef?,
-        data: COpaquePointer?,
-        dataLength: CPointer<ULongVar>?,
-        ->
+private const val RECEIVE_MAX = 65536u
+private const val WRITE_BUFFER = 8192
 
-        if (connection == null || data == null || dataLength == null) return@staticCFunction errSSLClosedAbort
-        val fdArr = connection.asStableRef<IntArray>().get()
-        val fd = fdArr[0]
-        val n = read(fd, data, dataLength.pointed.value)
-        when {
-            n > 0L -> {
-                dataLength.pointed.value = n.convert()
-                errSecSuccess
-            }
-
-            n == 0L -> {
-                dataLength.pointed.value = 0u
-                errSSLClosedGraceful
-            }
-
-            else -> {
-                dataLength.pointed.value = 0u
-                if (errno == EAGAIN || errno == EWOULDBLOCK) errSSLWouldBlock else errSSLClosedAbort
-            }
-        }
-    }
-
-private val sslWriteCallback =
-    staticCFunction {
-        connection: SSLConnectionRef?,
-        data: COpaquePointer?,
-        dataLength: CPointer<ULongVar>?,
-        ->
-
-        if (connection == null || data == null || dataLength == null) return@staticCFunction errSSLClosedAbort
-        val fdArr = connection.asStableRef<IntArray>().get()
-        val fd = fdArr[0]
-        val n = write(fd, data, dataLength.pointed.value)
-        when {
-            n >= 0L -> {
-                dataLength.pointed.value = n.convert()
-                errSecSuccess
-            }
-
-            else -> {
-                dataLength.pointed.value = 0u
-                if (errno == EAGAIN || errno == EWOULDBLOCK) errSSLWouldBlock else errSSLClosedAbort
-            }
-        }
-    }
-
-private fun createAndConnectSocket(
+actual suspend fun openPlainSocket(
+    selectorManager: SelectorManager,
     host: String,
     port: Int,
-): Int =
-    memScoped {
-        val hints =
-            alloc<addrinfo>().apply {
-                ai_family = AF_INET
-                ai_socktype = SOCK_STREAM
-                ai_protocol = IPPROTO_TCP
-            }
-        val resultPtr = alloc<CPointerVar<addrinfo>>()
-        val rc = getaddrinfo(host, port.toString(), hints.ptr, resultPtr.ptr)
-        check(rc == 0) { "getaddrinfo failed for $host:$port (rc=$rc)" }
-        val result = checkNotNull(resultPtr.value) { "getaddrinfo returned null for $host:$port" }
-        val fd = socket(result.pointed.ai_family, result.pointed.ai_socktype, result.pointed.ai_protocol)
-        check(fd >= 0) { "socket() failed" }
-        val connected = connect(fd, result.pointed.ai_addr, result.pointed.ai_addrlen)
-        freeaddrinfo(result)
-        if (connected != 0) {
-            // The descriptor exists even though connect() failed; without this every failed
-            // connection attempt burns one until the process runs out.
-            close(fd)
-            error("connect() failed to $host:$port")
-        }
-        fd
-    }
+    coroutineContext: CoroutineContext,
+): TLSSocketConnection = openNetworkSocket(host, port, coroutineContext, useTls = false)
 
-private fun setupTLS(
-    fd: Int,
+actual suspend fun openDefaultTlsSocket(
+    selectorManager: SelectorManager,
     host: String,
+    port: Int,
+    coroutineContext: CoroutineContext,
+): TLSSocketConnection =
+    // No TLS configuration of our own, so the system evaluates the chain against its own trust
+    // store -- which is what the MUD Mobile edge needs; it presents an ordinary public certificate.
+    openNetworkSocket(host, port, coroutineContext, useTls = true)
+
+actual suspend fun openTLSSocket(
+    selectorManager: SelectorManager,
+    host: String,
+    port: Int,
     certificate: ByteArray,
-): Pair<SSLContextRef, StableRef<IntArray>> {
-    val sslCtx =
-        checkNotNull(
-            SSLCreateContext(null, SSLProtocolSide.kSSLClientSide, SSLConnectionType.kSSLStreamType),
-        ) {
-            "SSLCreateContext failed"
-        }
-    val fdHolder = intArrayOf(fd)
-    val stableRef = StableRef.create(fdHolder)
+    coroutineContext: CoroutineContext,
+): TLSSocketConnection {
+    val verifyQueue = dispatch_queue_create("warlockfe.warlock3.socket.verify", null)
+    return openNetworkSocket(host, port, coroutineContext, useTls = true) { options ->
+        val secOptions = nw_tls_copy_sec_protocol_options(options)
+        sec_protocol_options_set_verify_block(
+            secOptions,
+            { _, trust, complete -> complete?.invoke(trustsPinnedCertificate(trust, certificate)) },
+            verifyQueue,
+        )
+    }
+}
 
-    // Anything thrown below (a failed handshake is routine) must not strand the
-    // SecureTransport context or the stable ref the IO callbacks read the fd from.
-    try {
-        SSLSetConnection(sslCtx, stableRef.asCPointer())
-        SSLSetIOFuncs(sslCtx, sslReadCallback, sslWriteCallback)
-        SSLSetPeerDomainName(sslCtx, host, host.length.convert())
+private suspend fun openNetworkSocket(
+    host: String,
+    port: Int,
+    coroutineContext: CoroutineContext,
+    useTls: Boolean,
+    configureTls: (nw_protocol_options_t) -> Unit = {},
+): TLSSocketConnection {
+    val queue = dispatch_queue_create("warlockfe.warlock3.socket", null)
 
-        // Break on server auth so we can evaluate trust with our custom certificate
-        SSLSetSessionOption(sslCtx, kSSLSessionOptionBreakOnServerAuth, true)
-
-        val firstStatus = SSLHandshake(sslCtx)
-        var status = firstStatus
-        if (status == errSSLPeerAuthCompleted) {
-            // Evaluate server trust with our custom CA certificate
-            evaluateServerTrust(sslCtx, certificate)
-            // Continue handshake after trust evaluation
-            status = SSLHandshake(sslCtx)
+    // The protocol stack is assembled by hand rather than with nw_parameters_create_secure_tcp.
+    // That helper selects behaviour by comparing its block arguments against the
+    // NW_PARAMETERS_DISABLE_PROTOCOL / NW_PARAMETERS_DEFAULT_CONFIGURATION sentinels by pointer
+    // identity, and Kotlin/Native wraps a block on its way across the boundary, so the comparison
+    // never matches. The framework then calls those sentinels as if they were ordinary
+    // configuration blocks, which left plain sockets attempting TLS and TLS sockets failing the
+    // handshake with "bad certificate format". Building the stack explicitly has no such ambiguity.
+    val parameters = nw_parameters_create()
+    val stack = nw_parameters_copy_default_protocol_stack(parameters)
+    nw_protocol_stack_set_transport_protocol(stack, nw_tcp_create_options())
+    if (useTls) {
+        val tlsOptions = nw_tls_create_options()
+        // A hand-built stack gets no SNI: nw_parameters_create_secure_tcp derives the server name
+        // from the endpoint, but nothing does that here, so it has to be set explicitly.
+        nw_tls_copy_sec_protocol_options(tlsOptions)?.let { secOptions ->
+            sec_protocol_options_set_tls_server_name(secOptions, host)
         }
-        // Report both statuses: -50 (errSecParam) on the *first* call means SecureTransport rejected the
-        // context setup, while -50 only on the second means the trust evaluation left it unusable. The
-        // two have completely different fixes, so never collapse them into one number.
-        check(status == errSecSuccess) {
-            "TLS handshake failed for $host (first=$firstStatus, final=$status)"
-        }
-    } catch (t: Throwable) {
-        CFRelease(sslCtx)
-        stableRef.dispose()
-        throw t
+        if (tlsOptions != null) configureTls(tlsOptions)
+        nw_protocol_stack_prepend_application_protocol(stack, tlsOptions)
     }
 
-    return sslCtx to stableRef
+    val endpoint = nw_endpoint_create_host(host, port.toString())
+    val connection =
+        checkNotNull(nw_connection_create(endpoint, parameters)) {
+            "nw_connection_create failed for $host:$port"
+        }
+    nw_connection_set_queue(connection, queue)
+
+    awaitReady(connection, host, port)
+
+    // Parented to the caller's job. `coroutineContext + job` *replaces* whatever Job the context
+    // carried, so a parentless SupervisorJob would quietly detach these loops from the caller:
+    // cancelling the caller would leave them running and the connection open.
+    val ioJob = SupervisorJob(coroutineContext[Job])
+    val scope = CoroutineScope(coroutineContext + ioJob)
+
+    val readChannel = ByteChannel(autoFlush = true)
+    scope.launch {
+        try {
+            while (isActive) {
+                val chunk = receiveChunk(connection) ?: break
+                if (chunk.isNotEmpty()) readChannel.writeFully(chunk)
+            }
+        } catch (_: CancellationException) {
+            // Closing the connection cancels this; not an error.
+        } catch (t: Throwable) {
+            logger.d(t) { "read loop for $host:$port ended" }
+        } finally {
+            readChannel.close()
+        }
+    }
+
+    // A real content context rather than NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT: that global is a
+    // sentinel, not an Objective-C object, and Kotlin/Native crashes trying to convert it into a
+    // Kotlin reference. One context is reused for every send on this connection.
+    val sendContext = nw_content_context_create("warlock")
+
+    val writeChannel = ByteChannel(autoFlush = true)
+    scope.launch {
+        val reader = writeChannel as ByteReadChannel
+        val buffer = ByteArray(WRITE_BUFFER)
+        try {
+            while (isActive && !reader.isClosedForRead) {
+                val count = reader.readAvailable(buffer)
+                if (count <= 0) continue
+                sendChunk(connection, buffer.copyOf(count), queue, sendContext)
+            }
+        } catch (_: CancellationException) {
+            // As above.
+        } catch (t: Throwable) {
+            logger.d(t) { "write loop for $host:$port ended" }
+        }
+    }
+
+    val closed = AtomicBoolean(false)
+
+    // Atomic: close() is reachable from more than one thread, and cancelling an nw_connection_t
+    // twice is not something to rely on being harmless.
+    fun closeConnection() {
+        if (closed.compareAndSet(false, true)) {
+            // Cancelling the connection makes any outstanding receive and send complete with an
+            // error, which ends both loops. There is nothing to release by hand afterwards.
+            nw_connection_cancel(connection)
+            ioJob.cancel()
+        }
+    }
+
+    // Cancelling the caller stops the loops but would otherwise leave the connection itself open,
+    // since only close() cancels it. Completion covers both routes: an explicit close (where this
+    // is already a no-op) and the caller's job being cancelled out from under us.
+    ioJob.invokeOnCompletion { closeConnection() }
+
+    return TLSSocketConnection(
+        readChannel = readChannel,
+        writeChannel = writeChannel,
+        close = { closeConnection() },
+    )
 }
 
-private fun pemToDer(pem: ByteArray): ByteArray {
-    val pemString = pem.decodeToString()
-    val base64 =
-        pemString
-            .lineSequence()
-            .filter { !it.startsWith("-----") }
-            .joinToString("")
-    @OptIn(kotlin.io.encoding.ExperimentalEncodingApi::class)
-    return kotlin.io.encoding.Base64
-        .decode(base64)
+/** Starts the connection and suspends until it is usable, or fails. */
+private suspend fun awaitReady(
+    connection: nw_connection_t,
+    host: String,
+    port: Int,
+) {
+    suspendCancellableCoroutine { continuation ->
+        nw_connection_set_state_changed_handler(connection) { state, error ->
+            when (state) {
+                nw_connection_state_ready -> {
+                    if (continuation.isActive) continuation.resume(Unit)
+                }
+
+                nw_connection_state_failed -> {
+                    if (continuation.isActive) {
+                        continuation.resumeWithException(
+                            IllegalStateException("connection to $host:$port failed${error.describe()}"),
+                        )
+                    }
+                }
+
+                nw_connection_state_cancelled -> {
+                    if (continuation.isActive) {
+                        continuation.resumeWithException(
+                            CancellationException("connection to $host:$port was cancelled"),
+                        )
+                    }
+                }
+
+                else -> {
+                    // waiting/preparing/invalid: nothing to do until one of the states above.
+                }
+            }
+        }
+        continuation.invokeOnCancellation { nw_connection_cancel(connection) }
+        nw_connection_start(connection)
+    }
+
+    // Past this point a state change is no longer something to resume; the IO loops surface
+    // failures by completing with an error.
+    nw_connection_set_state_changed_handler(connection) { state, error ->
+        if (state == nw_connection_state_failed) {
+            logger.d { "connection to $host:$port failed${error.describe()}" }
+        }
+    }
 }
 
-private fun evaluateServerTrust(
-    sslCtx: SSLContextRef,
+/** One receive. Returns null at end of stream or on error, which ends the read loop. */
+private suspend fun receiveChunk(connection: nw_connection_t): ByteArray? =
+    suspendCancellableCoroutine { continuation ->
+        nw_connection_receive(connection, 1u, RECEIVE_MAX) { content, _, isComplete, error ->
+            if (continuation.isActive) {
+                when {
+                    error != null -> continuation.resume(null)
+                    content != null -> continuation.resume(content.toByteArray())
+                    isComplete -> continuation.resume(null)
+                    else -> continuation.resume(ByteArray(0))
+                }
+            }
+        }
+    }
+
+private suspend fun sendChunk(
+    connection: nw_connection_t,
+    bytes: ByteArray,
+    queue: dispatch_queue_t,
+    context: nw_content_context_t,
+) {
+    suspendCancellableCoroutine { continuation ->
+        nw_connection_send(
+            connection,
+            bytes.toDispatchData(queue),
+            context,
+            true,
+            { error ->
+                if (continuation.isActive) {
+                    if (error != null) {
+                        continuation.resumeWithException(
+                            IllegalStateException("send failed${error.describe()}"),
+                        )
+                    } else {
+                        continuation.resume(Unit)
+                    }
+                }
+            },
+        )
+    }
+}
+
+private fun nw_error_t.describe(): String = if (this == null) "" else " (code=${nw_error_get_error_code(this)})"
+
+private fun ByteArray.toDispatchData(queue: dispatch_queue_t): dispatch_data_t =
+    usePinned { pinned ->
+        // A null destructor means DISPATCH_DATA_DESTRUCTOR_DEFAULT, which copies the buffer, so the
+        // pinned array does not have to outlive this call.
+        dispatch_data_create(pinned.addressOf(0), size.convert(), queue, null)
+    }
+
+private fun dispatch_data_t.toByteArray(): ByteArray =
+    memScoped {
+        val bufferPtr = alloc<COpaquePointerVar>()
+        val sizePtr = alloc<size_tVar>()
+        // A dispatch_data_t may be a rope of discontiguous regions; create_map flattens it and
+        // returns an object that *owns* the contiguous buffer bufferPtr points at.
+        val mapped = dispatch_data_create_map(this@toByteArray, bufferPtr.ptr, sizePtr.ptr)
+        val size = sizePtr.value.toInt()
+        val bytes =
+            if (size == 0) {
+                ByteArray(0)
+            } else {
+                ByteArray(size).also { out ->
+                    out.usePinned { pinned ->
+                        memcpy(pinned.addressOf(0), bufferPtr.value, sizePtr.value)
+                    }
+                }
+            }
+        // `mapped` has to outlive the copy above. Reading it here is what keeps it reachable --
+        // left unused, the runtime is free to collect it mid-memcpy and the buffer goes with it.
+        check(mapped != null || size == 0) { "dispatch_data_create_map returned null for $size bytes" }
+        bytes
+    }
+
+/**
+ * Trusts the chain if it validates against the pinned certificate as an additional anchor. Keeps
+ * the semantics the SecureTransport implementation had: system anchors still count, and the policy
+ * is plain X.509 with no hostname check, because the pinned CA certificate has no SAN for the game
+ * host.
+ */
+private fun trustsPinnedCertificate(
+    trust: sec_trust_t,
     certificate: ByteArray,
-) = memScoped {
-    val trustPtr = alloc<SecTrustRefVar>()
-    SSLCopyPeerTrust(sslCtx, trustPtr.ptr)
-    val trust = checkNotNull(trustPtr.value) { "SSLCopyPeerTrust returned null" }
-
-    // Everything below is acquired inside the try and released in the finally, in reverse order and
-    // only if it was actually acquired. A checkNotNull between two allocations would otherwise leak
-    // `trust` and whatever else had already been created.
+): Boolean {
+    val trustRef = sec_trust_copy_ref(trust) ?: return false
     var cert: SecCertificateRef? = null
     var policy: SecPolicyRef? = null
-    var certCFArray: CFArrayRef? = null
+    var certArray: CFArrayRef? = null
     var policyArray: CFArrayRef? = null
-
-    val trusted =
-        try {
-            // Convert PEM to DER if needed, then create SecCertificate
-            val derData =
+    return try {
+        memScoped {
+            val der =
                 if (certificate.decodeToString().contains("-----BEGIN")) {
                     pemToDer(certificate)
                 } else {
                     certificate
                 }
             val cfData =
-                checkNotNull(
-                    derData.usePinned { pinned ->
-                        CFDataCreate(null, pinned.addressOf(0).reinterpret(), derData.size.convert())
-                    },
-                ) { "CFDataCreate failed" }
-            val certRef = SecCertificateCreateWithData(null, cfData)
+                der.usePinned { pinned ->
+                    CFDataCreate(null, pinned.addressOf(0).reinterpret(), der.size.convert())
+                } ?: return@memScoped false
+            val certValue = SecCertificateCreateWithData(null, cfData)
             CFRelease(cfData)
-            val certValue = checkNotNull(certRef) { "SecCertificateCreateWithData failed" }
+            if (certValue == null) return@memScoped false
             cert = certValue
 
-            val policyValue =
-                checkNotNull(SecPolicyCreateBasicX509()) { "SecPolicyCreateBasicX509 failed" }
+            val policyValue = SecPolicyCreateBasicX509() ?: return@memScoped false
             policy = policyValue
 
-            // kCFTypeArrayCallBacks rather than null: an array built with null callbacks does not
-            // retain what it holds, so releasing `cert` and `policy` below would leave `trust`
-            // referencing freed memory. That is a use-after-free which only misbehaves when the
-            // allocator happens to reuse the block -- precisely the kind of fault that appears to
-            // come and go between runs.
-            certCFArray =
+            certArray =
                 CFArrayCreate(
                     null,
                     allocArrayOf(certValue as COpaquePointer).reinterpret(),
@@ -290,327 +425,33 @@ private fun evaluateServerTrust(
                     kCFTypeArrayCallBacks.ptr,
                 )
 
-            // Set as anchor certificate, but also allow system anchors
-            SecTrustSetAnchorCertificates(trust, certCFArray)
-            SecTrustSetAnchorCertificatesOnly(trust, false)
-
-            // Replace the SSL policy with a basic X.509 policy (no hostname check).
-            // Hostname verification is already handled by SSLSetPeerDomainName at the SSL layer;
-            // the self-signed CA cert doesn't have a SAN for the server hostname.
-            SecTrustSetPolicies(trust, policyArray)
+            SecTrustSetAnchorCertificates(trustRef, certArray)
+            SecTrustSetAnchorCertificatesOnly(trustRef, false)
+            SecTrustSetPolicies(trustRef, policyArray)
 
             val errorPtr = alloc<CFErrorRefVar>()
-            val result = SecTrustEvaluateWithError(trust, errorPtr.ptr)
+            val trusted = SecTrustEvaluateWithError(trustRef, errorPtr.ptr)
             errorPtr.value?.let { CFRelease(it) }
-            result
-        } finally {
-            policyArray?.let { CFRelease(it) }
-            certCFArray?.let { CFRelease(it) }
-            policy?.let { CFRelease(it) }
-            cert?.let { CFRelease(it) }
-            CFRelease(trust)
+            trusted
         }
-
-    check(trusted) { "Server certificate trust evaluation failed" }
+    } finally {
+        policyArray?.let { CFRelease(it) }
+        certArray?.let { CFRelease(it) }
+        policy?.let { CFRelease(it) }
+        cert?.let { CFRelease(it) }
+        CFRelease(trustRef)
+    }
 }
 
-actual suspend fun openPlainSocket(
-    selectorManager: SelectorManager,
-    host: String,
-    port: Int,
-    coroutineContext: CoroutineContext,
-): TLSSocketConnection {
-    val fd =
-        kotlinx.coroutines.withContext(Dispatchers.IO) {
-            createAndConnectSocket(host, port)
-        }
+private fun pemToDer(pem: ByteArray): ByteArray {
+    val base64 =
+        pem
+            .decodeToString()
+            .lineSequence()
+            .filter { !it.startsWith("-----") }
+            .joinToString("")
 
-    val ioJob = SupervisorJob()
-    val scope = CoroutineScope(coroutineContext + ioJob)
-
-    val readChannel = ByteChannel(autoFlush = true)
-    scope.launch(Dispatchers.IO) {
-        val buf = ByteArray(8192)
-        try {
-            while (isActive) {
-                val n =
-                    buf.usePinned { pinned ->
-                        read(fd, pinned.addressOf(0), buf.size.convert())
-                    }
-                if (n <= 0) break
-                readChannel.writeFully(buf, 0, n.toInt())
-            }
-        } finally {
-            readChannel.close()
-        }
-    }
-
-    val writeChannel = ByteChannel(autoFlush = true)
-    scope.launch(Dispatchers.IO) {
-        val reader = writeChannel as ByteReadChannel
-        val buf = ByteArray(8192)
-        try {
-            while (isActive && !reader.isClosedForRead) {
-                val n = reader.readAvailable(buf)
-                if (n <= 0) continue
-                buf.usePinned { pinned ->
-                    write(fd, pinned.addressOf(0), n.convert())
-                }
-            }
-        } catch (_: Exception) {
-        }
-    }
-
-    // Atomic, not a plain flag: close() can be called from more than one thread, and a lost
-    // race would run the teardown twice -- a double CFRelease over-releases the context and a
-    // double dispose() crashes, so this is not merely a redundant cleanup.
-    val closed = AtomicBoolean(false)
-    return TLSSocketConnection(
-        readChannel = readChannel,
-        writeChannel = writeChannel,
-        close = {
-            if (closed.compareAndSet(false, true)) {
-                // shutdown() rather than close(): it unblocks the blocking call each IO job is
-                // parked in, without freeing the descriptor number for another socket to reuse
-                // while those jobs still hold it.
-                shutdown(fd, SHUT_RDWR)
-                ioJob.cancel()
-                // cancel() does not wait, so the descriptor is closed only once both jobs have
-                // actually finished with it.
-                ioJob.invokeOnCompletion { close(fd) }
-            }
-        },
-    )
-}
-
-private fun setupDefaultTLS(
-    fd: Int,
-    host: String,
-): Pair<SSLContextRef, StableRef<IntArray>> {
-    val sslCtx =
-        checkNotNull(
-            SSLCreateContext(null, SSLProtocolSide.kSSLClientSide, SSLConnectionType.kSSLStreamType),
-        ) {
-            "SSLCreateContext failed"
-        }
-    val fdHolder = intArrayOf(fd)
-    val stableRef = StableRef.create(fdHolder)
-
-    // Anything thrown below (a failed handshake is routine) must not strand the
-    // SecureTransport context or the stable ref the IO callbacks read the fd from.
-    try {
-        SSLSetConnection(sslCtx, stableRef.asCPointer())
-        SSLSetIOFuncs(sslCtx, sslReadCallback, sslWriteCallback)
-        SSLSetPeerDomainName(sslCtx, host, host.length.convert())
-
-        // No breakOnServerAuth: SecureTransport performs default system trust evaluation during the
-        // handshake, which is exactly what we want for a public CA-signed certificate.
-        val status = SSLHandshake(sslCtx)
-        check(status == errSecSuccess) { "TLS handshake failed (status=$status)" }
-    } catch (t: Throwable) {
-        CFRelease(sslCtx)
-        stableRef.dispose()
-        throw t
-    }
-
-    return sslCtx to stableRef
-}
-
-actual suspend fun openDefaultTlsSocket(
-    selectorManager: SelectorManager,
-    host: String,
-    port: Int,
-    coroutineContext: CoroutineContext,
-): TLSSocketConnection {
-    val (fd, sslCtx, stableRef) =
-        kotlinx.coroutines.withContext(Dispatchers.IO) {
-            val fd = createAndConnectSocket(host, port)
-            val (ctx, ref) =
-                try {
-                    setupDefaultTLS(fd, host)
-                } catch (t: Throwable) {
-                    close(fd)
-                    throw t
-                }
-            Triple(fd, ctx, ref)
-        }
-
-    val ioJob = SupervisorJob()
-    val scope = CoroutineScope(coroutineContext + ioJob)
-
-    val readChannel = ByteChannel(autoFlush = true)
-    scope.launch(Dispatchers.IO) {
-        val ubuf = UByteArray(8192)
-        val processedRef = nativeHeap.alloc<ULongVar>()
-        try {
-            while (isActive) {
-                var n = 0
-                ubuf.usePinned { pinned ->
-                    processedRef.value = 0u
-                    val status = SSLRead(sslCtx, pinned.addressOf(0), 8192u, processedRef.ptr)
-                    n =
-                        if (status == errSecSuccess || status == errSSLWouldBlock) {
-                            processedRef.value.toInt()
-                        } else {
-                            -1
-                        }
-                }
-                if (n <= 0) break
-                readChannel.writeFully(ByteArray(n) { ubuf[it].toByte() })
-            }
-        } finally {
-            nativeHeap.free(processedRef.rawPtr)
-            readChannel.close()
-        }
-    }
-
-    val writeChannel = ByteChannel(autoFlush = true)
-    scope.launch(Dispatchers.IO) {
-        val reader = writeChannel as ByteReadChannel
-        val buf = ByteArray(8192)
-        val processedRef = nativeHeap.alloc<ULongVar>()
-        try {
-            while (isActive && !reader.isClosedForRead) {
-                val n = reader.readAvailable(buf)
-                if (n <= 0) continue
-                val ubuf2 = UByteArray(n) { buf[it].toUByte() }
-                ubuf2.usePinned { pinned ->
-                    processedRef.value = 0u
-                    SSLWrite(sslCtx, pinned.addressOf(0), n.convert(), processedRef.ptr)
-                }
-            }
-        } catch (_: Exception) {
-        } finally {
-            nativeHeap.free(processedRef.rawPtr)
-        }
-    }
-
-    // Atomic, not a plain flag: close() can be called from more than one thread, and a lost
-    // race would run the teardown twice -- a double CFRelease over-releases the context and a
-    // double dispose() crashes, so this is not merely a redundant cleanup.
-    val closed = AtomicBoolean(false)
-    return TLSSocketConnection(
-        readChannel = readChannel,
-        writeChannel = writeChannel,
-        close = {
-            if (closed.compareAndSet(false, true)) {
-                // shutdown() rather than close(): it unblocks the blocking call each IO job is
-                // parked in, without freeing the descriptor number for another socket to reuse
-                // while those jobs still hold it.
-                shutdown(fd, SHUT_RDWR)
-                ioJob.cancel()
-                // cancel() does not wait, and both jobs sit inside blocking SecureTransport calls.
-                // Releasing the context while one is still in SSLRead is a use-after-free, so the
-                // teardown runs only after both have finished.
-                ioJob.invokeOnCompletion {
-                    SSLClose(sslCtx)
-                    // SSLCreateContext returns a +1 reference; SSLClose does not consume it.
-                    CFRelease(sslCtx)
-                    close(fd)
-                    stableRef.dispose()
-                }
-            }
-        },
-    )
-}
-
-actual suspend fun openTLSSocket(
-    selectorManager: SelectorManager,
-    host: String,
-    port: Int,
-    certificate: ByteArray,
-    coroutineContext: CoroutineContext,
-): TLSSocketConnection {
-    val (fd, sslCtx, stableRef) =
-        kotlinx.coroutines.withContext(Dispatchers.IO) {
-            val fd = createAndConnectSocket(host, port)
-            val (ctx, ref) =
-                try {
-                    setupTLS(fd, host, certificate)
-                } catch (t: Throwable) {
-                    close(fd)
-                    throw t
-                }
-            Triple(fd, ctx, ref)
-        }
-
-    val ioJob = SupervisorJob()
-    val scope = CoroutineScope(coroutineContext + ioJob)
-
-    // SSLRead → ByteChannel
-    val readChannel = ByteChannel(autoFlush = true)
-    scope.launch(Dispatchers.IO) {
-        val ubuf = UByteArray(8192)
-        val processedRef = nativeHeap.alloc<ULongVar>()
-        try {
-            while (isActive) {
-                var n = 0
-                ubuf.usePinned { pinned ->
-                    processedRef.value = 0u
-                    val status = SSLRead(sslCtx, pinned.addressOf(0), 8192u, processedRef.ptr)
-                    n =
-                        if (status == errSecSuccess || status == errSSLWouldBlock) {
-                            processedRef.value.toInt()
-                        } else {
-                            -1
-                        }
-                }
-                if (n <= 0) break
-                readChannel.writeFully(ByteArray(n) { ubuf[it].toByte() })
-            }
-        } finally {
-            nativeHeap.free(processedRef.rawPtr)
-            readChannel.close()
-        }
-    }
-
-    // ByteChannel → SSLWrite
-    val writeChannel = ByteChannel(autoFlush = true)
-    scope.launch(Dispatchers.IO) {
-        val reader = writeChannel as ByteReadChannel
-        val buf = ByteArray(8192)
-        val processedRef = nativeHeap.alloc<ULongVar>()
-        try {
-            while (isActive && !reader.isClosedForRead) {
-                val n = reader.readAvailable(buf)
-                if (n <= 0) continue
-                val ubuf2 = UByteArray(n) { buf[it].toUByte() }
-                ubuf2.usePinned { pinned ->
-                    processedRef.value = 0u
-                    SSLWrite(sslCtx, pinned.addressOf(0), n.convert(), processedRef.ptr)
-                }
-            }
-        } catch (_: Exception) {
-        } finally {
-            nativeHeap.free(processedRef.rawPtr)
-        }
-    }
-
-    // Atomic, not a plain flag: close() can be called from more than one thread, and a lost
-    // race would run the teardown twice -- a double CFRelease over-releases the context and a
-    // double dispose() crashes, so this is not merely a redundant cleanup.
-    val closed = AtomicBoolean(false)
-    return TLSSocketConnection(
-        readChannel = readChannel,
-        writeChannel = writeChannel,
-        close = {
-            if (closed.compareAndSet(false, true)) {
-                // shutdown() rather than close(): it unblocks the blocking call each IO job is
-                // parked in, without freeing the descriptor number for another socket to reuse
-                // while those jobs still hold it.
-                shutdown(fd, SHUT_RDWR)
-                ioJob.cancel()
-                // cancel() does not wait, and both jobs sit inside blocking SecureTransport calls.
-                // Releasing the context while one is still in SSLRead is a use-after-free, so the
-                // teardown runs only after both have finished.
-                ioJob.invokeOnCompletion {
-                    SSLClose(sslCtx)
-                    // SSLCreateContext returns a +1 reference; SSLClose does not consume it.
-                    CFRelease(sslCtx)
-                    close(fd)
-                    stableRef.dispose()
-                }
-            }
-        },
-    )
+    @OptIn(kotlin.io.encoding.ExperimentalEncodingApi::class)
+    return kotlin.io.encoding.Base64
+        .decode(base64)
 }

--- a/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
+++ b/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
@@ -233,7 +233,11 @@ private suspend fun openNetworkSocket(
         try {
             while (isActive) {
                 val received = receiveChunk(connection) ?: break
+                // Written before the failure is raised: the channel autoflushes, so these bytes
+                // reach the reader even though cancelling below discards anything still buffered.
+                // ktor 3.5 has no close-with-cause that would preserve them outright.
                 if (received.bytes.isNotEmpty()) readChannel.writeFully(received.bytes)
+                received.failure?.let { throw it }
                 // The FIN can arrive with the last bytes rather than on its own; receiving again
                 // after that produces an error that looks like a failure rather than a clean end.
                 if (received.isComplete) break
@@ -353,6 +357,8 @@ private suspend fun awaitReady(
 private class Received(
     val bytes: ByteArray,
     val isComplete: Boolean,
+    /** Set when the receive failed but still delivered bytes; raise it only after writing them. */
+    val failure: IOException? = null,
 )
 
 /** One receive. Returns null at end of stream, and throws on error. */
@@ -360,25 +366,31 @@ private suspend fun receiveChunk(connection: nw_connection_t): Received? =
     suspendCancellableCoroutine { continuation ->
         nw_connection_receive(connection, 1u, RECEIVE_MAX) { content, _, isComplete, error ->
             if (continuation.isActive) {
+                // Content can accompany an error, so map it first and decide afterwards --
+                // checking the error alone would discard bytes that did arrive.
+                val bytes = content?.toByteArray()
                 when {
-                    error != null -> {
-                        // Not logged here: the read loop logs it with the cause attached.
+                    content != null && bytes == null -> {
+                        // Bytes arrived and could not be read out. Treating that as an empty
+                        // chunk would drop them and carry on as if nothing had happened.
                         continuation.resumeWithException(
-                            IOException("receive failed${error.describe()}"),
+                            IOException("could not map received data"),
                         )
                     }
 
-                    content != null -> {
-                        val bytes = content.toByteArray()
-                        if (bytes == null) {
-                            // Bytes arrived and could not be read out. Treating that as an empty
-                            // chunk would drop them and carry on as if nothing had happened.
-                            continuation.resumeWithException(
-                                IOException("could not map received data"),
-                            )
-                        } else {
-                            continuation.resume(Received(bytes, isComplete))
-                        }
+                    error != null -> {
+                        // Not logged here: the read loop logs it with the cause attached.
+                        continuation.resume(
+                            Received(
+                                bytes = bytes ?: ByteArray(0),
+                                isComplete = true,
+                                failure = IOException("receive failed${error.describe()}"),
+                            ),
+                        )
+                    }
+
+                    bytes != null -> {
+                        continuation.resume(Received(bytes, isComplete))
                     }
 
                     isComplete -> {

--- a/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
+++ b/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
@@ -70,6 +70,7 @@ import platform.Security.SecTrustEvaluateWithError
 import platform.Security.SecTrustSetAnchorCertificates
 import platform.Security.SecTrustSetAnchorCertificatesOnly
 import platform.Security.SecTrustSetPolicies
+import platform.Security.errSecSuccess
 import platform.Security.sec_protocol_options_set_tls_server_name
 import platform.Security.sec_protocol_options_set_verify_block
 import platform.Security.sec_trust_copy_ref
@@ -136,7 +137,10 @@ actual suspend fun openTLSSocket(
 ): TLSSocketConnection {
     val verifyQueue = dispatch_queue_create("warlockfe.warlock3.socket.verify", null)
     return openNetworkSocket(host, port, coroutineContext, useTls = true) { options ->
-        val secOptions = nw_tls_copy_sec_protocol_options(options)
+        val secOptions =
+            checkNotNull(nw_tls_copy_sec_protocol_options(options)) {
+                "nw_tls_copy_sec_protocol_options failed; refusing to connect without pinning"
+            }
         sec_protocol_options_set_verify_block(
             secOptions,
             { _, trust, complete -> complete?.invoke(trustsPinnedCertificate(trust, certificate)) },
@@ -165,13 +169,19 @@ private suspend fun openNetworkSocket(
     val stack = nw_parameters_copy_default_protocol_stack(parameters)
     nw_protocol_stack_set_transport_protocol(stack, nw_tcp_create_options())
     if (useTls) {
-        val tlsOptions = nw_tls_create_options()
+        // checkNotNull, not a null-safe skip: carrying on without these handles would mean no
+        // server name and, on the pinned path, no verify block -- a connection that looks fine
+        // while doing none of the checking it was asked for. Failing to connect is the safe
+        // outcome.
+        val tlsOptions = checkNotNull(nw_tls_create_options()) { "nw_tls_create_options failed" }
+        val secOptions =
+            checkNotNull(nw_tls_copy_sec_protocol_options(tlsOptions)) {
+                "nw_tls_copy_sec_protocol_options failed"
+            }
         // A hand-built stack gets no SNI: nw_parameters_create_secure_tcp derives the server name
         // from the endpoint, but nothing does that here, so it has to be set explicitly.
-        nw_tls_copy_sec_protocol_options(tlsOptions)?.let { secOptions ->
-            sec_protocol_options_set_tls_server_name(secOptions, host)
-        }
-        if (tlsOptions != null) configureTls(tlsOptions)
+        sec_protocol_options_set_tls_server_name(secOptions, host)
+        configureTls(tlsOptions)
         nw_protocol_stack_prepend_application_protocol(stack, tlsOptions)
     }
 
@@ -189,6 +199,7 @@ private suspend fun openNetworkSocket(
     // cancelling the caller would leave them running and the connection open.
     val ioJob = SupervisorJob(coroutineContext[Job])
     val scope = CoroutineScope(coroutineContext + ioJob)
+    val closed = AtomicBoolean(false)
 
     val readChannel = ByteChannel(autoFlush = true)
     scope.launch {
@@ -197,12 +208,19 @@ private suspend fun openNetworkSocket(
                 val chunk = receiveChunk(connection) ?: break
                 if (chunk.isNotEmpty()) readChannel.writeFully(chunk)
             }
-        } catch (_: CancellationException) {
-            // Closing the connection cancels this; not an error.
-        } catch (t: Throwable) {
-            logger.d(t) { "read loop for $host:$port ended" }
-        } finally {
             readChannel.close()
+        } catch (_: CancellationException) {
+            readChannel.close()
+        } catch (t: Throwable) {
+            if (closed.load()) {
+                // We cancelled the connection; the receive error is only that landing.
+                readChannel.close()
+            } else {
+                // Closing without a cause would reach the caller as a clean disconnect, and a
+                // dropped connection would be reported to the user as an ordinary logout.
+                logger.d(t) { "read loop for $host:$port failed" }
+                readChannel.cancel(t)
+            }
         }
     }
 
@@ -221,14 +239,20 @@ private suspend fun openNetworkSocket(
                 if (count <= 0) continue
                 sendChunk(connection, buffer.copyOf(count), queue, sendContext)
             }
+            writeChannel.close()
         } catch (_: CancellationException) {
-            // As above.
+            writeChannel.close()
         } catch (t: Throwable) {
-            logger.d(t) { "write loop for $host:$port ended" }
+            if (closed.load()) {
+                writeChannel.close()
+            } else {
+                // The producer keeps writing into a channel nobody drains and eventually suspends
+                // forever. Cancelling with the cause turns a silent hang into a reported failure.
+                logger.d(t) { "write loop for $host:$port failed" }
+                writeChannel.cancel(t)
+            }
         }
     }
-
-    val closed = AtomicBoolean(false)
 
     // Atomic: close() is reachable from more than one thread, and cancelling an nw_connection_t
     // twice is not something to rely on being harmless.
@@ -306,10 +330,24 @@ private suspend fun receiveChunk(connection: nw_connection_t): ByteArray? =
         nw_connection_receive(connection, 1u, RECEIVE_MAX) { content, _, isComplete, error ->
             if (continuation.isActive) {
                 when {
-                    error != null -> continuation.resume(null)
-                    content != null -> continuation.resume(content.toByteArray())
-                    isComplete -> continuation.resume(null)
-                    else -> continuation.resume(ByteArray(0))
+                    error != null -> {
+                        logger.d { "receive failed${error.describe()}" }
+                        continuation.resumeWithException(
+                            IllegalStateException("receive failed${error.describe()}"),
+                        )
+                    }
+
+                    content != null -> {
+                        continuation.resume(content.toByteArray())
+                    }
+
+                    isComplete -> {
+                        continuation.resume(null)
+                    }
+
+                    else -> {
+                        continuation.resume(ByteArray(0))
+                    }
                 }
             }
         }
@@ -425,9 +463,16 @@ private fun trustsPinnedCertificate(
                     kCFTypeArrayCallBacks.ptr,
                 )
 
-            SecTrustSetAnchorCertificates(trustRef, certArray)
-            SecTrustSetAnchorCertificatesOnly(trustRef, false)
-            SecTrustSetPolicies(trustRef, policyArray)
+            // Unchecked, a failing setter leaves SecTrustEvaluateWithError judging the chain
+            // against the default configuration, which can return true for a certificate that
+            // does not chain to the pinned one. Pinning would fail open, silently.
+            if (SecTrustSetAnchorCertificates(trustRef, certArray) != errSecSuccess ||
+                SecTrustSetAnchorCertificatesOnly(trustRef, false) != errSecSuccess ||
+                SecTrustSetPolicies(trustRef, policyArray) != errSecSuccess
+            ) {
+                logger.d { "could not configure pinned trust evaluation" }
+                return@memScoped false
+            }
 
             val errorPtr = alloc<CFErrorRefVar>()
             val trusted = SecTrustEvaluateWithError(trustRef, errorPtr.ptr)

--- a/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
+++ b/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.io.IOException
 import platform.CoreFoundation.CFArrayCreate
 import platform.CoreFoundation.CFArrayRef
 import platform.CoreFoundation.CFDataCreate
@@ -43,6 +44,7 @@ import platform.Network.nw_connection_start
 import platform.Network.nw_connection_state_cancelled
 import platform.Network.nw_connection_state_failed
 import platform.Network.nw_connection_state_ready
+import platform.Network.nw_connection_state_waiting
 import platform.Network.nw_connection_t
 import platform.Network.nw_content_context_create
 import platform.Network.nw_content_context_t
@@ -192,7 +194,15 @@ private suspend fun openNetworkSocket(
         }
     nw_connection_set_queue(connection, queue)
 
-    awaitReady(connection, host, port)
+    try {
+        awaitReady(connection, host, port)
+    } catch (t: Throwable) {
+        // A failed connection still holds resources, and its state handler is still installed.
+        // Nothing else can cancel it: closeConnection is only reachable through the
+        // TLSSocketConnection this function never gets to return.
+        nw_connection_cancel(connection)
+        throw t
+    }
 
     // Parented to the caller's job. `coroutineContext + job` *replaces* whatever Job the context
     // carried, so a parentless SupervisorJob would quietly detach these loops from the caller:
@@ -201,12 +211,32 @@ private suspend fun openNetworkSocket(
     val scope = CoroutineScope(coroutineContext + ioJob)
     val closed = AtomicBoolean(false)
 
+    // Atomic: close() is reachable from more than one thread, and cancelling an nw_connection_t
+    // twice is not something to rely on being harmless.
+    fun closeConnection() {
+        if (closed.compareAndSet(false, true)) {
+            // Cancelling the connection makes any outstanding receive and send complete with an
+            // error, which ends both loops. There is nothing to release by hand afterwards.
+            nw_connection_cancel(connection)
+            ioJob.cancel()
+        }
+    }
+
+    // Covers the caller's job being cancelled out from under us, which stops the loops but would
+    // otherwise leave the connection itself open. It does not cover the loops simply finishing:
+    // ioJob is a SupervisorJob nobody completes, so it stays active after its children end. The
+    // read loop calls closeConnection directly for that case.
+    ioJob.invokeOnCompletion { closeConnection() }
+
     val readChannel = ByteChannel(autoFlush = true)
     scope.launch {
         try {
             while (isActive) {
-                val chunk = receiveChunk(connection) ?: break
-                if (chunk.isNotEmpty()) readChannel.writeFully(chunk)
+                val received = receiveChunk(connection) ?: break
+                if (received.bytes.isNotEmpty()) readChannel.writeFully(received.bytes)
+                // The FIN can arrive with the last bytes rather than on its own; receiving again
+                // after that produces an error that looks like a failure rather than a clean end.
+                if (received.isComplete) break
             }
             readChannel.close()
         } catch (_: CancellationException) {
@@ -221,6 +251,10 @@ private suspend fun openNetworkSocket(
                 logger.d(t) { "read loop for $host:$port failed" }
                 readChannel.cancel(t)
             }
+        } finally {
+            // End of stream means the connection is finished, so stop the write loop and cancel
+            // the connection rather than leaving both parked forever.
+            closeConnection()
         }
     }
 
@@ -254,22 +288,6 @@ private suspend fun openNetworkSocket(
         }
     }
 
-    // Atomic: close() is reachable from more than one thread, and cancelling an nw_connection_t
-    // twice is not something to rely on being harmless.
-    fun closeConnection() {
-        if (closed.compareAndSet(false, true)) {
-            // Cancelling the connection makes any outstanding receive and send complete with an
-            // error, which ends both loops. There is nothing to release by hand afterwards.
-            nw_connection_cancel(connection)
-            ioJob.cancel()
-        }
-    }
-
-    // Cancelling the caller stops the loops but would otherwise leave the connection itself open,
-    // since only close() cancels it. Completion covers both routes: an explicit close (where this
-    // is already a no-op) and the caller's job being cancelled out from under us.
-    ioJob.invokeOnCompletion { closeConnection() }
-
     return TLSSocketConnection(
         readChannel = readChannel,
         writeChannel = writeChannel,
@@ -290,10 +308,17 @@ private suspend fun awaitReady(
                     if (continuation.isActive) continuation.resume(Unit)
                 }
 
-                nw_connection_state_failed -> {
+                // `waiting` is not transient for our purposes: Network.framework has failed to
+                // establish a path (refused, no route, DNS) and will retry indefinitely. The
+                // previous implementation failed the connect() immediately, and callers rely on
+                // that -- SgeClientImpl turns a thrown connect into "false", and the proxy path
+                // has a deadline that only advances when connect throws.
+                nw_connection_state_waiting,
+                nw_connection_state_failed,
+                -> {
                     if (continuation.isActive) {
                         continuation.resumeWithException(
-                            IllegalStateException("connection to $host:$port failed${error.describe()}"),
+                            IOException("connection to $host:$port failed${error.describe()}"),
                         )
                     }
                 }
@@ -324,8 +349,14 @@ private suspend fun awaitReady(
     }
 }
 
-/** One receive. Returns null at end of stream or on error, which ends the read loop. */
-private suspend fun receiveChunk(connection: nw_connection_t): ByteArray? =
+/** A single receive: the bytes, plus whether the peer signalled end of stream with them. */
+private class Received(
+    val bytes: ByteArray,
+    val isComplete: Boolean,
+)
+
+/** One receive. Returns null at end of stream, and throws on error. */
+private suspend fun receiveChunk(connection: nw_connection_t): Received? =
     suspendCancellableCoroutine { continuation ->
         nw_connection_receive(connection, 1u, RECEIVE_MAX) { content, _, isComplete, error ->
             if (continuation.isActive) {
@@ -333,12 +364,12 @@ private suspend fun receiveChunk(connection: nw_connection_t): ByteArray? =
                     error != null -> {
                         logger.d { "receive failed${error.describe()}" }
                         continuation.resumeWithException(
-                            IllegalStateException("receive failed${error.describe()}"),
+                            IOException("receive failed${error.describe()}"),
                         )
                     }
 
                     content != null -> {
-                        continuation.resume(content.toByteArray())
+                        continuation.resume(Received(content.toByteArray(), isComplete))
                     }
 
                     isComplete -> {
@@ -346,7 +377,7 @@ private suspend fun receiveChunk(connection: nw_connection_t): ByteArray? =
                     }
 
                     else -> {
-                        continuation.resume(ByteArray(0))
+                        continuation.resume(Received(ByteArray(0), false))
                     }
                 }
             }
@@ -369,7 +400,7 @@ private suspend fun sendChunk(
                 if (continuation.isActive) {
                     if (error != null) {
                         continuation.resumeWithException(
-                            IllegalStateException("send failed${error.describe()}"),
+                            IOException("send failed${error.describe()}"),
                         )
                     } else {
                         continuation.resume(Unit)
@@ -407,10 +438,11 @@ private fun dispatch_data_t.toByteArray(): ByteArray =
                     }
                 }
             }
-        // `mapped` has to outlive the copy above. Reading it here is what keeps it reachable --
-        // left unused, the runtime is free to collect it mid-memcpy and the buffer goes with it.
-        check(mapped != null || size == 0) { "dispatch_data_create_map returned null for $size bytes" }
-        bytes
+        // `mapped` has to outlive the copy above: left unused, the runtime is free to collect it
+        // mid-memcpy and the buffer goes with it. Reading it here keeps it reachable. Deliberately
+        // not a check() -- this runs inside an Objective-C block, where a throw would terminate
+        // the process.
+        if (mapped != null) bytes else ByteArray(0)
     }
 
 /**
@@ -420,6 +452,19 @@ private fun dispatch_data_t.toByteArray(): ByteArray =
  * host.
  */
 private fun trustsPinnedCertificate(
+    trust: sec_trust_t,
+    certificate: ByteArray,
+): Boolean =
+    // This runs inside an Objective-C block, where an escaping Kotlin exception terminates the
+    // process rather than failing the handshake. Base64.decode rejects malformed PEM and
+    // addressOf(0) rejects an empty array, so both are reachable with a bad certificate.
+    runCatching { evaluatePinnedTrust(trust, certificate) }
+        .getOrElse {
+            logger.d(it) { "pinned trust evaluation failed" }
+            false
+        }
+
+private fun evaluatePinnedTrust(
     trust: sec_trust_t,
     certificate: ByteArray,
 ): Boolean {

--- a/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
+++ b/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
@@ -369,7 +369,16 @@ private suspend fun receiveChunk(connection: nw_connection_t): Received? =
                     }
 
                     content != null -> {
-                        continuation.resume(Received(content.toByteArray(), isComplete))
+                        val bytes = content.toByteArray()
+                        if (bytes == null) {
+                            // Bytes arrived and could not be read out. Treating that as an empty
+                            // chunk would drop them and carry on as if nothing had happened.
+                            continuation.resumeWithException(
+                                IOException("could not map received data"),
+                            )
+                        } else {
+                            continuation.resume(Received(bytes, isComplete))
+                        }
                     }
 
                     isComplete -> {
@@ -420,7 +429,7 @@ private fun ByteArray.toDispatchData(queue: dispatch_queue_t): dispatch_data_t =
         dispatch_data_create(pinned.addressOf(0), size.convert(), queue, null)
     }
 
-private fun dispatch_data_t.toByteArray(): ByteArray =
+private fun dispatch_data_t.toByteArray(): ByteArray? =
     memScoped {
         val bufferPtr = alloc<COpaquePointerVar>()
         val sizePtr = alloc<size_tVar>()
@@ -430,9 +439,10 @@ private fun dispatch_data_t.toByteArray(): ByteArray =
         if (mapped == null) {
             // create_map leaves the out parameters untouched when it fails, and they are
             // uninitialised memScoped memory: reading them would size an array from garbage and
-            // memcpy from a garbage pointer. Deliberately not a check() -- this runs inside an
-            // Objective-C block, where a throw terminates the process.
-            return@memScoped ByteArray(0)
+            // memcpy from a garbage pointer. Null rather than an empty array, because an empty
+            // array is a legitimate payload and this is lost data. Deliberately not a check() --
+            // this runs inside an Objective-C block, where a throw terminates the process.
+            return@memScoped null
         }
         val size = sizePtr.value.toInt()
         val bytes =

--- a/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
+++ b/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
@@ -332,7 +332,7 @@ private suspend fun awaitReady(
                 }
 
                 else -> {
-                    // waiting/preparing/invalid: nothing to do until one of the states above.
+                    // preparing/invalid: nothing to do until one of the states above.
                 }
             }
         }
@@ -362,7 +362,7 @@ private suspend fun receiveChunk(connection: nw_connection_t): Received? =
             if (continuation.isActive) {
                 when {
                     error != null -> {
-                        logger.d { "receive failed${error.describe()}" }
+                        // Not logged here: the read loop logs it with the cause attached.
                         continuation.resumeWithException(
                             IOException("receive failed${error.describe()}"),
                         )
@@ -427,6 +427,13 @@ private fun dispatch_data_t.toByteArray(): ByteArray =
         // A dispatch_data_t may be a rope of discontiguous regions; create_map flattens it and
         // returns an object that *owns* the contiguous buffer bufferPtr points at.
         val mapped = dispatch_data_create_map(this@toByteArray, bufferPtr.ptr, sizePtr.ptr)
+        if (mapped == null) {
+            // create_map leaves the out parameters untouched when it fails, and they are
+            // uninitialised memScoped memory: reading them would size an array from garbage and
+            // memcpy from a garbage pointer. Deliberately not a check() -- this runs inside an
+            // Objective-C block, where a throw terminates the process.
+            return@memScoped ByteArray(0)
+        }
         val size = sizePtr.value.toInt()
         val bytes =
             if (size == 0) {
@@ -438,11 +445,9 @@ private fun dispatch_data_t.toByteArray(): ByteArray =
                     }
                 }
             }
-        // `mapped` has to outlive the copy above: left unused, the runtime is free to collect it
-        // mid-memcpy and the buffer goes with it. Reading it here keeps it reachable. Deliberately
-        // not a check() -- this runs inside an Objective-C block, where a throw would terminate
-        // the process.
-        if (mapped != null) bytes else ByteArray(0)
+        // `mapped` owns the buffer copied above and has to outlive the copy; left unreferenced
+        // afterwards, the runtime is free to collect it mid-memcpy and the buffer goes with it.
+        mapped.let { bytes }
     }
 
 /**


### PR DESCRIPTION
Replaces the hand-rolled SecureTransport implementation of the iOS sockets with Network.framework.

### Why

Apple deprecated SecureTransport years ago, and every review finding on #293 was a lifetime or concurrency defect in the old design — CoreFoundation objects released while still referenced, a socket and TLS context stranded on failure paths, teardown racing two jobs parked inside blocking native calls, a non-atomic close gate. Each fix exposed the next layer.

Network.framework removes the category rather than patching it. `nw_connection_t` and friends are Objective-C objects, so the Kotlin/Native runtime owns their lifetime and there is nothing to `CFRelease`. Cancellation is asynchronous by design. Both IO paths are callbacks bridged into coroutines, so no thread parks in a blocking call that cancellation cannot interrupt.

Certificate pinning keeps the previous semantics exactly: pinned certificate as an additional anchor, system anchors still trusted, hostname checking off because the Simutronics CA certificate has no SAN for the game host.

### Three interop traps

None of these produce a compiler error. All three compiled cleanly and failed at runtime.

- **`NW_PARAMETERS_DISABLE_PROTOCOL` is matched by pointer identity.** Kotlin/Native wraps a block crossing the boundary, so the comparison never matches and the framework *calls* the sentinel as an ordinary configuration block — which had a **plain** socket attempting TLS. The protocol stack is assembled by hand instead, which also means SNI must be set explicitly.
- **`NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT` is also a sentinel**, not a real object. Converting it aborts the process inside `Kotlin_Interop_refFromObjC`.
- **`dispatch_data_create_map` returns an object owning the flattened buffer.** Left unused, the runtime can collect it mid-`memcpy`.

### Also fixed

The IO scope used a parentless `SupervisorJob`, and `coroutineContext + job` *replaces* whatever `Job` the context held — so the loops were detached from the caller's cancellation and the connection stayed open until something called `close()` explicitly. Carried over from the old implementation, where it was worse: the stranded loops held a file descriptor, an SSL context and a stable ref. The job is now a child of the caller's, and teardown runs from the job's completion as well as from `close()`.

### Verification

- **Plain TCP**: verified end-to-end against a real server — connect, send, and a genuine HTTP response read back.
- **Pinned TLS**: verified by connecting to a game. That path is `openTLSSocket`, since iOS `SgeSettings` sets `secure = true`.
- **`openDefaultTlsSocket`**: not exercised. It is used only by the MUD Mobile router and differs from the pinned path only in adding no verify block.

Worth knowing for future debugging: a Kotlin/Native test binary cannot do TLS trust evaluation or reach the Keychain — it has no app container, so Security services are restricted. TLS there fails with `-9808 "bad certificate format"` regardless of the code. Verification of anything touching Security has to happen in the app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS connection reliability for plain, standard TLS, and certificate-pinned connections.
  * Improved handling of connection failures, cancellations, interrupted network activity, and closed connections.
  * Strengthened certificate validation, including support for system trust anchors and PEM certificates.
  * Improved asynchronous sending and receiving, with more consistent reporting of network errors.
  * Fixed handling of data received alongside connection closures, helping prevent lost messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->