### PR TITLE
Put a reopened window back where it was

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
@@ -50,6 +50,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import warlockfe.warlock3.compose.ui.window.StreamWindowData
 import warlockfe.warlock3.compose.ui.window.WindowUiState
 import warlockfe.warlock3.core.window.WindowLocation
@@ -350,6 +352,9 @@ fun rememberGameDockState(
                     Logger.w { "Window restore still running after $CHARACTER_WAIT; docking against it" }
                 }
                 val saved = runCatching { viewModel.loadDockLayout() }.getOrNull()
+                // Before the restore, so the reconcile inside it can already put a window the
+                // character closed in an earlier session back where they left it.
+                spots.restore(runCatching { viewModel.loadDockSpots() }.getOrNull())
                 applyRestoredLayout(state, saved, liveOpenWindows(), ::registerWindow, spots)
                 restoreFinished.complete(Unit)
                 snapshotFlow { state.layout }
@@ -357,6 +362,9 @@ fun rememberGameDockState(
                     .debounce(1.seconds)
                     .collect {
                         viewModel.saveDockLayout(DockingPersistence.encode(state.captureLayout()))
+                        // Spots only ever change as part of a close or a reopen, and both of those
+                        // move the layout, so this beat catches every change to them.
+                        viewModel.saveDockSpots(spots.encode())
                     }
             }
             // Hold the first layout pass for the restore, so early windows do not flash into
@@ -705,12 +713,12 @@ internal data class RememberedSpot(
 )
 
 /**
- * Where closed windows were, for the length of the session.
+ * Where closed windows were, saved alongside the character's arrangement.
  *
- * Deliberately not persisted: the saved arrangement records where the *open* windows are, and a
- * window that is closed when the client quits comes back in its announced spot, as it always has.
- * This is for the close-and-reopen cycle within a session, which is the one that happens constantly
- * - toggling a panel from the Windows menu and finding it back where you left it.
+ * Stored apart from the arrangement rather than folded into it, so an unreadable set of spots costs
+ * only the memory, and every layout already saved still reads. The arrangement records where the
+ * *open* windows are; this records the rest, so a window closed a fortnight ago still comes back
+ * where its owner left it rather than where the game first put it.
  */
 internal class DockSpotMemory {
     private val spots = mutableMapOf<String, RememberedSpot>()
@@ -724,7 +732,58 @@ internal class DockSpotMemory {
 
     /** Reads and clears: a spot is good for the reopen that follows the close it came from. */
     fun take(name: String): RememberedSpot? = spots.remove(name)
+
+    fun encode(): String = Json.encodeToString(spots.mapValues { it.value.toStored() })
+
+    /** Replaces the contents with [saved]. Anything unreadable is dropped, which only costs memory. */
+    fun restore(saved: String?) {
+        spots.clear()
+        if (saved.isNullOrBlank()) return
+        runCatching { Json.decodeFromString<Map<String, StoredSpot>>(saved) }
+            .onSuccess { stored -> stored.forEach { (name, spot) -> spot.toSpot()?.let { spots[name] = it } } }
+            .onFailure { Logger.w(it) { "Discarding unreadable dock spots" } }
+    }
 }
+
+/**
+ * [RememberedSpot] as it is written to disk. A shape of our own rather than the library's types
+ * annotated, so a rename there cannot quietly invalidate what characters have saved; [DockRegion] is
+ * stored by name and anything unrecognised reads back as no spot at all.
+ */
+@Serializable
+internal data class StoredSpot(
+    val siblings: List<String> = emptyList(),
+    val region: String,
+    val proportion: Float,
+    val detached: Boolean = false,
+    val x: Float? = null,
+    val y: Float? = null,
+    val width: Float? = null,
+    val height: Float? = null,
+) {
+    fun toSpot(): RememberedSpot? {
+        val dockRegion = DockRegion.entries.firstOrNull { it.name == region } ?: return null
+        val bounds =
+            if (x != null && y != null && width != null && height != null) {
+                WindowBounds(x, y, width, height)
+            } else {
+                null
+            }
+        return RememberedSpot(siblings, dockRegion, proportion, detached, bounds)
+    }
+}
+
+private fun RememberedSpot.toStored(): StoredSpot =
+    StoredSpot(
+        siblings = siblings,
+        region = region.name,
+        proportion = proportion,
+        detached = detached,
+        x = bounds?.x,
+        y = bounds?.y,
+        width = bounds?.width,
+        height = bounds?.height,
+    )
 
 /**
  * Where [name] is sitting right now, in the terms [RememberedSpot] keeps, or null when there is

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
@@ -52,6 +52,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
 import warlockfe.warlock3.compose.ui.window.StreamWindowData
 import warlockfe.warlock3.compose.ui.window.WindowUiState
 import warlockfe.warlock3.core.window.WindowLocation
@@ -363,8 +365,11 @@ fun rememberGameDockState(
                     .collect {
                         viewModel.saveDockLayout(DockingPersistence.encode(state.captureLayout()))
                         // Spots only ever change as part of a close or a reopen, and both of those
-                        // move the layout, so this beat catches every change to them.
-                        viewModel.saveDockSpots(spots.encode())
+                        // move the layout, so this beat catches every change to them. Most layout
+                        // changes are drags and resizes, which change no spot at all, so only write
+                        // when something actually moved - the writer does not de-duplicate.
+                        spots.prune(liveOpenWindows().keys + dockedIds(state.layout).map { it.value })
+                        if (spots.isDirty()) viewModel.saveDockSpots(spots.encode())
                     }
             }
             // Hold the first layout pass for the restore, so early windows do not flash into
@@ -435,7 +440,7 @@ internal fun applyRestoredLayout(
     saved: String?,
     openWindows: Map<String, OpenGameWindow>,
     registerWindow: (String, AnchorId?) -> Unit,
-    spots: DockSpotMemory = DockSpotMemory(),
+    spots: DockSpotMemory,
 ) {
     if (saved != null) {
         runCatching { DockingPersistence.decode(saved) }
@@ -479,16 +484,17 @@ internal fun reconcile(
     state: DockState,
     openWindows: Map<String, OpenGameWindow>,
     registerWindow: (String, AnchorId?) -> Unit,
-    spots: DockSpotMemory = DockSpotMemory(),
+    spots: DockSpotMemory,
 ) {
-    dockedIds(state.layout)
-        .filter { it.value != MAIN_WINDOW_NAME && it.value !in openWindows }
-        .forEach { id ->
-            // Note where it was before it goes, so reopening can put it back between the same
-            // windows rather than at the bottom of its column.
-            spots.remember(id.value, rememberedSpotOf(state, id.value))
-            state.undock(id)
-        }
+    val leaving = dockedIds(state.layout).filter { it.value != MAIN_WINDOW_NAME && it.value !in openWindows }
+    // Every spot is read off the tree as it stands before any of them leaves it. Undocking as we
+    // went had the second window of a pair record its neighbours from a tree the first had already
+    // been taken out of, so both ended up describing an arrangement that never existed.
+    leaving.associate { it.value to rememberedSpotOf(state, it.value) }.forEach { (name, spot) ->
+        spots.remember(name, spot)
+    }
+    leaving.forEach { state.undock(it) }
+
     val mainWindow = state.layout.mainWindow
     val tree = mainWindow.maximized?.savedRoot ?: mainWindow.root
     openWindows.forEach { (name, window) ->
@@ -506,35 +512,49 @@ internal fun reconcile(
                 else -> tree?.let { currentAnchorOf(it, name) } ?: window.location.anchor
             }
         registerWindow(name, anchor)
-        val id = DockableId(name)
-        if (!state.isOpen(id)) {
-            val remembered = spots.take(name)
-            val rememberedPlacement = remembered?.let { placementFromMemory(it, state.layout) }
-            when {
-                // Closed while detached, so it reopens detached, at the size and place it had.
-                remembered?.detached == true && platformDockCapabilities.floatingWindows -> {
-                    detachWindow(state, name, remembered.bounds)
-                }
+    }
 
-                rememberedPlacement != null -> {
-                    state.dock(id, rememberedPlacement.target, rememberedPlacement.region, rememberedPlacement.proportion)
-                }
+    val pending = openWindows.filterKeys { !state.isOpen(DockableId(it)) }.toMutableMap()
+    // Windows are put back by their remembered spots first, and in whatever order those become
+    // usable: closing a pair and reopening it leaves each of them waiting on the other, and the one
+    // that can be placed goes first so the other has something to be placed against. A spot is only
+    // spent when it is used, so a window that never gets its chance this pass keeps it for the next.
+    while (true) {
+        val placeable =
+            pending.keys.firstNotNullOfOrNull { name ->
+                spots.peek(name)?.let { spot ->
+                    when {
+                        // Company it can rejoin comes first; a new window is for one that was alone.
+                        placementFromMemory(spot, state.layout) != null -> name to placementFromMemory(spot, state.layout)
 
-                opensDetached(window) -> {
-                    detachWindow(state, name)
-                }
+                        spot.detached && platformDockCapabilities.floatingWindows -> name to null
 
-                else -> {
-                    val placement =
-                        defaultPlacement(
-                            name = name,
-                            location = window.location,
-                            layout = state.layout,
-                            openWindows = openWindows,
-                        )
-                    state.dock(id, placement.target, placement.region, placement.proportion)
+                        else -> null
+                    }
                 }
-            }
+            } ?: break
+        val (name, placement) = placeable
+        val spot = spots.spend(name)
+        if (placement == null) {
+            detachWindow(state, name, spot?.bounds)
+        } else {
+            state.dock(DockableId(name), placement.target, placement.region, placement.proportion)
+        }
+        pending.remove(name)
+    }
+
+    pending.forEach { (name, window) ->
+        if (opensDetached(window)) {
+            detachWindow(state, name)
+        } else {
+            val placement =
+                defaultPlacement(
+                    name = name,
+                    location = window.location,
+                    layout = state.layout,
+                    openWindows = openWindows,
+                )
+            state.dock(DockableId(name), placement.target, placement.region, placement.proportion)
         }
     }
     closeEmptyDetachedWindows(state)
@@ -722,26 +742,78 @@ internal data class RememberedSpot(
  */
 internal class DockSpotMemory {
     private val spots = mutableMapOf<String, RememberedSpot>()
+    private var dirty = false
 
+    /**
+     * Records where [name] was. A null [spot] means "nothing worth recording", which is not the same
+     * as "forget what we knew": a window undocked from somewhere unrecognisable - or one the restore
+     * pass sweeps up before it has been placed - keeps the spot it already had rather than losing it.
+     */
     fun remember(
         name: String,
         spot: RememberedSpot?,
     ) {
-        if (spot == null) spots.remove(name) else spots[name] = spot
+        if (spot != null && spots[name] != spot) {
+            spots[name] = spot
+            dirty = true
+        }
     }
 
-    /** Reads and clears: a spot is good for the reopen that follows the close it came from. */
-    fun take(name: String): RememberedSpot? = spots.remove(name)
+    /** Drops [name]'s spot outright, for a window that is not coming back. */
+    fun forget(name: String) {
+        if (spots.remove(name) != null) dirty = true
+    }
 
-    fun encode(): String = Json.encodeToString(spots.mapValues { it.value.toStored() })
+    /** Whether anything has changed since the last [encode]. */
+    fun isDirty(): Boolean = dirty
 
-    /** Replaces the contents with [saved]. Anything unreadable is dropped, which only costs memory. */
+    /** Looks without spending. A spot survives a pass that could not use it. */
+    fun peek(name: String): RememberedSpot? = spots[name]
+
+    /** Spends a spot: it is good for the reopen that follows the close it came from, and no more. */
+    fun spend(name: String): RememberedSpot? = spots.remove(name)?.also { dirty = true }
+
+    fun encode(): String {
+        dirty = false
+        return json.encodeToString(spots.mapValues { it.value.toStored() })
+    }
+
+    /**
+     * Reads [saved] in, keeping anything already recorded this session - a window closed while the
+     * character was still being identified would otherwise have its spot wiped by the restore that
+     * follows. Read entry by entry, so one unreadable spot costs only itself.
+     */
     fun restore(saved: String?) {
-        spots.clear()
         if (saved.isNullOrBlank()) return
-        runCatching { Json.decodeFromString<Map<String, StoredSpot>>(saved) }
-            .onSuccess { stored -> stored.forEach { (name, spot) -> spot.toSpot()?.let { spots[name] = it } } }
-            .onFailure { Logger.w(it) { "Discarding unreadable dock spots" } }
+        val entries =
+            runCatching { json.decodeFromString<Map<String, JsonElement>>(saved) }
+                .onFailure { Logger.w(it) { "Discarding unreadable dock spots" } }
+                .getOrNull() ?: return
+        entries.forEach { (name, element) ->
+            if (name in spots) return@forEach
+            runCatching { json.decodeFromJsonElement<StoredSpot>(element).toSpot() }
+                .onSuccess { spot ->
+                    spot?.let {
+                        spots[name] = it
+                        dirty = true
+                    }
+                }.onFailure { Logger.w(it) { "Discarding unreadable dock spot for $name" } }
+        }
+    }
+
+    /** Drops spots for windows that no longer exist, so the set cannot grow without bound. */
+    fun prune(known: Set<String>) {
+        val gone = spots.keys - known
+        if (gone.isNotEmpty()) {
+            gone.forEach { spots.remove(it) }
+            dirty = true
+        }
+    }
+
+    private companion object {
+        // Lenient on the way in: a field added by a later build must cost that one spot at worst,
+        // and preferably nothing at all. The library's own persistence reads its layouts the same way.
+        val json = Json { ignoreUnknownKeys = true }
     }
 }
 
@@ -794,18 +866,28 @@ internal fun rememberedSpotOf(
     name: String,
 ): RememberedSpot? {
     val id = DockableId(name)
-    if (isDetached(state, name)) {
-        val window = state.layout.floatingWindows.firstOrNull { it.containsDockable(id) } ?: return null
-        return RememberedSpot(emptyList(), DockRegion.Center, 0.5f, detached = true, bounds = window.bounds)
+    // Whichever window it is in, not just the main one: a window torn off with company remembers
+    // that company, so reopening puts it back beside them in the same torn-off window rather than
+    // opening a second one on top of the first.
+    val window = state.layout.windows.firstOrNull { it.containsDockable(id) } ?: return null
+    val detached = window.id != WindowId.MAIN
+    val tree = window.maximized?.savedRoot ?: window.root
+    val neighbours =
+        tree?.let {
+            // Tabbed with others: back into the same strip beats any split it happens to sit in.
+            it.tabsContaining(id)?.let { tabs ->
+                val others = tabs.tabs.map { tab -> tab.dockableId.value }.filter { other -> other != name }
+                if (others.isNotEmpty()) RememberedSpot(others, DockRegion.Center, 0.5f) else null
+            } ?: it.splitSpotOf(id)
+        }
+    return when {
+        neighbours != null -> neighbours.copy(detached = detached, bounds = window.bounds.takeIf { detached })
+
+        // Alone in a window of its own: the window itself is the thing to remember.
+        detached -> RememberedSpot(emptyList(), DockRegion.Center, 0.5f, detached = true, bounds = window.bounds)
+
+        else -> null
     }
-    val mainWindow = state.layout.mainWindow
-    val tree = mainWindow.maximized?.savedRoot ?: mainWindow.root ?: return null
-    // Tabbed with others: going back into the same tab strip beats any split it happens to sit in.
-    tree.tabsContaining(id)?.let { tabs ->
-        val others = tabs.tabs.map { it.dockableId.value }.filter { it != name }
-        if (others.isNotEmpty()) return RememberedSpot(others, DockRegion.Center, 0.5f)
-    }
-    return tree.splitSpotOf(id)
 }
 
 /** The split this leaf is a direct child of, described from the leaf's side of it. */
@@ -845,9 +927,15 @@ internal fun placementFromMemory(
     spot: RememberedSpot,
     layout: DockLayout,
 ): DockPlacement? {
-    if (spot.detached) return null
-    val mainWindow = layout.mainWindow
-    val tree = mainWindow.maximized?.savedRoot ?: mainWindow.root ?: return null
+    if (spot.siblings.isEmpty()) return null
+    // The live tree only. A target naming something that is only in a window's pre-maximize tree
+    // cannot be resolved when the dock comes to apply it, and an unresolvable target is dropped
+    // silently - the window would simply not appear.
+    val window =
+        layout.windows.firstOrNull { candidate ->
+            candidate.root?.let { root -> spot.siblings.any { root.containsDockable(DockableId(it)) } } == true
+        } ?: return null
+    val tree = window.root ?: return null
     val surviving = spot.siblings.map { DockableId(it) }.filter { tree.containsDockable(it) }
     if (surviving.isEmpty()) return null
     // Back into the tab strip: docking Center onto a member is what appends a tab.
@@ -855,7 +943,7 @@ internal fun placementFromMemory(
         return DockPlacement(DockTarget.OnDockable(surviving.first()), DockRegion.Center, spot.proportion)
     }
     val node = tree.smallestNodeHolding(surviving.toSet()) ?: return null
-    return DockPlacement(DockTarget.OnNode(mainWindow.id, node.id), spot.region, spot.proportion)
+    return DockPlacement(DockTarget.OnNode(window.id, node.id), spot.region, spot.proportion)
 }
 
 /** Whether this window's tree holds [id], maximized or not. */

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
@@ -718,11 +718,17 @@ internal fun opensDetached(window: OpenGameWindow): Boolean =
  * The spot is described by its *neighbours* rather than by coordinates, because coordinates do not
  * survive the rest of the layout moving underneath them. What is remembered is which windows it was
  * split away from (or tabbed with), which side of them it was on, and how much of them it had. Reopen
- * it while any of those neighbours are still docked and it goes back between the same windows, at the
+ * it while those neighbours are all still docked and it goes back between the same windows at the
  * same size, wherever they have since been dragged to.
  *
- * [siblings] empty with [detached] set is the other case: it was in a window of its own, and reopens
- * in one, at [bounds].
+ * Best effort, and two places it falls short of that, both better than the announced spot and
+ * neither of them "where it was":
+ *  - when only some of the neighbours survive, the proportion is applied to what is left of them, so
+ *    a window that had a quarter of a column comes back with a quarter of the one window still there.
+ *  - a window that was tabbed rejoins the strip at the end of it, not at the index it had.
+ *
+ * [siblings] empty with [detached] set is the other case: it was alone in a window of its own, and
+ * reopens in one, at [bounds].
  */
 internal data class RememberedSpot(
     val siblings: List<String>,
@@ -919,9 +925,10 @@ private fun DockNode.splitSpotOf(id: DockableId): RememberedSpot? {
 }
 
 /**
- * Turns a remembered spot back into a placement, or null when too much of it has gone - every
- * neighbour it was next to has since been closed, so there is nothing left to sit beside and the
- * announced spot is the better answer.
+ * Turns a remembered spot back into a placement, or null when it cannot be honoured right now -
+ * every neighbour has since been closed, or none of them is in a live tree yet, so there is nothing
+ * to sit beside. The caller keeps the spot in that case and tries again, which is what lets a pair
+ * of windows closed together be reopened together.
  */
 internal fun placementFromMemory(
     spot: RememberedSpot,

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
@@ -20,6 +20,7 @@ import com.seanproctor.docking.model.AnchorId
 import com.seanproctor.docking.model.DockLayout
 import com.seanproctor.docking.model.DockNode
 import com.seanproctor.docking.model.DockRegion
+import com.seanproctor.docking.model.DockWindow
 import com.seanproctor.docking.model.DockableId
 import com.seanproctor.docking.model.DockableOptions
 import com.seanproctor.docking.model.SplitOrientation
@@ -408,8 +409,7 @@ fun rememberGameDockState(
                     val current =
                         layout.floatingWindows.associate { window ->
                             window.id to
-                                listOfNotNull(window.root, window.maximized?.savedRoot)
-                                    .flatMap { it.dockableIds() }
+                                window.allTrees.flatMap { it.dockableIds() }
                         }
                     (detached.keys - current.keys).forEach { closed ->
                         detached[closed]
@@ -496,7 +496,7 @@ internal fun reconcile(
     leaving.forEach { state.undock(it) }
 
     val mainWindow = state.layout.mainWindow
-    val tree = mainWindow.maximized?.savedRoot ?: mainWindow.root
+    val tree = mainWindow.arrangement
     openWindows.forEach { (name, window) ->
         val anchor =
             when {
@@ -539,6 +539,9 @@ internal fun reconcile(
             detachWindow(state, name, spot?.bounds)
         } else {
             state.dock(DockableId(name), placement.target, placement.region, placement.proportion)
+            // Docking Center appends to the strip, so a window that was not last has to be moved
+            // back to its own place in it.
+            spot?.tabIndex?.let { restoreTabIndex(state, name, it) }
         }
         pending.remove(name)
     }
@@ -627,7 +630,7 @@ internal fun isHiddenTab(
     val root =
         state.layout.windows
             .firstNotNullOfOrNull { window ->
-                (window.maximized?.savedRoot ?: window.root)?.takeIf { it.containsDockable(id) }
+                window.arrangement?.takeIf { it.containsDockable(id) }
             } ?: return false
     val tabs = root.tabsContaining(id) ?: return false
     return tabs.selectedTab.dockableId != id
@@ -682,6 +685,23 @@ internal fun redockIntoMainWindow(
     closeEmptyDetachedWindows(state)
 }
 
+/**
+ * Puts a window that has just rejoined a tab strip back at the index it had. Docking appends, so
+ * without this a window that was first of four comes back fourth.
+ */
+private fun restoreTabIndex(
+    state: DockState,
+    name: String,
+    index: Int,
+) {
+    val id = DockableId(name)
+    val window = state.layout.windows.firstOrNull { it.containsDockable(id) } ?: return
+    val tabs = window.arrangement?.tabsContaining(id) ?: return
+    val from = tabs.tabs.indexOfFirst { it.dockableId == id }
+    val to = index.coerceIn(0, tabs.tabs.lastIndex)
+    if (from >= 0 && from != to) state.moveTab(tabs.id, from, to)
+}
+
 /** Whether [name] is currently in a detached window rather than the main one. */
 internal fun isDetached(
     state: DockState,
@@ -721,11 +741,9 @@ internal fun opensDetached(window: OpenGameWindow): Boolean =
  * it while those neighbours are all still docked and it goes back between the same windows at the
  * same size, wherever they have since been dragged to.
  *
- * Best effort, and two places it falls short of that, both better than the announced spot and
- * neither of them "where it was":
- *  - when only some of the neighbours survive, the proportion is applied to what is left of them, so
- *    a window that had a quarter of a column comes back with a quarter of the one window still there.
- *  - a window that was tabbed rejoins the strip at the end of it, not at the index it had.
+ * Best effort, and one place it falls short: the size is a share of the neighbours that are still
+ * there, so a window reopened next to fewer of them than it left is the size it would have been had
+ * it never gone - which is right, but is not the same as the size it was when it closed.
  *
  * [siblings] empty with [detached] set is the other case: it was alone in a window of its own, and
  * reopens in one, at [bounds].
@@ -736,6 +754,8 @@ internal data class RememberedSpot(
     val proportion: Float,
     val detached: Boolean = false,
     val bounds: WindowBounds? = null,
+    // Which tab it was, when it was one, so it rejoins the strip in its own place rather than at the end.
+    val tabIndex: Int? = null,
 )
 
 /**
@@ -838,6 +858,7 @@ internal data class StoredSpot(
     val y: Float? = null,
     val width: Float? = null,
     val height: Float? = null,
+    val tabIndex: Int? = null,
 ) {
     fun toSpot(): RememberedSpot? {
         val dockRegion = DockRegion.entries.firstOrNull { it.name == region } ?: return null
@@ -847,7 +868,7 @@ internal data class StoredSpot(
             } else {
                 null
             }
-        return RememberedSpot(siblings, dockRegion, proportion, detached, bounds)
+        return RememberedSpot(siblings, dockRegion, proportion, detached, bounds, tabIndex)
     }
 }
 
@@ -861,6 +882,7 @@ private fun RememberedSpot.toStored(): StoredSpot =
         y = bounds?.y,
         width = bounds?.width,
         height = bounds?.height,
+        tabIndex = tabIndex,
     )
 
 /**
@@ -877,13 +899,22 @@ internal fun rememberedSpotOf(
     // opening a second one on top of the first.
     val window = state.layout.windows.firstOrNull { it.containsDockable(id) } ?: return null
     val detached = window.id != WindowId.MAIN
-    val tree = window.maximized?.savedRoot ?: window.root
+    val tree = window.arrangement
     val neighbours =
         tree?.let {
             // Tabbed with others: back into the same strip beats any split it happens to sit in.
             it.tabsContaining(id)?.let { tabs ->
                 val others = tabs.tabs.map { tab -> tab.dockableId.value }.filter { other -> other != name }
-                if (others.isNotEmpty()) RememberedSpot(others, DockRegion.Center, 0.5f) else null
+                if (others.isNotEmpty()) {
+                    RememberedSpot(
+                        siblings = others,
+                        region = DockRegion.Center,
+                        proportion = 0.5f,
+                        tabIndex = tabs.tabs.indexOfFirst { tab -> tab.dockableId == id }.takeIf { index -> index >= 0 },
+                    )
+                } else {
+                    null
+                }
             } ?: it.splitSpotOf(id)
         }
     return when {
@@ -950,12 +981,30 @@ internal fun placementFromMemory(
         return DockPlacement(DockTarget.OnDockable(surviving.first()), DockRegion.Center, spot.proportion)
     }
     val node = tree.smallestNodeHolding(surviving.toSet()) ?: return null
+    // The proportion goes back unscaled even when only some of the siblings are left, which looks
+    // wrong and is not: the space a closed window had was already given to the ones that remain, so
+    // what survives fills the same extent the whole group did. Taking the old share of it puts the
+    // window back at the size it had. Scaling it to the survivors was tried and made the window grow.
     return DockPlacement(DockTarget.OnNode(window.id, node.id), spot.region, spot.proportion)
 }
 
-/** Whether this window's tree holds [id], maximized or not. */
-private fun com.seanproctor.docking.model.DockWindow.containsDockable(id: DockableId): Boolean =
-    listOfNotNull(root, maximized?.savedRoot).any { it.containsDockable(id) }
+/**
+ * The window's arrangement: the tree it would show if nothing were maximized. Maximizing swaps the
+ * real tree out for the maximized dockable alone and keeps the arrangement in `savedRoot`, so this is
+ * what to read when the question is where windows sit relative to one another.
+ */
+internal val DockWindow.arrangement: DockNode?
+    get() = maximized?.savedRoot ?: root
+
+/**
+ * Every tree the window holds - the live one and, while maximized, the arrangement underneath it.
+ * What to read when the question is merely whether a window is in here somewhere.
+ */
+internal val DockWindow.allTrees: List<DockNode>
+    get() = listOfNotNull(root, maximized?.savedRoot)
+
+/** Whether this window holds [id] in any of its trees. */
+internal fun DockWindow.containsDockable(id: DockableId): Boolean = allTrees.any { it.containsDockable(id) }
 
 /** Where [reconcile] puts a window with no saved dock spot. */
 internal data class DockPlacement(
@@ -993,7 +1042,7 @@ internal fun defaultPlacement(
         return DockPlacement(DockTarget.Root(), DockRegion.Center, BAND_PROPORTION)
     }
     val mainWindow = layout.mainWindow
-    val tree = mainWindow.maximized?.savedRoot ?: mainWindow.root
+    val tree = mainWindow.arrangement
     val mainId = DockableId(MAIN_WINDOW_NAME)
     val anchor = location.anchor
     if (tree != null && tree.holdsAnchor(anchor)) {
@@ -1134,8 +1183,7 @@ internal fun relativeRegion(
 private fun dockedIds(layout: DockLayout): List<DockableId> =
     layout.windows
         .flatMap { window ->
-            listOfNotNull(window.root, window.maximized?.savedRoot)
-                .flatMap { it.dockableIds() }
+            window.allTrees.flatMap { it.dockableIds() }
         }.distinct()
 
 private fun DockNode.dockableIds(): List<DockableId> =

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
@@ -365,12 +365,7 @@ fun rememberGameDockState(
                     .debounce(1.seconds)
                     .collect {
                         viewModel.saveDockLayout(DockingPersistence.encode(state.captureLayout()))
-                        // Spots only ever change as part of a close or a reopen, and both of those
-                        // move the layout, so this beat catches every change to them. Most layout
-                        // changes are drags and resizes, which change no spot at all, so only write
-                        // when something actually moved - the writer does not de-duplicate.
-                        spots.prune(liveOpenWindows().keys + dockedIds(state.layout).map { it.value })
-                        if (spots.isDirty()) viewModel.saveDockSpots(spots.encode())
+                        dockSpotsToSave(spots)?.let { viewModel.saveDockSpots(it) }
                     }
             }
             // Hold the first layout pass for the restore, so early windows do not flash into
@@ -759,6 +754,21 @@ internal data class RememberedSpot(
 )
 
 /**
+ * What the debounced save should write for the spots, or null when nothing has moved.
+ *
+ * Spots only ever change as part of a close or a reopen, and both of those move the layout, so the
+ * same beat that saves the arrangement catches every change to them. Most layout changes are drags
+ * and resizes, which change no spot at all, and the writer does not de-duplicate, so an unchanged
+ * set is not worth a write.
+ *
+ * It takes the memory and nothing else on purpose. An earlier version bounded the map here against
+ * the windows that were open or docked - which are precisely the two things a window that has just
+ * been closed is not, so it deleted the spot of the window whose close the user was most likely to
+ * undo, one second after they closed it. There is no set of live windows to be tempted by here.
+ */
+internal fun dockSpotsToSave(spots: DockSpotMemory): String? = if (spots.isDirty()) spots.encode() else null
+
+/**
  * Where closed windows were, saved alongside the character's arrangement.
  *
  * Stored apart from the arrangement rather than folded into it, so an unreadable set of spots costs
@@ -779,10 +789,13 @@ internal class DockSpotMemory {
         name: String,
         spot: RememberedSpot?,
     ) {
-        if (spot != null && spots[name] != spot) {
-            spots[name] = spot
-            dirty = true
-        }
+        if (spot == null) return
+        if (spots[name] != spot) dirty = true
+        // Re-inserted rather than replaced, so the map runs least- to most-recently recorded and
+        // [trim] drops whichever nobody has touched in longest.
+        spots.remove(name)
+        spots[name] = spot
+        trim()
     }
 
     /** Drops [name]'s spot outright, for a window that is not coming back. */
@@ -827,11 +840,19 @@ internal class DockSpotMemory {
         }
     }
 
-    /** Drops spots for windows that no longer exist, so the set cannot grow without bound. */
-    fun prune(known: Set<String>) {
-        val gone = spots.keys - known
-        if (gone.isNotEmpty()) {
-            gone.forEach { spots.remove(it) }
+    /**
+     * Forgets the least recently recorded spots once there are more than [MAX_SPOTS] of them.
+     *
+     * Bounded by count rather than by which windows still exist, because a window that has just been
+     * closed exists nowhere: it is gone from the view model's open list and undocked from the layout
+     * in the same breath. Pruning against "open or docked" therefore deleted the spot of the very
+     * window that had just been closed, on the debounced save a second later - which is every close
+     * a user is likely to undo.
+     */
+    private fun trim() {
+        while (spots.size > MAX_SPOTS) {
+            val oldest = spots.keys.firstOrNull() ?: break
+            spots.remove(oldest)
             dirty = true
         }
     }
@@ -840,6 +861,10 @@ internal class DockSpotMemory {
         // Lenient on the way in: a field added by a later build must cost that one spot at worst,
         // and preferably nothing at all. The library's own persistence reads its layouts the same way.
         val json = Json { ignoreUnknownKeys = true }
+
+        // Far more than the windows a character has, so nothing is dropped in practice; this only
+        // stops a client that runs for years growing the saved blob without limit.
+        const val MAX_SPOTS = 128
     }
 }
 

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameDocking.kt
@@ -24,6 +24,7 @@ import com.seanproctor.docking.model.DockableId
 import com.seanproctor.docking.model.DockableOptions
 import com.seanproctor.docking.model.SplitOrientation
 import com.seanproctor.docking.model.TabPreference
+import com.seanproctor.docking.model.WindowBounds
 import com.seanproctor.docking.model.WindowId
 import com.seanproctor.docking.persistence.DockingPersistence
 import com.seanproctor.docking.persistence.captureLayout
@@ -209,6 +210,10 @@ fun rememberGameDockState(
     // Snapshot-state mirror read by the dockable specs' lambdas (title, actions, content), so a
     // registered dockable keeps rendering the live ui state without re-registration.
     val windowsByName = remember { mutableStateMapOf<String, OpenGameWindow>() }
+
+    // Where windows were when they were closed, so reopening puts them back. Held here rather than
+    // inside reconcile so it outlives the pass that filled it.
+    val spots = remember { DockSpotMemory() }
     SideEffect {
         windowsByName.keys.retainAll(openWindows.keys)
         openWindows.forEach { (name, window) ->
@@ -345,7 +350,7 @@ fun rememberGameDockState(
                     Logger.w { "Window restore still running after $CHARACTER_WAIT; docking against it" }
                 }
                 val saved = runCatching { viewModel.loadDockLayout() }.getOrNull()
-                applyRestoredLayout(state, saved, liveOpenWindows(), ::registerWindow)
+                applyRestoredLayout(state, saved, liveOpenWindows(), ::registerWindow, spots)
                 restoreFinished.complete(Unit)
                 snapshotFlow { state.layout }
                     .drop(1)
@@ -360,7 +365,7 @@ fun rememberGameDockState(
             // after the timeout reconciles again above.
             launch {
                 withTimeoutOrNull(CHARACTER_WAIT) { restoreFinished.await() }
-                reconcile(state, liveOpenWindows(), ::registerWindow)
+                reconcile(state, liveOpenWindows(), ::registerWindow, spots)
                 merge(
                     snapshotFlow { currentOpenWindows.value }.map { },
                     // A drop can re-dock a window the game closed mid-drag; a Docked event is the
@@ -370,7 +375,7 @@ fun rememberGameDockState(
                         .filter { !it.isTemporary }
                         .map { },
                 ).collect {
-                    reconcile(state, liveOpenWindows(), ::registerWindow)
+                    reconcile(state, liveOpenWindows(), ::registerWindow, spots)
                 }
             }
             // A detached window's own close button is the OS one, which drops the window's contents
@@ -422,6 +427,7 @@ internal fun applyRestoredLayout(
     saved: String?,
     openWindows: Map<String, OpenGameWindow>,
     registerWindow: (String, AnchorId?) -> Unit,
+    spots: DockSpotMemory = DockSpotMemory(),
 ) {
     if (saved != null) {
         runCatching { DockingPersistence.decode(saved) }
@@ -447,7 +453,7 @@ internal fun applyRestoredLayout(
     // closed right now; reconcile immediately so they never render as placeholders. This also
     // re-docks anything a late restore displaced, when the bounded wait in the bridge gave up and
     // laid windows out first.
-    reconcile(state, openWindows, registerWindow)
+    reconcile(state, openWindows, registerWindow, spots)
 }
 
 /**
@@ -465,10 +471,16 @@ internal fun reconcile(
     state: DockState,
     openWindows: Map<String, OpenGameWindow>,
     registerWindow: (String, AnchorId?) -> Unit,
+    spots: DockSpotMemory = DockSpotMemory(),
 ) {
     dockedIds(state.layout)
         .filter { it.value != MAIN_WINDOW_NAME && it.value !in openWindows }
-        .forEach { state.undock(it) }
+        .forEach { id ->
+            // Note where it was before it goes, so reopening can put it back between the same
+            // windows rather than at the bottom of its column.
+            spots.remember(id.value, rememberedSpotOf(state, id.value))
+            state.undock(id)
+        }
     val mainWindow = state.layout.mainWindow
     val tree = mainWindow.maximized?.savedRoot ?: mainWindow.root
     openWindows.forEach { (name, window) ->
@@ -488,17 +500,32 @@ internal fun reconcile(
         registerWindow(name, anchor)
         val id = DockableId(name)
         if (!state.isOpen(id)) {
-            if (opensDetached(window)) {
-                detachWindow(state, name)
-            } else {
-                val placement =
-                    defaultPlacement(
-                        name = name,
-                        location = window.location,
-                        layout = state.layout,
-                        openWindows = openWindows,
-                    )
-                state.dock(id, placement.target, placement.region, placement.proportion)
+            val remembered = spots.take(name)
+            val rememberedPlacement = remembered?.let { placementFromMemory(it, state.layout) }
+            when {
+                // Closed while detached, so it reopens detached, at the size and place it had.
+                remembered?.detached == true && platformDockCapabilities.floatingWindows -> {
+                    detachWindow(state, name, remembered.bounds)
+                }
+
+                rememberedPlacement != null -> {
+                    state.dock(id, rememberedPlacement.target, rememberedPlacement.region, rememberedPlacement.proportion)
+                }
+
+                opensDetached(window) -> {
+                    detachWindow(state, name)
+                }
+
+                else -> {
+                    val placement =
+                        defaultPlacement(
+                            name = name,
+                            location = window.location,
+                            layout = state.layout,
+                            openWindows = openWindows,
+                        )
+                    state.dock(id, placement.target, placement.region, placement.proportion)
+                }
             }
         }
     }
@@ -597,8 +624,9 @@ private fun DockNode.tabsContaining(id: DockableId): DockNode.Tabs? =
 internal fun detachWindow(
     state: DockState,
     name: String,
+    bounds: WindowBounds? = null,
 ) {
-    state.moveToNewWindow(DockableId(name))
+    state.moveToNewWindow(DockableId(name), bounds)
 }
 
 /**
@@ -655,6 +683,125 @@ internal fun opensDetached(window: OpenGameWindow): Boolean =
     window.location == WindowLocation.DETACHED &&
         !window.isMain &&
         platformDockCapabilities.floatingWindows
+
+/**
+ * Where a window sat when it was closed, so that reopening can put it back there.
+ *
+ * The spot is described by its *neighbours* rather than by coordinates, because coordinates do not
+ * survive the rest of the layout moving underneath them. What is remembered is which windows it was
+ * split away from (or tabbed with), which side of them it was on, and how much of them it had. Reopen
+ * it while any of those neighbours are still docked and it goes back between the same windows, at the
+ * same size, wherever they have since been dragged to.
+ *
+ * [siblings] empty with [detached] set is the other case: it was in a window of its own, and reopens
+ * in one, at [bounds].
+ */
+internal data class RememberedSpot(
+    val siblings: List<String>,
+    val region: DockRegion,
+    val proportion: Float,
+    val detached: Boolean = false,
+    val bounds: WindowBounds? = null,
+)
+
+/**
+ * Where closed windows were, for the length of the session.
+ *
+ * Deliberately not persisted: the saved arrangement records where the *open* windows are, and a
+ * window that is closed when the client quits comes back in its announced spot, as it always has.
+ * This is for the close-and-reopen cycle within a session, which is the one that happens constantly
+ * - toggling a panel from the Windows menu and finding it back where you left it.
+ */
+internal class DockSpotMemory {
+    private val spots = mutableMapOf<String, RememberedSpot>()
+
+    fun remember(
+        name: String,
+        spot: RememberedSpot?,
+    ) {
+        if (spot == null) spots.remove(name) else spots[name] = spot
+    }
+
+    /** Reads and clears: a spot is good for the reopen that follows the close it came from. */
+    fun take(name: String): RememberedSpot? = spots.remove(name)
+}
+
+/**
+ * Where [name] is sitting right now, in the terms [RememberedSpot] keeps, or null when there is
+ * nothing worth remembering - it is alone in the layout, or not docked at all.
+ */
+internal fun rememberedSpotOf(
+    state: DockState,
+    name: String,
+): RememberedSpot? {
+    val id = DockableId(name)
+    if (isDetached(state, name)) {
+        val window = state.layout.floatingWindows.firstOrNull { it.containsDockable(id) } ?: return null
+        return RememberedSpot(emptyList(), DockRegion.Center, 0.5f, detached = true, bounds = window.bounds)
+    }
+    val mainWindow = state.layout.mainWindow
+    val tree = mainWindow.maximized?.savedRoot ?: mainWindow.root ?: return null
+    // Tabbed with others: going back into the same tab strip beats any split it happens to sit in.
+    tree.tabsContaining(id)?.let { tabs ->
+        val others = tabs.tabs.map { it.dockableId.value }.filter { it != name }
+        if (others.isNotEmpty()) return RememberedSpot(others, DockRegion.Center, 0.5f)
+    }
+    return tree.splitSpotOf(id)
+}
+
+/** The split this leaf is a direct child of, described from the leaf's side of it. */
+private fun DockNode.splitSpotOf(id: DockableId): RememberedSpot? {
+    if (this !is DockNode.Split) return null
+    val firstIsIt = first.let { it is DockNode.Leaf && it.dockableId == id }
+    val secondIsIt = second.let { it is DockNode.Leaf && it.dockableId == id }
+    return when {
+        firstIsIt -> {
+            RememberedSpot(
+                siblings = second.dockableIds().map { it.value },
+                region = if (orientation == SplitOrientation.Horizontal) DockRegion.West else DockRegion.North,
+                proportion = proportion,
+            )
+        }
+
+        secondIsIt -> {
+            RememberedSpot(
+                siblings = first.dockableIds().map { it.value },
+                region = if (orientation == SplitOrientation.Horizontal) DockRegion.East else DockRegion.South,
+                proportion = 1f - proportion,
+            )
+        }
+
+        else -> {
+            first.splitSpotOf(id) ?: second.splitSpotOf(id)
+        }
+    }
+}
+
+/**
+ * Turns a remembered spot back into a placement, or null when too much of it has gone - every
+ * neighbour it was next to has since been closed, so there is nothing left to sit beside and the
+ * announced spot is the better answer.
+ */
+internal fun placementFromMemory(
+    spot: RememberedSpot,
+    layout: DockLayout,
+): DockPlacement? {
+    if (spot.detached) return null
+    val mainWindow = layout.mainWindow
+    val tree = mainWindow.maximized?.savedRoot ?: mainWindow.root ?: return null
+    val surviving = spot.siblings.map { DockableId(it) }.filter { tree.containsDockable(it) }
+    if (surviving.isEmpty()) return null
+    // Back into the tab strip: docking Center onto a member is what appends a tab.
+    if (spot.region == DockRegion.Center) {
+        return DockPlacement(DockTarget.OnDockable(surviving.first()), DockRegion.Center, spot.proportion)
+    }
+    val node = tree.smallestNodeHolding(surviving.toSet()) ?: return null
+    return DockPlacement(DockTarget.OnNode(mainWindow.id, node.id), spot.region, spot.proportion)
+}
+
+/** Whether this window's tree holds [id], maximized or not. */
+private fun com.seanproctor.docking.model.DockWindow.containsDockable(id: DockableId): Boolean =
+    listOfNotNull(root, maximized?.savedRoot).any { it.containsDockable(id) }
 
 /** Where [reconcile] puts a window with no saved dock spot. */
 internal data class DockPlacement(

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -129,6 +129,10 @@ const val TABLET_WINDOW_LOCATION_KEY = "tabletWindowLocation"
 // every layout change; a window it does not know yet docks at its game-announced location.
 const val DOCK_LAYOUT_KEY = "dockLayout"
 
+// Where windows were when they were closed. Separate from the arrangement rather than folded
+// into it, so an unreadable one costs only the memory and every layout already saved still reads.
+const val DOCK_SPOTS_KEY = "dockSpots"
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class GameViewModel(
     private val windowSettingsRepository: WindowSettingsRepository,
@@ -1489,6 +1493,12 @@ class GameViewModel(
             characterSettingsRepository.get(characterId, DOCK_LAYOUT_KEY)
         }
 
+    /** The character's saved closed-window spots, or null when none have been saved yet. */
+    suspend fun loadDockSpots(): String? =
+        client.characterId.value?.let { characterId ->
+            characterSettingsRepository.get(characterId, DOCK_SPOTS_KEY)
+        }
+
     // The dock layout is auto-saved, so two writes that finished out of order would leave the older
     // arrangement stored with nothing to correct it. Both writers - the bridge's debounced save and
     // the flush in [close] - go through one [LatestValueWriter], which keeps the newest layout the
@@ -1503,12 +1513,27 @@ class GameViewModel(
         }
     }
 
+    // Saved on the same beat as the arrangement, and for the same reason: out-of-order writes would
+    // leave the older set stored with nothing to correct it.
+    private val dockSpotsWriter = LatestValueWriter(::writeDockSpots)
+
+    private suspend fun writeDockSpots(spots: String) {
+        client.characterId.value?.let { characterId ->
+            characterSettingsRepository.save(characterId, DOCK_SPOTS_KEY, spots)
+        }
+    }
+
     /**
      * Persists the docking-layout JSON. Layout churn is debounced by the caller, which collects
      * sequentially and awaits this, so saves never pile up behind one another.
      */
     suspend fun saveDockLayout(layout: String) {
         dockLayoutWriter.write(layout)
+    }
+
+    /** Persists where closed windows were, so reopening puts them back in a later session too. */
+    suspend fun saveDockSpots(spots: String) {
+        dockSpotsWriter.write(spots)
     }
 
     /** Shared handling for a clickable game-text action (command link or menu). */
@@ -1650,6 +1675,7 @@ class GameViewModel(
         // from the composition because callers await close() before tearing the window down (and,
         // on the last window, before exiting the process), so the write is ordered ahead of both.
         dockLayoutWriter.flush()
+        dockSpotsWriter.flush()
         // If a reconnect is still in flight (e.g. the user returned to the dashboard while it was
         // running), cancel it first so the in-progress attempt is unwound: cancellation runs the
         // connect use case's finally blocks, which close any half-opened client/socket so nothing leaks.

--- a/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
+++ b/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
@@ -978,18 +978,49 @@ class GameDockingTest {
         assertEquals(RememberedSpot(listOf("logons"), DockRegion.South, 0.5f), spots.spend("thoughts"))
     }
 
-    // Windows the game has stopped sending would otherwise accumulate a spot each, forever, and be
-    // re-serialized into the character's settings on every save.
+    // The debounced save runs a second after a close, when the window it was for is neither open
+    // (the view model dropped it) nor docked (reconcile undocked it). Bounding the map by liveness
+    // therefore deleted the spot of the very window just closed - every close a user might undo.
     @Test
-    fun pruningDropsSpotsForWindowsThatAreGone() {
+    fun aJustClosedWindowKeepsItsSpotThroughASave() {
+        val state = newState()
+        val registerWindow = register(state)
         val spots = DockSpotMemory()
-        spots.remember("thoughts", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
-        spots.remember("ancient", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
+        reconcile(state, column(), registerWindow, spots)
 
-        spots.prune(setOf("thoughts", "logons"))
+        reconcile(state, column().filterKeys { it != "logons" }, registerWindow, spots)
+        // The debounced collector's own save step, on a layout that no longer mentions the window.
+        val encoded = dockSpotsToSave(spots)
+        assertFalse(state.isOpen(DockableId("logons")), "the window under test has to actually be gone")
 
-        assertNotNull(spots.spend("thoughts"))
-        assertNull(spots.spend("ancient"))
+        assertNotNull(spots.peek("logons"), "the spot was dropped before it could be used")
+        assertTrue(encoded?.contains("logons") == true, "the spot was not saved")
+    }
+
+    // The whole cycle a user actually performs: close, let the save run, then reopen.
+    @Test
+    fun aWindowReopenedAfterASaveStillGoesBackWhereItWas() {
+        val state = newState()
+        val registerWindow = register(state)
+        val spots = DockSpotMemory()
+        reconcile(state, column(), registerWindow, spots)
+        val orderBefore = order(state)
+
+        reconcile(state, column().filterKeys { it != "logons" }, registerWindow, spots)
+        dockSpotsToSave(spots)
+        reconcile(state, column(), registerWindow, spots)
+
+        assertEquals(orderBefore, order(state))
+    }
+
+    // Bounded by count, so a client running for years cannot grow the blob forever.
+    @Test
+    fun theOldestSpotsAreForgottenOnceThereAreTooMany() {
+        val spots = DockSpotMemory()
+        repeat(200) { spots.remember("window$it", RememberedSpot(listOf("other"), DockRegion.South, 0.5f)) }
+
+        assertNull(spots.peek("window0"), "the oldest should have been dropped")
+        assertNotNull(spots.peek("window199"), "the newest must survive")
     }
 
     // Only a real change is worth a database write; drags and resizes move the layout but no spot.
@@ -1131,5 +1162,14 @@ class GameDockingTest {
         val restored = DockSpotMemory().apply { restore(spots.encode()) }
 
         assertEquals(spot, restored.spend("thoughts"))
+    }
+
+    @Test
+    fun anUnchangedSetOfSpotsIsNotWorthASave() {
+        val spots = DockSpotMemory()
+        spots.remember("thoughts", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
+
+        assertNotNull(dockSpotsToSave(spots))
+        assertNull(dockSpotsToSave(spots), "nothing moved, so there is nothing to write")
     }
 }

--- a/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
+++ b/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
@@ -21,6 +21,9 @@ import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class GameDockingTest {
@@ -757,5 +760,100 @@ class GameDockingTest {
                 .containsDockable(DockableId("room")),
             "room should be folded back into the main window rather than lost",
         )
+    }
+
+    // --- Remembering where a closed window was ---
+
+    // Top to bottom down the column, which is what "where it was" means for a stacked area.
+    private fun orderedDockables(node: DockNode): List<String> =
+        when (node) {
+            is DockNode.Leaf -> listOf(node.dockableId.value)
+            is DockNode.Tabs -> node.tabs.map { it.dockableId.value }
+            is DockNode.Anchor -> emptyList()
+            is DockNode.Split -> orderedDockables(node.first) + orderedDockables(node.second)
+        }
+
+    private fun order(state: DockState): List<String> = orderedDockables(state.layout.mainWindow.root!!)
+
+    private fun column() =
+        openWindows(
+            MAIN_WINDOW_NAME to WindowLocation.CENTER,
+            "thoughts" to WindowLocation.LEFT,
+            "logons" to WindowLocation.LEFT,
+            "deaths" to WindowLocation.LEFT,
+        )
+
+    // The point of the whole thing: close a window out of the middle of an arranged column, reopen
+    // it, and it is back between the same two windows at the same size.
+    @Test
+    fun aReopenedWindowGoesBackWhereItWas() {
+        val state = newState()
+        val registerWindow = register(state)
+        val spots = DockSpotMemory()
+        reconcile(state, column(), registerWindow, spots)
+        val orderBefore = order(state)
+        val sizesBefore = shares(state.layout.mainWindow.root!!)
+
+        reconcile(state, column().filterKeys { it != "logons" }, registerWindow, spots)
+        reconcile(state, column(), registerWindow, spots)
+
+        assertEquals(orderBefore, order(state))
+        val after = shares(state.layout.mainWindow.root!!)
+        listOf("thoughts", "logons", "deaths").forEach { name ->
+            val id = DockableId(name)
+            assertEquals(sizesBefore[id]!!, after[id]!!, absoluteTolerance = 0.02f, message = "$name resized")
+        }
+    }
+
+    // Pins that the test above is testing something: with no memory carried across the calls, the
+    // reopened window is placed by its announced area and comes back at the end of the column.
+    @Test
+    fun withoutTheMemoryAReopenedWindowIsPlacedByItsAnnouncedArea() {
+        val state = newState()
+        val registerWindow = register(state)
+        reconcile(state, column(), registerWindow)
+        val orderBefore = order(state)
+
+        reconcile(state, column().filterKeys { it != "thoughts" }, registerWindow)
+        reconcile(state, column(), registerWindow)
+
+        assertNotEquals(orderBefore, order(state))
+    }
+
+    // Everything it sat beside has closed too, so there is nothing left to be next to. It should
+    // fall back to its announced area rather than throwing or landing somewhere arbitrary.
+    @Test
+    fun aWindowWhoseNeighboursAllClosedFallsBackToItsAnnouncedArea() {
+        val state = newState()
+        val registerWindow = register(state)
+        val spots = DockSpotMemory()
+        val announced =
+            openWindows(
+                MAIN_WINDOW_NAME to WindowLocation.CENTER,
+                "thoughts" to WindowLocation.LEFT,
+                "logons" to WindowLocation.LEFT,
+            )
+        reconcile(state, announced, registerWindow, spots)
+
+        reconcile(state, openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER), registerWindow, spots)
+        reconcile(state, announced, registerWindow, spots)
+
+        assertEquals(setOf(MAIN_WINDOW_NAME, "thoughts", "logons"), order(state).toSet())
+    }
+
+    // A spot is spent by the reopen that uses it, so a window moved afterwards is not yanked back to
+    // a stale one the next time it is closed and opened.
+    @Test
+    fun aSpotIsNotReusedAfterItHasBeenSpent() {
+        val spots = DockSpotMemory()
+        spots.remember("thoughts", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
+
+        assertNotNull(spots.take("thoughts"))
+        assertNull(spots.take("thoughts"))
+    }
+
+    @Test
+    fun aWindowThatIsNotDockedHasNoSpotToRemember() {
+        assertNull(rememberedSpotOf(newState(), "never-docked"))
     }
 }

--- a/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
+++ b/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
@@ -95,7 +95,7 @@ class GameDockingTest {
                 "logons" to WindowLocation.LEFT,
                 "room" to WindowLocation.CENTER,
             )
-        reconcile(state, windows, register(state))
+        reconcile(state, windows, register(state), DockSpotMemory())
         windows.keys.forEach { name ->
             assertTrue(state.isOpen(DockableId(name)), "$name should be docked")
         }
@@ -109,9 +109,9 @@ class GameDockingTest {
                 MAIN_WINDOW_NAME to WindowLocation.CENTER,
                 "thoughts" to WindowLocation.LEFT,
             )
-        reconcile(state, before, register(state))
+        reconcile(state, before, register(state), DockSpotMemory())
         val after = openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER)
-        reconcile(state, after, register(state))
+        reconcile(state, after, register(state), DockSpotMemory())
         assertFalse(state.isOpen(DockableId("thoughts")))
         assertTrue(state.isOpen(DockableId(MAIN_WINDOW_NAME)))
     }
@@ -124,9 +124,9 @@ class GameDockingTest {
                 MAIN_WINDOW_NAME to WindowLocation.CENTER,
                 "thoughts" to WindowLocation.LEFT,
             )
-        reconcile(state, windows, register(state))
+        reconcile(state, windows, register(state), DockSpotMemory())
         val arranged = state.layout
-        reconcile(state, windows, register(state))
+        reconcile(state, windows, register(state), DockSpotMemory())
         assertEquals(arranged, state.layout)
     }
 
@@ -204,7 +204,7 @@ class GameDockingTest {
         val opened = mutableListOf(MAIN_WINDOW_NAME to WindowLocation.CENTER)
         column.forEach { name ->
             opened += name to WindowLocation.LEFT
-            reconcile(state, openWindows(*opened.toTypedArray()), registerWindow)
+            reconcile(state, openWindows(*opened.toTypedArray()), registerWindow, DockSpotMemory())
         }
 
         val shares = shares(state.layout.mainWindow.root!!)
@@ -238,7 +238,7 @@ class GameDockingTest {
                 assertEquals(1f / (index + 1), placement.proportion, "window ${index + 1} of the column")
             }
             opened += name to WindowLocation.LEFT
-            reconcile(state, openWindows(*opened.toTypedArray()), registerWindow)
+            reconcile(state, openWindows(*opened.toTypedArray()), registerWindow, DockSpotMemory())
         }
     }
 
@@ -248,12 +248,17 @@ class GameDockingTest {
         val registerWindow = register(state)
         val mainId = DockableId(MAIN_WINDOW_NAME)
         val left = WindowLocation.LEFT.anchor
-        reconcile(state, openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER, "thoughts" to WindowLocation.LEFT), registerWindow)
+        reconcile(
+            state,
+            openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER, "thoughts" to WindowLocation.LEFT),
+            registerWindow,
+            DockSpotMemory(),
+        )
         assertEquals(DockRegion.West, relativeRegion(state.layout.mainWindow.root!!, DockableId("thoughts"), mainId))
 
         // The user closes the only window in the left column. The column is what the anchor buys us:
         // without it the split would collapse and the area would be gone.
-        reconcile(state, openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER), registerWindow)
+        reconcile(state, openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER), registerWindow, DockSpotMemory())
         assertTrue(
             state.layout.mainWindow.root!!
                 .holdsAnchor(left),
@@ -261,7 +266,12 @@ class GameDockingTest {
         )
 
         // The next left window drops into that slot rather than opening a second column.
-        reconcile(state, openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER, "logons" to WindowLocation.LEFT), registerWindow)
+        reconcile(
+            state,
+            openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER, "logons" to WindowLocation.LEFT),
+            registerWindow,
+            DockSpotMemory(),
+        )
         assertEquals(DockRegion.West, relativeRegion(state.layout.mainWindow.root!!, DockableId("logons"), mainId))
         assertFalse(
             state.layout.mainWindow.root!!
@@ -277,12 +287,12 @@ class GameDockingTest {
         val thoughtsId = DockableId("thoughts")
         // The announcement says left, and stays saying left for the whole test.
         val announced = openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER, "thoughts" to WindowLocation.LEFT)
-        reconcile(state, announced, registerWindow)
+        reconcile(state, announced, registerWindow, DockSpotMemory())
         assertEquals(WindowLocation.LEFT.anchor, state.registry[thoughtsId]?.options?.anchor)
 
         // The user drags it into the right column; the drop, not the announcement, decides the area.
         state.dock(thoughtsId, DockTarget.Root(), DockRegion.East)
-        reconcile(state, announced, registerWindow)
+        reconcile(state, announced, registerWindow, DockSpotMemory())
         assertEquals(WindowLocation.RIGHT.anchor, state.registry[thoughtsId]?.options?.anchor)
 
         // The left column it came from stays open. A move undocks before it re-docks, so vacating
@@ -303,6 +313,7 @@ class GameDockingTest {
                 "logons" to WindowLocation.LEFT,
             ),
             registerWindow,
+            DockSpotMemory(),
         )
         val root = state.layout.mainWindow.root!!
         assertFalse(root.holdsAnchor(WindowLocation.LEFT.anchor), "the placeholder should have been replaced")
@@ -345,7 +356,7 @@ class GameDockingTest {
             )
         assertEquals(DockTarget.Anchor(WindowLocation.CENTER.anchor), placement.target)
         // Which is where the band was declared: above the main text window.
-        reconcile(state, windows, register(state))
+        reconcile(state, windows, register(state), DockSpotMemory())
         assertEquals(
             DockRegion.North,
             relativeRegion(state.layout.mainWindow.root!!, DockableId("room"), DockableId(MAIN_WINDOW_NAME)),
@@ -364,6 +375,7 @@ class GameDockingTest {
                 "room" to WindowLocation.CENTER,
             ),
             registerWindow,
+            DockSpotMemory(),
         )
         val roomId = DockableId("room")
         assertEquals(DockRegion.North, relativeRegion(state.layout.mainWindow.root!!, roomId, mainId))
@@ -382,6 +394,7 @@ class GameDockingTest {
                 "atmospherics" to WindowLocation.CENTER,
             ),
             registerWindow,
+            DockSpotMemory(),
         )
         assertEquals(
             DockRegion.North,
@@ -403,6 +416,7 @@ class GameDockingTest {
                 "room" to WindowLocation.CENTER,
             ),
             registerWindow,
+            DockSpotMemory(),
         )
         val windows =
             openWindows(
@@ -418,7 +432,7 @@ class GameDockingTest {
                 openWindows = windows,
             )
         assertEquals(DockTarget.Anchor(WindowLocation.RIGHT.anchor), placement.target)
-        reconcile(state, windows, registerWindow)
+        reconcile(state, windows, registerWindow, DockSpotMemory())
         val tree = state.layout.mainWindow.root!!
         // Right of the main window and of the center band alike.
         assertEquals(DockRegion.East, relativeRegion(tree, DockableId("inv"), mainId))
@@ -459,6 +473,7 @@ class GameDockingTest {
                 "inv" to WindowLocation.RIGHT,
             ),
             registerWindow,
+            DockSpotMemory(),
         )
         // The user drags the right-seeded window above main. The centre area is declared and
         // still empty, so the next centre window fills it rather than joining the dragged-in
@@ -482,7 +497,7 @@ class GameDockingTest {
 
         // Once the area has something in it, the next one stacks onto that, wherever the user
         // has since moved it.
-        reconcile(state, windows, registerWindow)
+        reconcile(state, windows, registerWindow, DockSpotMemory())
         val next =
             defaultPlacement(
                 name = "atmospherics",
@@ -504,9 +519,9 @@ class GameDockingTest {
     private fun savedArrangement(announced: Map<String, OpenGameWindow>): String {
         val state = newState()
         val registerWindow = register(state)
-        reconcile(state, announced, registerWindow)
+        reconcile(state, announced, registerWindow, DockSpotMemory())
         state.dock(DockableId("room"), DockTarget.OnDockable(DockableId("thoughts")), DockRegion.South)
-        reconcile(state, announced, registerWindow)
+        reconcile(state, announced, registerWindow, DockSpotMemory())
         assertEquals(
             WindowLocation.LEFT.anchor,
             currentAnchorOf(state.layout.mainWindow.root!!, "room"),
@@ -527,7 +542,7 @@ class GameDockingTest {
     @Test
     fun aRestoreAppliedAgainstTheRestoredWindowsKeepsTheArrangement() {
         val state = newState()
-        applyRestoredLayout(state, savedArrangement(announced), announced, register(state))
+        applyRestoredLayout(state, savedArrangement(announced), announced, register(state), DockSpotMemory())
         assertEquals(
             WindowLocation.LEFT.anchor,
             anchorOfRoom(state),
@@ -544,9 +559,9 @@ class GameDockingTest {
     fun aRestoreAppliedBeforeTheWindowsAreRestoredLosesTheArrangement() {
         val state = newState()
         val onlyMain = openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER)
-        applyRestoredLayout(state, savedArrangement(announced), onlyMain, register(state))
+        applyRestoredLayout(state, savedArrangement(announced), onlyMain, register(state), DockSpotMemory())
         // The windows arrive a moment later and fall back to their game-announced spots.
-        reconcile(state, announced, register(state))
+        reconcile(state, announced, register(state), DockSpotMemory())
         assertEquals(
             WindowLocation.CENTER.anchor,
             anchorOfRoom(state),
@@ -557,7 +572,7 @@ class GameDockingTest {
     @Test
     fun anUnreadableSavedLayoutFallsBackToTheDefaults() {
         val state = newState()
-        applyRestoredLayout(state, "{not json", announced, register(state))
+        applyRestoredLayout(state, "{not json", announced, register(state), DockSpotMemory())
         // The areas are still there and every window is docked, rather than the connect failing.
         announced.keys.forEach { name ->
             assertTrue(state.isOpen(DockableId(name)), "$name should be docked")
@@ -568,7 +583,7 @@ class GameDockingTest {
     @Test
     fun aCharacterWithNoSavedLayoutGetsTheAnnouncedSpots() {
         val state = newState()
-        applyRestoredLayout(state, null, announced, register(state))
+        applyRestoredLayout(state, null, announced, register(state), DockSpotMemory())
         assertEquals(WindowLocation.LEFT.anchor, currentAnchorOf(state.layout.mainWindow.root!!, "thoughts"))
         assertEquals(WindowLocation.CENTER.anchor, anchorOfRoom(state))
     }
@@ -595,6 +610,7 @@ class GameDockingTest {
                 "charsheet" to WindowLocation.DETACHED,
             ),
             register(state),
+            DockSpotMemory(),
         )
 
         assertTrue(isDetached(state, "charsheet"), "a detached announcement should open detached")
@@ -618,13 +634,13 @@ class GameDockingTest {
                 MAIN_WINDOW_NAME to WindowLocation.CENTER,
                 "charsheet" to WindowLocation.DETACHED,
             )
-        reconcile(state, windows, registerWindow)
+        reconcile(state, windows, registerWindow, DockSpotMemory())
         // The user reattaches it, then the layout is saved and restored on the next connect.
         redockIntoMainWindow(state, windows.getValue("charsheet"), windows)
         val saved = DockingPersistence.encode(state.captureLayout())
 
         val next = newState()
-        applyRestoredLayout(next, saved, windows, register(next))
+        applyRestoredLayout(next, saved, windows, register(next), DockSpotMemory())
         assertFalse(isDetached(next, "charsheet"), "the arrangement wins over the announcement")
         assertTrue(next.isOpen(DockableId("charsheet")))
     }
@@ -632,7 +648,7 @@ class GameDockingTest {
     @Test
     fun theMainWindowCannotBeDetached() {
         val state = newState()
-        reconcile(state, announced, register(state))
+        reconcile(state, announced, register(state), DockSpotMemory())
         assertFalse(
             state.canFloat(DockableId(MAIN_WINDOW_NAME)),
             "main is the fixed point the areas are measured against, so it must stay put",
@@ -643,7 +659,7 @@ class GameDockingTest {
     fun detachingMovesAWindowOutOfTheMainWindow() {
         if (!assumeFloatingWindows()) return
         val state = newState()
-        reconcile(state, announced, register(state))
+        reconcile(state, announced, register(state), DockSpotMemory())
         detachWindow(state, "room")
 
         assertTrue(isDetached(state, "room"), "room should be in a window of its own")
@@ -664,7 +680,7 @@ class GameDockingTest {
     fun detachingTheLastWindowOfAnAreaLeavesItsSlotOpen() {
         if (!assumeFloatingWindows()) return
         val state = newState()
-        reconcile(state, announced, register(state))
+        reconcile(state, announced, register(state), DockSpotMemory())
         detachWindow(state, "thoughts")
         assertTrue(
             state.layout.mainWindow.root!!
@@ -677,7 +693,7 @@ class GameDockingTest {
     fun reattachingPutsTheWindowBackInItsArea() {
         if (!assumeFloatingWindows()) return
         val state = newState()
-        reconcile(state, announced, register(state))
+        reconcile(state, announced, register(state), DockSpotMemory())
         detachWindow(state, "thoughts")
         redockIntoMainWindow(state, announced.getValue("thoughts"), announced)
 
@@ -698,11 +714,11 @@ class GameDockingTest {
         if (!assumeFloatingWindows()) return
         val state = newState()
         val registerWindow = register(state)
-        reconcile(state, announced, registerWindow)
+        reconcile(state, announced, registerWindow, DockSpotMemory())
         detachWindow(state, "room")
         val detached = state.layout
 
-        reconcile(state, announced, registerWindow)
+        reconcile(state, announced, registerWindow, DockSpotMemory())
         assertEquals(detached, state.layout, "a reconcile pass should not reel a detached window back in")
     }
 
@@ -713,7 +729,7 @@ class GameDockingTest {
         if (!assumeFloatingWindows()) return
         val state = newState()
         val registerWindow = register(state)
-        reconcile(state, announced, registerWindow)
+        reconcile(state, announced, registerWindow, DockSpotMemory())
         detachWindow(state, "room")
 
         reconcile(
@@ -723,6 +739,7 @@ class GameDockingTest {
                 "thoughts" to WindowLocation.LEFT,
             ),
             registerWindow,
+            DockSpotMemory(),
         )
         assertFalse(state.isOpen(DockableId("room")))
         assertTrue(state.layout.floatingWindows.isEmpty())
@@ -732,12 +749,12 @@ class GameDockingTest {
     fun aDetachedArrangementSurvivesASaveAndRestore() {
         if (!assumeFloatingWindows()) return
         val saving = newState()
-        reconcile(saving, announced, register(saving))
+        reconcile(saving, announced, register(saving), DockSpotMemory())
         detachWindow(saving, "room")
         val saved = DockingPersistence.encode(saving.captureLayout())
 
         val state = newState()
-        applyRestoredLayout(state, saved, announced, register(state))
+        applyRestoredLayout(state, saved, announced, register(state), DockSpotMemory())
         assertTrue(isDetached(state, "room"), "room should come back detached")
         assertTrue(state.isOpen(DockableId("thoughts")), "the docked windows come back too")
     }
@@ -749,7 +766,7 @@ class GameDockingTest {
     fun aDetachedArrangementMergesWhereThereAreNoFloatingWindows() {
         if (!assumeFloatingWindows()) return
         val saving = newState()
-        reconcile(saving, announced, register(saving))
+        reconcile(saving, announced, register(saving), DockSpotMemory())
         detachWindow(saving, "room")
         val persisted = DockingPersistence.decode(DockingPersistence.encode(saving.captureLayout()))
 
@@ -812,11 +829,11 @@ class GameDockingTest {
     fun withoutTheMemoryAReopenedWindowIsPlacedByItsAnnouncedArea() {
         val state = newState()
         val registerWindow = register(state)
-        reconcile(state, column(), registerWindow)
+        reconcile(state, column(), registerWindow, DockSpotMemory())
         val orderBefore = order(state)
 
-        reconcile(state, column().filterKeys { it != "thoughts" }, registerWindow)
-        reconcile(state, column(), registerWindow)
+        reconcile(state, column().filterKeys { it != "thoughts" }, registerWindow, DockSpotMemory())
+        reconcile(state, column(), registerWindow, DockSpotMemory())
 
         assertNotEquals(orderBefore, order(state))
     }
@@ -839,7 +856,10 @@ class GameDockingTest {
         reconcile(state, openWindows(MAIN_WINDOW_NAME to WindowLocation.CENTER), registerWindow, spots)
         reconcile(state, announced, registerWindow, spots)
 
-        assertEquals(setOf(MAIN_WINDOW_NAME, "thoughts", "logons"), order(state).toSet())
+        // The announced-area arrangement, not merely the same three names in some order.
+        val fresh = newState()
+        reconcile(fresh, announced, register(fresh), DockSpotMemory())
+        assertEquals(order(fresh), order(state))
     }
 
     // A spot is spent by the reopen that uses it, so a window moved afterwards is not yanked back to
@@ -849,8 +869,8 @@ class GameDockingTest {
         val spots = DockSpotMemory()
         spots.remember("thoughts", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
 
-        assertNotNull(spots.take("thoughts"))
-        assertNull(spots.take("thoughts"))
+        assertNotNull(spots.spend("thoughts"))
+        assertNull(spots.spend("thoughts"))
     }
 
     @Test
@@ -892,23 +912,98 @@ class GameDockingTest {
 
         val restored = DockSpotMemory().apply { restore(spots.encode()) }
 
-        assertEquals(RememberedSpot(listOf("logons", "deaths"), DockRegion.South, 0.25f), restored.take("thoughts"))
+        assertEquals(RememberedSpot(listOf("logons", "deaths"), DockRegion.South, 0.25f), restored.spend("thoughts"))
         assertEquals(
             RememberedSpot(emptyList(), DockRegion.Center, 0.5f, detached = true, bounds = WindowBounds(1f, 2f, 3f, 4f)),
-            restored.take("room"),
+            restored.spend("room"),
         )
     }
 
-    // A character whose saved spots are unreadable loses only the spots - they still get their
-    // arrangement, and windows open where they always did.
+    // A character whose saved spots are unreadable loses the saved ones, and nothing else: whatever
+    // this session has already recorded stays.
     @Test
-    fun unreadableSpotsAreDiscardedRatherThanThrown() {
+    fun unreadableSpotsAreDiscardedWithoutDisturbingThisSession() {
         val spots = DockSpotMemory()
         spots.remember("thoughts", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
 
         spots.restore("{not json")
 
-        assertNull(spots.take("thoughts"))
+        assertEquals(RememberedSpot(listOf("logons"), DockRegion.South, 0.5f), spots.spend("thoughts"))
+    }
+
+    // A window closed while the character was still being identified: the restore that follows must
+    // not wipe the spot just recorded for it.
+    @Test
+    fun aSpotRecordedBeforeTheRestoreSurvivesIt() {
+        val spots = DockSpotMemory()
+        spots.remember("thoughts", RememberedSpot(listOf("deaths"), DockRegion.North, 0.4f))
+
+        spots.restore("""{"thoughts":{"siblings":["logons"],"region":"South","proportion":0.9}}""")
+
+        assertEquals(RememberedSpot(listOf("deaths"), DockRegion.North, 0.4f), spots.spend("thoughts"))
+    }
+
+    // A field written by a later build must cost at most its own spot, and preferably nothing.
+    @Test
+    fun anUnknownFieldDoesNotDiscardTheSpot() {
+        val spots = DockSpotMemory()
+
+        spots.restore("""{"logons":{"siblings":["deaths"],"region":"South","proportion":0.25,"futureField":7}}""")
+
+        assertEquals(RememberedSpot(listOf("deaths"), DockRegion.South, 0.25f), spots.spend("logons"))
+    }
+
+    // One unreadable entry must not take the readable ones with it.
+    @Test
+    fun oneUnreadableEntryDoesNotTakeTheOthers() {
+        val spots = DockSpotMemory()
+
+        spots.restore(
+            """{"thoughts":{"region":12345,"proportion":"nonsense"},""" +
+                """"logons":{"siblings":["deaths"],"region":"South","proportion":0.25}}""",
+        )
+
+        assertNull(spots.spend("thoughts"))
+        assertEquals(RememberedSpot(listOf("deaths"), DockRegion.South, 0.25f), spots.spend("logons"))
+    }
+
+    // "Nothing worth recording now" is not "forget what we knew".
+    @Test
+    fun rememberingNothingKeepsWhatWasAlreadyKnown() {
+        val spots = DockSpotMemory()
+        spots.remember("thoughts", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
+
+        spots.remember("thoughts", null)
+
+        assertEquals(RememberedSpot(listOf("logons"), DockRegion.South, 0.5f), spots.spend("thoughts"))
+    }
+
+    // Windows the game has stopped sending would otherwise accumulate a spot each, forever, and be
+    // re-serialized into the character's settings on every save.
+    @Test
+    fun pruningDropsSpotsForWindowsThatAreGone() {
+        val spots = DockSpotMemory()
+        spots.remember("thoughts", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
+        spots.remember("ancient", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
+
+        spots.prune(setOf("thoughts", "logons"))
+
+        assertNotNull(spots.spend("thoughts"))
+        assertNull(spots.spend("ancient"))
+    }
+
+    // Only a real change is worth a database write; drags and resizes move the layout but no spot.
+    @Test
+    fun encodingIsOnlyAskedForWhenSomethingMoved() {
+        val spots = DockSpotMemory()
+        spots.remember("thoughts", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
+        assertTrue(spots.isDirty())
+
+        spots.encode()
+
+        assertFalse(spots.isDirty())
+        spots.remember("thoughts", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
+        assertFalse(spots.isDirty(), "re-recording an identical spot is not a change")
     }
 
     @Test
@@ -916,7 +1011,7 @@ class GameDockingTest {
         val spots = DockSpotMemory()
         spots.restore(null)
         spots.restore("")
-        assertNull(spots.take("thoughts"))
+        assertNull(spots.spend("thoughts"))
     }
 
     // A region name this build does not know (an older client reading a newer save) drops that one
@@ -930,7 +1025,24 @@ class GameDockingTest {
                 """"logons":{"siblings":["deaths"],"region":"South","proportion":0.25}}""",
         )
 
-        assertNull(spots.take("thoughts"))
-        assertEquals(RememberedSpot(listOf("deaths"), DockRegion.South, 0.25f), spots.take("logons"))
+        assertNull(spots.spend("thoughts"))
+        assertEquals(RememberedSpot(listOf("deaths"), DockRegion.South, 0.25f), spots.spend("logons"))
+    }
+
+    // Closing two windows at once and reopening them both. Reported by review: the capture loop ran
+    // against a tree earlier iterations had already changed, and a spot was spent even when it could
+    // not be used, so both windows lost their places for good.
+    @Test
+    fun twoWindowsClosedTogetherBothComeBack() {
+        val state = newState()
+        val registerWindow = register(state)
+        val spots = DockSpotMemory()
+        reconcile(state, column(), registerWindow, spots)
+        val orderBefore = order(state)
+
+        reconcile(state, column().filterKeys { it != "logons" && it != "deaths" }, registerWindow, spots)
+        reconcile(state, column(), registerWindow, spots)
+
+        assertEquals(orderBefore, order(state))
     }
 }

--- a/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
+++ b/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
@@ -6,6 +6,7 @@ import com.seanproctor.docking.model.DockNode
 import com.seanproctor.docking.model.DockRegion
 import com.seanproctor.docking.model.DockableId
 import com.seanproctor.docking.model.DockableOptions
+import com.seanproctor.docking.model.WindowBounds
 import com.seanproctor.docking.persistence.DockingPersistence
 import com.seanproctor.docking.persistence.captureLayout
 import com.seanproctor.docking.persistence.restoreLayout
@@ -855,5 +856,81 @@ class GameDockingTest {
     @Test
     fun aWindowThatIsNotDockedHasNoSpotToRemember() {
         assertNull(rememberedSpotOf(newState(), "never-docked"))
+    }
+
+    // --- Spots surviving a restart ---
+
+    // The point of persisting: close a window, quit, come back, reopen it, and it is still where it
+    // was. The second session is a fresh DockState and a fresh memory, restored from what was saved.
+    @Test
+    fun aSpotSurvivesIntoTheNextSession() {
+        val first = newState()
+        val firstSpots = DockSpotMemory()
+        reconcile(first, column(), register(first), firstSpots)
+        val orderBefore = order(first)
+        reconcile(first, column().filterKeys { it != "logons" }, register(first), firstSpots)
+        val savedLayout = DockingPersistence.encode(first.captureLayout())
+        val savedSpots = firstSpots.encode()
+
+        val next = newState()
+        val nextSpots = DockSpotMemory()
+        nextSpots.restore(savedSpots)
+        applyRestoredLayout(next, savedLayout, column().filterKeys { it != "logons" }, register(next), nextSpots)
+        reconcile(next, column(), register(next), nextSpots)
+
+        assertEquals(orderBefore, order(next))
+    }
+
+    @Test
+    fun spotsSurviveTheirOwnRoundTrip() {
+        val spots = DockSpotMemory()
+        spots.remember("thoughts", RememberedSpot(listOf("logons", "deaths"), DockRegion.South, 0.25f))
+        spots.remember(
+            "room",
+            RememberedSpot(emptyList(), DockRegion.Center, 0.5f, detached = true, bounds = WindowBounds(1f, 2f, 3f, 4f)),
+        )
+
+        val restored = DockSpotMemory().apply { restore(spots.encode()) }
+
+        assertEquals(RememberedSpot(listOf("logons", "deaths"), DockRegion.South, 0.25f), restored.take("thoughts"))
+        assertEquals(
+            RememberedSpot(emptyList(), DockRegion.Center, 0.5f, detached = true, bounds = WindowBounds(1f, 2f, 3f, 4f)),
+            restored.take("room"),
+        )
+    }
+
+    // A character whose saved spots are unreadable loses only the spots - they still get their
+    // arrangement, and windows open where they always did.
+    @Test
+    fun unreadableSpotsAreDiscardedRatherThanThrown() {
+        val spots = DockSpotMemory()
+        spots.remember("thoughts", RememberedSpot(listOf("logons"), DockRegion.South, 0.5f))
+
+        spots.restore("{not json")
+
+        assertNull(spots.take("thoughts"))
+    }
+
+    @Test
+    fun noSavedSpotsIsNotAnError() {
+        val spots = DockSpotMemory()
+        spots.restore(null)
+        spots.restore("")
+        assertNull(spots.take("thoughts"))
+    }
+
+    // A region name this build does not know (an older client reading a newer save) drops that one
+    // spot rather than the whole set.
+    @Test
+    fun anUnknownRegionDropsOnlyItsOwnSpot() {
+        val spots = DockSpotMemory()
+
+        spots.restore(
+            """{"thoughts":{"region":"Sideways","proportion":0.5},""" +
+                """"logons":{"siblings":["deaths"],"region":"South","proportion":0.25}}""",
+        )
+
+        assertNull(spots.take("thoughts"))
+        assertEquals(RememberedSpot(listOf("deaths"), DockRegion.South, 0.25f), spots.take("logons"))
     }
 }

--- a/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
+++ b/compose/src/commonTest/kotlin/warlockfe/warlock3/compose/ui/game/GameDockingTest.kt
@@ -1045,4 +1045,91 @@ class GameDockingTest {
 
         assertEquals(orderBefore, order(state))
     }
+
+    // --- The three the first review round left open ---
+
+    // A window that was the first of a strip came back last, because docking Center appends.
+    @Test
+    fun aTabbedWindowRejoinsTheStripAtItsOwnIndex() {
+        val state = newState()
+        val registerWindow = register(state)
+        val spots = DockSpotMemory()
+        val windows =
+            openWindows(
+                MAIN_WINDOW_NAME to WindowLocation.CENTER,
+                "thoughts" to WindowLocation.LEFT,
+                "logons" to WindowLocation.LEFT,
+                "deaths" to WindowLocation.LEFT,
+            )
+        reconcile(state, windows, registerWindow, spots)
+        // Gather the three into one strip, so "thoughts" is the first of three tabs.
+        state.dock(DockableId("logons"), DockTarget.OnDockable(DockableId("thoughts")), DockRegion.Center)
+        state.dock(DockableId("deaths"), DockTarget.OnDockable(DockableId("thoughts")), DockRegion.Center)
+        val stripBefore = tabOrder(state)
+        assertEquals("thoughts", stripBefore.first())
+
+        reconcile(state, windows.filterKeys { it != "thoughts" }, registerWindow, spots)
+        reconcile(state, windows, registerWindow, spots)
+
+        assertEquals(stripBefore, tabOrder(state))
+    }
+
+    private fun tabOrder(state: DockState): List<String> {
+        fun find(node: DockNode): DockNode.Tabs? =
+            when (node) {
+                is DockNode.Tabs -> node
+                is DockNode.Split -> find(node.first) ?: find(node.second)
+                else -> null
+            }
+        return find(state.layout.mainWindow.root!!)?.tabs?.map { it.dockableId.value } ?: emptyList()
+    }
+
+    // A window whose sibling was a subtree of two, one of which has since closed. Review round one
+    // read this as a bug - the old proportion applied to a smaller thing - but the space the closed
+    // window had was already handed to the ones remaining, so the survivors fill the same extent the
+    // group did and the old share of them is the size it had. Scaling to the survivors was tried, and
+    // made the window grow instead. This pins the behaviour so it is not "fixed" again.
+    @Test
+    fun aWindowComesBackTheRightSizeWhenOnlySomeNeighboursSurvive() {
+        val state = newState()
+        val registerWindow = register(state)
+        val spots = DockSpotMemory()
+        reconcile(state, column(), registerWindow, spots)
+        // deaths sits opposite the subtree holding thoughts and logons.
+        val spot = rememberedSpotOf(state, "deaths")!!
+        assertEquals(setOf("thoughts", "logons"), spot.siblings.toSet())
+
+        reconcile(state, column().filterKeys { it != "deaths" }, registerWindow, spots)
+        reconcile(state, column().filterKeys { it != "deaths" && it != "logons" }, registerWindow, spots)
+        reconcile(state, column().filterKeys { it != "logons" }, registerWindow, spots)
+
+        // Against the one surviving sibling, its share of that pair should still be the share it had
+        // of the pair it left - a half of what it is now beside, not a quarter.
+        val after = shares(state.layout.mainWindow.root!!)
+        val deaths = after[DockableId("deaths")]!!
+        val thoughts = after[DockableId("thoughts")]!!
+        assertEquals(
+            spot.proportion,
+            deaths / (deaths + thoughts),
+            absoluteTolerance = 0.02f,
+            message = "deaths came back at ${deaths / (deaths + thoughts)} of its pair, having had ${spot.proportion}",
+        )
+    }
+
+    @Test
+    fun tabIndexAndSharesSurviveTheRoundTrip() {
+        val spots = DockSpotMemory()
+        val spot =
+            RememberedSpot(
+                siblings = listOf("logons", "deaths"),
+                region = DockRegion.South,
+                proportion = 0.25f,
+                tabIndex = 2,
+            )
+        spots.remember("thoughts", spot)
+
+        val restored = DockSpotMemory().apply { restore(spots.encode()) }
+
+        assertEquals(spot, restored.spend("thoughts"))
+    }
 }


### PR DESCRIPTION
Closing a window undocked it outright, so reopening one was placed as if the game had just announced it — at the end of its column, at a fresh share. A window the user had put third in the left column and sized to taste came back last, at a size nobody chose. Toggling a panel off and on is routine, and it rearranged the layout every time.

## What is remembered

The spot is described by its **neighbours**, not by coordinates — coordinates do not survive the rest of the layout moving underneath them. What `RememberedSpot` keeps is:

- which windows it was split away from (or tabbed with)
- which side of them it was on
- how much of them it had

So it goes back between the same windows at the same size, *wherever those have since been dragged to*. Three cases:

| closed while | reopens |
|---|---|
| split into a column/row | between the same neighbours, at the same proportion |
| tabbed with others | back into the same tab strip |
| detached | detached again, at the size and screen position it had |

## Best effort, and where the effort stops

When every window it sat beside has closed too, there is nothing left to sit beside — it falls back to the announced spot it would have had before. That is a test, not an accident.

A spot is **spent by the reopen that uses it**, so a window moved after reopening is not yanked back to a stale one the next time it is closed.

**Persisted per character**, under a key of its own (`dockSpots`) rather than folded into the arrangement JSON — an unreadable set of spots then costs only the memory, and every layout already saved still reads. Loaded before the restore, so the reconcile inside it can already put a window closed in a previous session back where its owner left it. Written on the same beat as the arrangement: spots only change as part of a close or a reopen, and both move the layout, so the existing debounced save fires for every change — and the flush in `close()` covers a change made within a second of quitting.

The stored shape is ours, not the library's types annotated, so a rename there cannot quietly invalidate what characters have saved. A region name this build does not know reads back as *no* spot rather than a broken one, which is what an older client reading a newer save will meet.

## Testing

37 tests in `GameDockingTest`. The main one closes a window out of the middle of an arranged column, reopens it, and asserts both the order and every window's size are unchanged.

Because a test like that can pass for the wrong reason, each half was checked by breaking it:

| broken | test that failed |
|---|---|
| memory neutered | `aReopenedWindowGoesBackWhereItWas` — `expected:<[thoughts, logons, deaths, main]> but was:<[thoughts, deaths, logons, main]>` |
| decode neutered | `aSpotSurvivesIntoTheNextSession` — `expected:<[thoughts, logons, deaths, main]> but was:<[logons, thoughts, deaths, main]>` |

There is also a test pinning the old behaviour directly: with no memory carried across the calls, the reopened window lands at the end of the column. Plus the round trip including detached bounds, unreadable JSON, absent JSON, and an unknown region dropping only its own entry.

`./gradlew check -PiosSkip=true -PlintSkip=true` passes.

**One gap, stated rather than glossed:** the tests drive `reconcile` and the memory directly, which is where the logic lives, but they do not exercise the composable that holds the memory across passes and wires it to the view model. That wiring was checked by reading. I meant to confirm it live, but X screen capture is unavailable on this machine right now (`import` fails on both the window and the root), so I could not drive the Windows menu and watch the result. What I did confirm live is that the app builds, starts, connects and lays out windows with the change in place, with no runtime errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round

`/code-review` found fourteen things. Nine were real and are fixed; the top four I reproduced before touching anything.

**Fixed — correctness**

| | was |
|---|---|
| capture order | spots were read one at a time *as* windows were undocked, so the second of a pair read its neighbours from a tree the first had already left. Both described an arrangement that never existed. Now every spot is read before any window leaves. |
| spend-before-use | a spot was consumed whether or not it could be used. Closing two windows and reopening them lost both places permanently. Now peeked, spent only on use, and placement retries until no more windows can be placed from memory — so a pair waiting on each other resolves. |
| JSON strictness | the default `Json` rejects unknown keys, so one field added by a later build would have discarded *every* spot — the opposite of the KDoc. Now lenient, and decoded entry by entry. |
| detached grouping | a window torn off with company remembered only "floating", so both reopened in separate windows at identical bounds, stacked exactly on each other. A spot now records neighbours from whichever window it was in and rejoins them there. |
| maximized target | a target naming something only in a pre-maximize tree is unresolvable, and `dock()` drops those silently — reopening a tabbed window while maximized made it **vanish**. Only live trees are consulted now. |
| `remember(name, null)` | erased a good spot instead of declining to record a new one. |
| `restore()` | cleared what the session had already collected, losing a spot recorded before a slow character identification. It merges now. |
| unbounded growth | a spot per window ever closed, re-serialized on every layout change (drags included). Pruned to live windows, and written only when something actually moved. |
| the `spots` default | `= DockSpotMemory()` silently disabled the feature for any caller that forgot it. Now required. |

**Reproduced first**, e.g. the batch close: `expected:<[thoughts, logons, deaths, main]> but was:<[thoughts, deaths, logons, main]>`.

**One of my tests was right to be called out.** `aWindowWhoseNeighboursAllClosedFallsBackToItsAnnouncedArea` asserted the *set* of docked names, which any arrangement of those names satisfies — it did not test the fallback it was named for. It now compares against a state reconciled from scratch.

44 tests.

**Not fixed, deliberately:**

- **Tab index is not restored** — a window that was first of four tabs comes back last in the strip. The stored sibling list has the information; using it means an index-aware dock the bridge does not currently do. Real gap, worth its own change.
- **Partially surviving siblings give the wrong size** — if a window was West of `{logons, deaths}` at 0.25 and only `logons` survives, it docks West of `logons` alone at 0.25, so it comes back smaller than it was. Better than the announced-area fallback, but not "the same size".
- **One duplicated tree-walking helper** — four spellings of "the tree of a window" now coexist in this file. Worth one `DockWindow.liveTree` helper across all of them, but that touches code this PR does not otherwise.

I have adjusted the KDoc so it no longer claims more than the code does for the two size/order cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Closed windows now remember dock positions, tab order, split relationships, and proportions when reopened.
  * Detached windows restore their previous size and position.
  * Docking layouts and window positions persist across sessions and character changes.
  * Maximized and floating window arrangements restore more reliably.

* **Bug Fixes**
  * Improved handling of incomplete or invalid saved layout data.
  * Obsolete saved docking information is automatically removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->