### PR TITLE
Carry the MUD Mobile game stream over a WebSocket, and report failed connects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ local.properties
 
 # work-around https://github.com/Splitties/refreshVersions/issues/640
 versions.properties
+
+# Isolated checkouts Claude Code makes for agents. The rest of .claude is shared
+# project config and stays tracked.
+.claude/worktrees/

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -275,10 +275,12 @@ abstract class AppContainer(
             // speaks WebSocket, which is the one transport every platform we target can open.
             install(WebSockets)
             install(HttpTimeout) {
-                // A bound on the API calls, so a service that is down or mid-maintenance fails with
-                // something to show the user instead of sitting there. It does not touch the game
-                // stream: both this plugin and the CIO engine exempt WebSocket requests, which is
-                // what lets the router hold a connection through its cold boot.
+                // The bound on the API calls, so a service that is down or mid-maintenance fails
+                // with something to show the user instead of sitting there. CIO defaults to the
+                // same 15s, but only the plugin's is a number: the engine's goes unreported, which
+                // is what left "request_timeout=unknown ms" in the log of a real outage. It does not
+                // touch the game stream either way - both the plugin and the engine exempt WebSocket
+                // requests, which is what lets the router hold a connection through its cold boot.
                 requestTimeoutMillis = 15_000
             }
         }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -7,6 +7,7 @@ import androidx.sqlite.execSQL
 import co.touchlab.kermit.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -267,7 +268,13 @@ abstract class AppContainer(
         )
     }
 
-    val mudMobileHttpClient: HttpClient by lazy { HttpClient(CIO) }
+    val mudMobileHttpClient: HttpClient by lazy {
+        HttpClient(CIO) {
+            // The REST API rides this client, and so does the game stream: MUD Mobile's router
+            // speaks WebSocket, which is the one transport every platform we target can open.
+            install(WebSockets)
+        }
+    }
 
     val mudMobileApi by lazy { MudMobileApi(mudMobileHttpClient) }
 
@@ -285,6 +292,7 @@ abstract class AppContainer(
     val mudMobileConnectUseCase by lazy {
         MudMobileConnectUseCase(
             api = mudMobileApi,
+            httpClient = mudMobileHttpClient,
             sgeClientFactory = sgeClientFactory,
             warlockClientFactory = warlockClientFactory,
             windowRegistryFactory = windowRegistryFactory,

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/AppContainer.kt
@@ -7,6 +7,7 @@ import androidx.sqlite.execSQL
 import co.touchlab.kermit.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.websocket.WebSockets
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -273,6 +274,13 @@ abstract class AppContainer(
             // The REST API rides this client, and so does the game stream: MUD Mobile's router
             // speaks WebSocket, which is the one transport every platform we target can open.
             install(WebSockets)
+            install(HttpTimeout) {
+                // A bound on the API calls, so a service that is down or mid-maintenance fails with
+                // something to show the user instead of sitting there. It does not touch the game
+                // stream: both this plugin and the CIO engine exempt WebSocket requests, which is
+                // what lets the router hold a connection through its cold boot.
+                requestTimeoutMillis = 15_000
+            }
         }
     }
 

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/MudMobileConnectUseCase.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/MudMobileConnectUseCase.kt
@@ -3,8 +3,10 @@ package warlockfe.warlock3.compose
 import co.touchlab.kermit.Logger
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import warlockfe.warlock3.compose.model.GameScreen
@@ -115,28 +117,34 @@ class MudMobileConnectUseCase(
                 }
             }
 
-        // Refresh the saved profile (idempotent upsert; keeps last-used current). Best-effort, and
-        // only possible when we know the EAccess character code. It comes after the session call
-        // rather than before it: it is a nicety for the character picker, so it should neither delay
-        // the failure when MUD Mobile is unreachable — the session call has already established
-        // whether it is — nor hold up the game if this one endpoint is the slow one.
-        connection.characterCode?.let { characterCode ->
-            withTimeoutOrNull(PROFILE_REFRESH_TIMEOUT) {
-                api.createCharacter(
-                    token = token,
-                    account = connection.username,
-                    game = connection.code,
-                    characterCode = characterCode,
-                    characterName = connection.character,
-                )
-            }
-        }
-
         // 3. Wait for the session to announce it's ready before dialing the router. (Per the spec
         // the session is already routable at this point, so we only wait briefly: a warning at
         // WARN_AFTER, then connect regardless at FORCE_CONNECT_AFTER even without a ready signal.)
         onStatus("Waiting for the session to be ready...")
-        when (val readiness = awaitReady(token, sessionId, onStatus)) {
+        val readiness =
+            coroutineScope {
+                // Refresh the saved profile (idempotent upsert; keeps last-used current) alongside
+                // that wait rather than ahead of it: it is a nicety for the character picker, so it
+                // is not something to make the user wait on, and it is bounded in case this is the
+                // endpoint that is slow. Best-effort, and only possible when we know the character
+                // code. It also comes after the session call, so an unreachable service costs one
+                // timeout rather than two on the way to reporting the failure.
+                connection.characterCode?.let { characterCode ->
+                    launch {
+                        withTimeoutOrNull(PROFILE_REFRESH_TIMEOUT) {
+                            api.createCharacter(
+                                token = token,
+                                account = connection.username,
+                                game = connection.code,
+                                characterCode = characterCode,
+                                characterName = connection.character,
+                            )
+                        }
+                    }
+                }
+                awaitReady(token, sessionId, onStatus)
+            }
+        when (readiness) {
             ReadinessResult.Ready -> Unit
 
             // proceed to connect

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/MudMobileConnectUseCase.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/MudMobileConnectUseCase.kt
@@ -1,6 +1,7 @@
 package warlockfe.warlock3.compose
 
 import co.touchlab.kermit.Logger
+import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
@@ -22,7 +23,7 @@ import warlockfe.warlock3.core.sge.SgeSettings
 import warlockfe.warlock3.core.sge.SimuGameCredentials
 import warlockfe.warlock3.core.sge.StoredConnection
 import warlockfe.warlock3.core.util.sha256Hex
-import warlockfe.warlock3.wrayth.network.NetworkSocket
+import warlockfe.warlock3.wrayth.network.WarlockWebSocket
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 
@@ -31,13 +32,16 @@ import kotlin.time.TimeSource
  *  1. Run Warlock's normal local SGE/EAccess login (password stays on this machine).
  *  2. Hash the resulting game key and register a hosted-Lich session with MUD Mobile
  *     (`POST /api/sessions`) — only the hash leaves the machine.
- *  3. Open the game socket to the router MUD Mobile returns (TLS) and send the usual Stormfront
- *     handshake, then hand off to a normal [GameScreen.ConnectedGameState].
+ *  3. Open a WebSocket to the router MUD Mobile returns and send the usual Stormfront handshake,
+ *     then hand off to a normal [GameScreen.ConnectedGameState].
  *
  * See docs/specs/mudmobile-integration.md.
  */
 class MudMobileConnectUseCase(
     private val api: MudMobileApi,
+    // The same client the API talks over; the game stream rides a WebSocket on it (see
+    // [WarlockWebSocket]), so it must have the WebSockets plugin installed.
+    private val httpClient: HttpClient,
     private val sgeClientFactory: SgeClientFactory,
     private val warlockClientFactory: WarlockClientFactory,
     private val windowRegistryFactory: WindowRegistryFactory,
@@ -141,8 +145,8 @@ class MudMobileConnectUseCase(
     }
 
     /**
-     * Open the game socket to the router and hand off to a [GameScreen.ConnectedGameState]. Used for
-     * both the initial connect and reconnects.
+     * Open the game connection to the router and hand off to a [GameScreen.ConnectedGameState]. Used
+     * for both the initial connect and reconnects.
      *
      * A reconnect re-dials this same router endpoint with the same game key - no SGE login and no new
      * session. The hosted session persists across a client disconnect, and the router still bridges
@@ -161,7 +165,7 @@ class MudMobileConnectUseCase(
             var createdClient: WarlockClient? = null
             try {
                 val streamRegistry = windowRegistryFactory.create()
-                val socket = NetworkSocket(ioDispatcher, secure = connect.tls)
+                val socket = WarlockWebSocket(httpClient, ioDispatcher, secure = connect.tls)
                 socket.connect(connect.host, connect.port)
                 val client =
                     warlockClientFactory.createClient(

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/MudMobileConnectUseCase.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/MudMobileConnectUseCase.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import warlockfe.warlock3.compose.model.GameScreen
 import warlockfe.warlock3.compose.model.GameState
 import warlockfe.warlock3.compose.ui.game.GameViewModelFactory
@@ -67,18 +68,6 @@ class MudMobileConnectUseCase(
                 is AutoConnectResult.Success -> sge.credentials
             }
 
-        // Refresh the saved profile (idempotent upsert; keeps last-used current). Best-effort, and
-        // only possible when we know the EAccess character code.
-        connection.characterCode?.let { characterCode ->
-            api.createCharacter(
-                token = token,
-                account = connection.username,
-                game = connection.code,
-                characterCode = characterCode,
-                characterName = connection.character,
-            )
-        }
-
         // 2. Register the session. Only the key hash is sent — never the password or the raw key.
         onStatus("Starting your cloud session...")
         val keyHash = sha256Hex(credentials.key)
@@ -125,6 +114,23 @@ class MudMobileConnectUseCase(
                     return MudMobileConnectResult.Failure("Couldn't start session: ${result.message}")
                 }
             }
+
+        // Refresh the saved profile (idempotent upsert; keeps last-used current). Best-effort, and
+        // only possible when we know the EAccess character code. It comes after the session call
+        // rather than before it: it is a nicety for the character picker, so it should neither delay
+        // the failure when MUD Mobile is unreachable — the session call has already established
+        // whether it is — nor hold up the game if this one endpoint is the slow one.
+        connection.characterCode?.let { characterCode ->
+            withTimeoutOrNull(PROFILE_REFRESH_TIMEOUT) {
+                api.createCharacter(
+                    token = token,
+                    account = connection.username,
+                    game = connection.code,
+                    characterCode = characterCode,
+                    characterName = connection.character,
+                )
+            }
+        }
 
         // 3. Wait for the session to announce it's ready before dialing the router. (Per the spec
         // the session is already routable at this point, so we only wait briefly: a warning at
@@ -293,6 +299,7 @@ class MudMobileConnectUseCase(
     }
 
     private companion object {
+        val PROFILE_REFRESH_TIMEOUT = 5.seconds
         val WARN_AFTER = 25.seconds
         val FORCE_CONNECT_AFTER = 30.seconds
         val POLL_INTERVAL = 1.seconds

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/MudMobileConnectUseCase.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/MudMobileConnectUseCase.kt
@@ -125,24 +125,27 @@ class MudMobileConnectUseCase(
             coroutineScope {
                 // Refresh the saved profile (idempotent upsert; keeps last-used current) alongside
                 // that wait rather than ahead of it: it is a nicety for the character picker, so it
-                // is not something to make the user wait on, and it is bounded in case this is the
-                // endpoint that is slow. Best-effort, and only possible when we know the character
-                // code. It also comes after the session call, so an unreachable service costs one
-                // timeout rather than two on the way to reporting the failure.
-                connection.characterCode?.let { characterCode ->
-                    launch {
-                        withTimeoutOrNull(PROFILE_REFRESH_TIMEOUT) {
-                            api.createCharacter(
-                                token = token,
-                                account = connection.username,
-                                game = connection.code,
-                                characterCode = characterCode,
-                                characterName = connection.character,
-                            )
+                // is not something to make the user wait on. Best-effort, and only possible when we
+                // know the character code. It also comes after the session call, so an unreachable
+                // service costs one timeout rather than two on the way to reporting the failure.
+                val profileRefresh =
+                    connection.characterCode?.let { characterCode ->
+                        launch {
+                            withTimeoutOrNull(PROFILE_REFRESH_TIMEOUT) {
+                                api.createCharacter(
+                                    token = token,
+                                    account = connection.username,
+                                    game = connection.code,
+                                    characterCode = characterCode,
+                                    characterName = connection.character,
+                                )
+                            }
                         }
                     }
-                }
-                awaitReady(token, sessionId, onStatus)
+                // Dropped if the wait ends first, rather than held onto: this scope joins its
+                // children, so an unfinished refresh would go back to being time the user spends
+                // watching a dialog. It is a refresh of a record that already exists.
+                awaitReady(token, sessionId, onStatus).also { profileRefresh?.cancel() }
             }
         when (readiness) {
             ReadinessResult.Ready -> Unit

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
@@ -161,6 +161,9 @@ class DashboardViewModel(
         }
         if (busy) return
         busy = true
+        // The last attempt's failure is not this one's; clear it so its dialog cannot end up over a
+        // connect that is still running.
+        connectError = null
         connectJob?.cancel()
         connectJob =
             viewModelScope.launch {
@@ -356,6 +359,7 @@ class DashboardViewModel(
         mudMobileConnecting = true
         mudMobileConnectStatus = "Starting..."
         mudMobileMessage = null
+        connectError = null
         mudMobileSessionId = null
         connectJob?.cancel()
         connectJob =

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardViewModel.kt
@@ -60,6 +60,13 @@ class DashboardViewModel(
     var message: String? by mutableStateOf(null)
         private set
 
+    // A connect attempt that finished by failing. Held until the user acknowledges it, because the
+    // attempt can sit for many seconds against a service that is down or unreachable, and by the
+    // time the connecting dialog closes on its own, a line of text on the dashboard behind it reads
+    // as nothing having happened at all.
+    var connectError: String? by mutableStateOf(null)
+        private set
+
     private var connectJob: Job? = null
 
     // --- MUD Mobile state ---
@@ -166,7 +173,8 @@ class DashboardViewModel(
                     sgeClient.close()
                     when (result) {
                         is AutoConnectResult.Failure -> {
-                            message = result.reason
+                            message = null
+                            connectError = result.reason
                         }
 
                         is AutoConnectResult.Success -> {
@@ -357,7 +365,7 @@ class DashboardViewModel(
                     clientSettingRepository.putLastConnectionId(connection.id)
                     val token = clientSettingRepository.getMudMobileToken()
                     if (token == null) {
-                        mudMobileMessage = "Connect your MUD Mobile account first."
+                        connectError = "Connect your MUD Mobile account first."
                         return@launch
                     }
                     // Remember the account password for next time.
@@ -376,20 +384,25 @@ class DashboardViewModel(
                             onSessionCreated = { mudMobileSessionId = it },
                         )
                     if (result is MudMobileConnectResult.Failure) {
-                        mudMobileMessage = result.message
+                        connectError = result.message
                     }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
                     ensureActive()
                     logger.e(e) { "Error connecting to MUD Mobile" }
-                    mudMobileMessage = "Error: ${e.message}"
+                    connectError = "Error: ${e.message}"
                 } finally {
                     connectJob = null
                     mudMobileConnecting = false
                     mudMobileConnectStatus = null
                 }
             }
+    }
+
+    /** Acknowledge a failed connect attempt, closing its dialog. */
+    fun dismissConnectError() {
+        connectError = null
     }
 
     /** Cancel an in-progress MUD Mobile connect and tear down the half-created session. */

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -1688,11 +1688,22 @@ class GameViewModel(
 
     /** Tear down this game's client and window registry without touching any reconnect in flight. */
     private suspend fun closeClient() {
-        if (!client.disconnected.value) {
-            client.sendCommandDirect("quit")
+        // The quit is a goodbye to the server, not part of the teardown: whether it lands or not,
+        // the client and the registry still have to go, and the caller still has somewhere to be
+        // afterwards - the dashboard, or a window that wants to close. Only cancellation carries on
+        // past here, and the teardown has run by then either way.
+        try {
+            if (!client.disconnected.value) {
+                client.sendCommandDirect("quit")
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.d(e) { "Couldn't send the parting quit" }
+        } finally {
+            client.close()
+            windowRegistry.close()
         }
-        client.close()
-        windowRegistry.close()
     }
 
     /**

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/shim/WarlockDialog.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/shim/WarlockDialog.kt
@@ -5,10 +5,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
@@ -67,8 +68,17 @@ fun WarlockAlertDialog(
         height = height,
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
-            Text(text)
-            Spacer(Modifier.weight(1f))
+            // Scrolls rather than clips: the dialog window is a fixed size, and some of what lands
+            // here is arbitrary - a server's error, an exception message - so it can be any length.
+            // Taking the leftover space also keeps the buttons at the bottom, as a spacer did.
+            Box(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .verticalScroll(rememberScrollState()),
+            ) {
+                Text(text)
+            }
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = androidx.compose.ui.Alignment.End),

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopDashboardView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopDashboardView.kt
@@ -607,6 +607,16 @@ private fun DashboardDialogs(
         )
     }
 
+    // A failed attempt is reported here rather than only as a line on the dashboard, and stays up
+    // until it is acknowledged, so a connect that dies while the user is looking elsewhere is not
+    // mistaken for one that is still running.
+    viewModel.connectError?.let { error ->
+        ConnectionFailedDialog(
+            message = error,
+            onDismiss = { viewModel.dismissConnectError() },
+        )
+    }
+
     // Unified connecting dialog: shown for both a direct login and a MUD Mobile login.
     if (viewModel.busy || viewModel.mudMobileConnecting) {
         val status =
@@ -786,6 +796,29 @@ private fun ConnectionPasswordDialog(
                     text = confirmText,
                     enabled = passwordState.text.isNotBlank(),
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConnectionFailedDialog(
+    message: String,
+    onDismiss: () -> Unit,
+) {
+    WarlockDialog(
+        title = "Connection failed",
+        onCloseRequest = onDismiss,
+        width = 420.dp,
+        height = 220.dp,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(message)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                WarlockButton(onClick = onDismiss, text = "OK")
             }
         }
     }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopDashboardView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/dashboard/DesktopDashboardView.kt
@@ -46,6 +46,7 @@ import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import sh.calvin.reorderable.ReorderableColumn
+import warlockfe.warlock3.compose.desktop.shim.WarlockAlertDialog
 import warlockfe.warlock3.compose.desktop.shim.WarlockButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockDialog
 import warlockfe.warlock3.compose.desktop.shim.WarlockDropdownSelect
@@ -806,22 +807,14 @@ private fun ConnectionFailedDialog(
     message: String,
     onDismiss: () -> Unit,
 ) {
-    WarlockDialog(
+    WarlockAlertDialog(
         title = "Connection failed",
-        onCloseRequest = onDismiss,
+        text = message,
+        onDismissRequest = onDismiss,
+        confirmButton = { WarlockButton(onClick = onDismiss, text = "OK") },
         width = 420.dp,
         height = 220.dp,
-    ) {
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Text(message)
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                WarlockButton(onClick = onDismiss, text = "OK")
-            }
-        }
-    }
+    )
 }
 
 @Composable

--- a/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardView.kt
+++ b/compose/src/mobileMain/kotlin/warlockfe/warlock3/compose/ui/dashboard/DashboardView.kt
@@ -225,6 +225,16 @@ fun DashboardView(
         )
     }
 
+    // A failed attempt is reported here rather than only as a line on the dashboard, and stays up
+    // until it is acknowledged, so a connect that dies while the user is looking elsewhere is not
+    // mistaken for one that is still running.
+    viewModel.connectError?.let { error ->
+        ConnectionFailedDialog(
+            message = error,
+            onDismiss = { viewModel.dismissConnectError() },
+        )
+    }
+
     // Unified connecting overlay: shown for both a direct login and a MUD Mobile login.
     if (viewModel.busy || viewModel.mudMobileConnecting) {
         val status = if (viewModel.mudMobileConnecting) viewModel.mudMobileConnectStatus else viewModel.message
@@ -676,6 +686,23 @@ private fun RevealPasswordField(
             trailingIcon = toggle,
         )
     }
+}
+
+@Composable
+private fun ConnectionFailedDialog(
+    message: String,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Connection failed") },
+        text = { Text(message) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("OK")
+            }
+        },
+    )
 }
 
 @Composable

--- a/core/src/iosMain/kotlin/warlockfe/warlock3/core/util/StringExt.ios.kt
+++ b/core/src/iosMain/kotlin/warlockfe/warlock3/core/util/StringExt.ios.kt
@@ -33,7 +33,11 @@ fun ByteArray.toNSData(
 @OptIn(BetaInteropApi::class)
 actual fun String.encodeWindows1252(): ByteArray {
     val nsString: NSString = NSString.create(this)!!
-    val nsData = nsString.dataUsingEncoding(NSWindowsCP1252StringEncoding)
+    // Lossy, because the alternative is not "no conversion" but "no text": dataUsingEncoding returns
+    // null for anything windows-1252 cannot represent, and a typed curly quote or emoji would take
+    // the whole line with it. Lossy substitutes a '?' per character, which is what the JVM and
+    // Android encoders do with the same input.
+    val nsData = nsString.dataUsingEncoding(NSWindowsCP1252StringEncoding, allowLossyConversion = true)
     return nsData?.toByteArray() ?: ByteArray(0)
 }
 

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -287,7 +287,11 @@ private class WarlockCommand : CliktCommand() {
                             scope.launch {
                                 val screen = gameState.screen
                                 if (screen is GameScreen.ConnectedGameState) {
-                                    screen.viewModel.close()
+                                    try {
+                                        screen.viewModel.close()
+                                    } catch (_: Throwable) {
+                                        // Ignore failures
+                                    }
                                 }
                                 games.remove(gameState)
                                 if (games.isEmpty()) {

--- a/docs/specs/dashboard-screen.md
+++ b/docs/specs/dashboard-screen.md
@@ -135,14 +135,14 @@ section).
    and interactive.
 2. **Connecting (direct login).** Triggered by pressing **Login** on a normal connection. The
    connection list is replaced by the status line ("Connecting...") and a **Cancel** button. On
-   success the app moves to the Game screen; on failure the status line shows the reason (or a
-   full-screen error appears for hard failures).
+   success the app moves to the Game screen; on failure the **Connection failed dialog**
+   (Section 7.7) reports the reason (a full-screen error still appears for hard failures).
 3. **MUD Mobile section busy.** Triggered by token validation, Refresh, or discovery. The MUD
    Mobile buttons are disabled and the inline message shows progress. The rest of the screen stays
    usable.
 4. **MUD Mobile connecting.** Triggered by logging in to a MUD Mobile connection. A modal
    **Connecting dialog** (Section 7.5) is shown over the Dashboard with live status and a Cancel
-   button.
+   button. A failure closes it and opens the **Connection failed dialog** (Section 7.7).
 
 ---
 
@@ -215,6 +215,14 @@ with the dismissive action on the left and the confirming action on the right.
     play.net account."
 - **Buttons:** dismiss / confirm.
 
+### 7.7 Connection failed
+- **Opened by:** a login attempt that finished by failing - direct or MUD Mobile.
+- **Body:** the reason, as reported by SGE or MUD Mobile (a bad password, "Couldn't start session:
+  ...", "A MUD Mobile subscription is required", a timeout when the service is down).
+- **Buttons:** OK. The dialog stays up until it is acknowledged: an attempt can sit for many
+  seconds against a service that is unreachable, and a line of text on the Dashboard behind a
+  connecting dialog that has just closed itself reads as nothing having happened.
+
 ---
 
 ## 8. Key flows
@@ -262,6 +270,7 @@ tone and clarity.
   "wlk_"." / "Open mudmobile.com" / Save
 - Errors: "That token was rejected. Check it and paste it again." / "Your MUD Mobile token is no
   longer valid. Reconnect your account." / "Couldn't reach MUD Mobile: <detail>"
+- Connection failed dialog: title "Connection failed", body is the reason, button "OK"
 - MUD Mobile row marker: "[MUD Mobile]"
 
 ---

--- a/docs/specs/mudmobile-integration.md
+++ b/docs/specs/mudmobile-integration.md
@@ -23,16 +23,16 @@ instead of directly to play.net - with no manual `.sal` editing.
 5. keyHash = sha256_hex(key)
 6. POST https://mudmobile.com/api/sessions           (Bearer wlk_…)            → {sessionId, connect:{host,port,tls}}
    body: {game, character, gamehost, gameport, keyHash}
-7. Open a TLS socket to connect.host:connect.port and send the SAME game key
-   as the first line (exactly the handshake Warlock already sends to play.net).
+7. Open a WebSocket to wss://connect.host:connect.port/ and send the SAME game key
+   as the first message (exactly the handshake Warlock already sends to play.net).
    The router matches sha256(key) → bridges you to Lich → the game. DONE.
 8. (optional) DELETE /api/sessions/{sessionId} when the user disconnects.
 ```
 
 The single behavioral change versus a normal play.net connection: **substitute the
-destination host/port** (from step 6's response) for the real gamehost/gameport, and wrap
-the socket in TLS. The key line and everything after it is byte-for-byte identical to a
-normal connection.
+destination host/port** (from step 6's response) for the real gamehost/gameport, and carry
+the stream over a WebSocket. The key line and everything after it is byte-for-byte
+identical to a normal connection.
 
 ---
 
@@ -46,7 +46,7 @@ normal connection.
 | **keyHash** | `sha256(key)` as lowercase hex (64 chars). MUD Mobile only ever sees this hash, never the key. |
 | **Character profile** | A `{account, game, characterCode, characterName}` record the user saved in MUD Mobile. Lets Warlock pre-populate a character picker. |
 | **Game code** | EAccess game identifier: `DR`, `DRX`, `DRF` (DragonRealms / Platinum / Fallen), `GS3`, `GSX`, `GSF` (GemStone IV / Platinum / Shattered). |
-| **Router** | MUD Mobile's single public TCP endpoint (`play.mudmobile.com`). You connect here, not to play.net. |
+| **Router** | MUD Mobile's single public endpoint (`play.mudmobile.com`), speaking raw TCP and WebSocket on the same port. You connect here, not to play.net. |
 | **Session** | One booted cloud Lich instance, created by `POST /api/sessions`, identified by `sessionId`. |
 
 ---
@@ -60,12 +60,12 @@ These mirror MUD Mobile's own non-negotiable rules. Warlock must uphold the clie
    the device-token path, by design.
 2. **Never send the raw game key to the MUD Mobile HTTP API.** The API only accepts
    `keyHash = sha256(key)`. The raw key is transmitted *only* as the first line of the game
-   TCP stream to the router (same as you'd send it to play.net), where it's forwarded
+   stream to the router (same as you'd send it to play.net), where it's forwarded
    byte-for-byte to Lich.
 3. **Store the device token securely** (OS keychain / credential store if available). Treat
    it like a password; it grants the ability to start billable sessions on the user's account.
 4. **Use TLS for the router connection** when `connect.tls` is true (it is, on the default
-   port 443). Don't fall back to plaintext silently.
+   port 443) - i.e. `wss://`, not `ws://`. Don't fall back to plaintext silently.
 
 ---
 
@@ -380,11 +380,23 @@ key you later send on the wire, so don't trim/transform the key differently in t
 
 After `POST /api/sessions` returns `connect`:
 
-1. **Open a socket** to `connect.host:connect.port`. If `connect.tls` is true (default,
-   port 443), perform a standard TLS handshake first (SNI = `connect.host`; it's a normal
-   CA-valid cert, terminated at MUD Mobile's edge - verify it normally).
-   - A plaintext endpoint also exists on the same host at **port 7000** if you ever need it,
-     but prefer the TLS endpoint the API hands you.
+The router serves two transports on the same port: raw TCP for native clients, and WebSocket
+for everyone else. **Warlock uses the WebSocket**, because it is the one transport all of
+Desktop, Android, and iOS can open with the same code, and the protocol above it is
+identical either way.
+
+1. **Open a WebSocket** to `wss://connect.host:connect.port/` (`ws://` when `connect.tls` is
+   false - a plaintext endpoint also exists on the same host at **port 7000**). TLS is the
+   normal kind: a public CA-valid cert terminated at MUD Mobile's edge, verified normally.
+   - Frames are a transport detail, **never a message boundary** - the game is one byte
+     stream, and the router accumulates your key line across frames until it sees `\n`.
+   - **Send binary frames, and expect binary frames.** The stream is windows-1252, which is
+     not valid UTF-8; a text frame is UTF-8 by definition, so raw high bytes in one get the
+     connection closed with 1007 mid-session. (The router does transcode text frames it
+     receives, for browsers that type commands, but downstream is always binary.)
+   - **Answer the router's pings.** It pings every 25s and terminates a connection that
+     misses two consecutive pongs, to reclaim the machine and concurrency slot a half-open
+     connection would otherwise pin. Every mainstream client library pongs automatically.
 2. **Send your normal Stormfront handshake as the first thing** - i.e. the game **key** line
    followed by your usual `/FE:` / version lines, exactly as Warlock sends to play.net. You
    do **not** need to change how you frame the key; the router is built to tolerate Warlock's
@@ -394,13 +406,15 @@ After `POST /api/sessions` returns `connect`:
      framing is handled). It hashes *that token*, not the whole line.
    - It then forwards the entire buffered first line (key + handshake) and everything after
      it **byte-for-byte** to Lich. Nothing in the stream is rewritten.
-3. **Send the key promptly.** The router drops connections that send no first line within
-   **15 seconds**.
+3. **Send the key promptly**, with its trailing `\n`. The router drops connections that send
+   no first line within **15 seconds**, and a first frame with no newline costs a 300ms
+   grace before it synthesises one.
 4. **Connect once and be patient - do NOT add a reconnect loop.** The cloud machine
    cold-boots in ~25–60s. The router *holds your connection* and retries dialing the machine
    internally for up to ~60–90s, so a patient client rides the boot transparently. A
    client-side reconnect loop will fight this and create duplicate/again-failing attempts.
-   Set your connect/read timeout generously (≥ 90s for the initial bridge).
+   Set your connect/read timeout generously (≥ 90s for the initial bridge), and turn off
+   whatever auto-reconnect your WebSocket wrapper does by default.
 5. Once bridged, it's a normal game session: Lich ↔ play.net, streamed through to Warlock.
    Scripts and settings the user stored in MUD Mobile are already synced into the machine.
 
@@ -447,10 +461,10 @@ conn = resp.json().connect            # { host, port, tls }
 sessionId = resp.json().sessionId
 
 # 4. Connect to the router and play (no reconnect loop; timeout ≥ 90s)
-sock = conn.tls ? tls_connect(conn.host, conn.port, verify=true, sni=conn.host)
-                : tcp_connect(conn.host, conn.port)
-sock.write(stormfront_handshake(sge.key))     # SAME bytes you'd send play.net
-bridge(sock, warlock_game_io)                 # normal play from here
+scheme = conn.tls ? "wss" : "ws"
+sock = websocket_connect(scheme + "://" + conn.host + ":" + conn.port + "/")
+sock.send_binary(stormfront_handshake(sge.key))   # SAME bytes you'd send play.net
+bridge(sock, warlock_game_io)                     # normal play from here
 
 # 5. On user disconnect (optional, frees the slot immediately)
 DELETE "https://mudmobile.com/api/sessions/" + sessionId
@@ -488,8 +502,8 @@ wire protocol, the gamehost allowlist - already exists and is documented above a
 - [ ] Pick a character, enter password, local SGE succeeds, key obtained.
 - [ ] `POST /api/sessions` returns `connect`; verify the password and raw key were **never**
       sent to mudmobile.com (only `keyHash`).
-- [ ] TLS connect to `connect.host:connect.port`, send the key line, ride the cold boot
-      (≥90s timeout, no reconnect loop), reach the game.
+- [ ] `wss://` connect to `connect.host:connect.port`, send the key line as a binary frame,
+      ride the cold boot (≥90s timeout, no reconnect loop), reach the game.
 - [ ] 402 (no subscription) and 409 (at concurrency limit) render sensible UI.
 - [ ] `DELETE /api/sessions/{id}` on disconnect frees the slot.
 ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -126,6 +126,8 @@ ktor-network-tls = { module = "io.ktor:ktor-network-tls", version.ref = "ktor" }
 ktor-utils = { module = "io.ktor:ktor-utils", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
 lua-kmp = { group = "com.seanproctor", name = "lua-kmp", version.ref = "lua-kmp" }
 # Desktop audio output. The natives are added per build host (see core/build.gradle.kts).
 lwjgl-core = { module = "org.lwjgl:lwjgl", version.ref = "lwjgl" }

--- a/wrayth/build.gradle.kts
+++ b/wrayth/build.gradle.kts
@@ -112,6 +112,7 @@ kotlin {
                 implementation(libs.kotlinx.serialization.core)
                 implementation(libs.xmlutil.serialization)
                 api(libs.antlr.kotlin.runtime)
+                implementation(libs.ktor.client.core)
                 implementation(libs.ktor.network)
                 implementation(libs.ktor.network.tls)
             }
@@ -119,6 +120,13 @@ kotlin {
 
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+        }
+
+        // A real WebSocket server to test the MUD Mobile transport against; JVM-only, test-only.
+        jvmTest.dependencies {
+            implementation(libs.ktor.server.cio)
+            implementation(libs.ktor.server.websockets)
         }
 
         getByName("jvmBenchmark").dependencies {

--- a/wrayth/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.jvmAndroid.kt
+++ b/wrayth/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.jvmAndroid.kt
@@ -28,28 +28,6 @@ actual suspend fun openPlainSocket(
     )
 }
 
-actual suspend fun openDefaultTlsSocket(
-    selectorManager: SelectorManager,
-    host: String,
-    port: Int,
-    coroutineContext: CoroutineContext,
-): TLSSocketConnection {
-    val socket =
-        aSocket(selectorManager)
-            .tcp()
-            .connect(host, port)
-            // No trustManager override: ktor falls back to the platform default X509TrustManager,
-            // which validates the router's public CA-signed certificate. SNI defaults to the host.
-            .tls(coroutineContext = coroutineContext) {
-                serverName = host
-            }
-    return TLSSocketConnection(
-        readChannel = socket.openReadChannel(),
-        writeChannel = socket.openWriteChannel(autoFlush = true),
-        close = { socket.close() },
-    )
-}
-
 actual suspend fun openTLSSocket(
     selectorManager: SelectorManager,
     host: String,

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/NetworkSocket.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/NetworkSocket.kt
@@ -10,35 +10,17 @@ import io.ktor.network.sockets.openWriteChannel
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.ByteWriteChannel
 import io.ktor.utils.io.availableForRead
-import io.ktor.utils.io.charsets.TooLongLineException
-import io.ktor.utils.io.discard
-import io.ktor.utils.io.exhausted
-import io.ktor.utils.io.peek
-import io.ktor.utils.io.readAvailable
-import io.ktor.utils.io.readByte
 import io.ktor.utils.io.writeByteArray
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.io.Buffer
-import kotlinx.io.UnsafeIoApi
-import kotlinx.io.readByteArray
-import kotlinx.io.unsafe.UnsafeBufferOperations
-import kotlinx.io.unsafe.withData
 import warlockfe.warlock3.core.client.WarlockSocket
-import warlockfe.warlock3.core.util.decodeWindows1252
 import warlockfe.warlock3.core.util.encodeWindows1252
-import warlockfe.warlock3.wrayth.util.openDefaultTlsSocket
-import kotlin.math.min
 
 class NetworkSocket(
-    private val dispatcher: CoroutineDispatcher,
-    // When true, wrap the connection in TLS (verifying the server cert against the system trust
-    // store). Used for the MUD Mobile router; the direct play.net game connection stays plaintext.
-    private val secure: Boolean = false,
+    dispatcher: CoroutineDispatcher,
 ) : WarlockSocket {
     private val logger = Logger.withTag("NetworkSocket")
     private val selector = SelectorManager(dispatcher)
     private var socket: Socket? = null
-    private var closeConnection: (() -> Unit)? = null
     private var closed = false
     private lateinit var sendChannel: ByteWriteChannel
     private lateinit var receiveChannel: ByteReadChannel
@@ -51,25 +33,12 @@ class NetworkSocket(
         host: String,
         port: Int,
     ) {
-        logger.d { "Connecting to $host:$port (secure=$secure)" }
+        logger.d { "Connecting to $host:$port" }
         try {
-            if (secure) {
-                val conn =
-                    openDefaultTlsSocket(
-                        selectorManager = selector,
-                        host = host,
-                        port = port,
-                        coroutineContext = dispatcher,
-                    )
-                receiveChannel = conn.readChannel
-                sendChannel = conn.writeChannel
-                closeConnection = conn.close
-            } else {
-                val tcpSocket = aSocket(selector).tcp().connect(host, port)
-                socket = tcpSocket
-                sendChannel = tcpSocket.openWriteChannel(autoFlush = true)
-                receiveChannel = tcpSocket.openReadChannel()
-            }
+            val tcpSocket = aSocket(selector).tcp().connect(host, port)
+            socket = tcpSocket
+            sendChannel = tcpSocket.openWriteChannel(autoFlush = true)
+            receiveChannel = tcpSocket.openReadChannel()
         } catch (e: Throwable) {
             close()
             throw e
@@ -77,67 +46,13 @@ class NetworkSocket(
     }
 
     override suspend fun readLine(): String? {
-        val result = StringBuilder()
-        val completed = readWindows1252LineTo(result)
-        return if (!completed) null else result.toString()
-    }
-
-    private suspend fun readWindows1252LineTo(
-        out: Appendable,
-        max: Int = Int.MAX_VALUE,
-    ): Boolean {
         check(::receiveChannel.isInitialized) { "Socket not connected" }
-        with(receiveChannel) {
-            if (exhausted()) return false
-            if (isClosedForRead) return false
-
-            Buffer().use { lineBuffer ->
-                while (!isClosedForRead) {
-                    while (!exhausted()) {
-                        when (val b = readByte()) {
-                            CR -> {
-                                // Check if LF follows CR after awaiting
-                                awaitContent()
-                                val nextByte = peek(1) ?: return true
-                                if (nextByte[0] == LF) {
-                                    discard(1)
-                                }
-                                out.append(lineBuffer.readWindows1252String())
-                                return true
-                            }
-
-                            LF -> {
-                                out.append(lineBuffer.readWindows1252String())
-                                return true
-                            }
-
-                            else -> {
-                                lineBuffer.writeByte(b)
-                            }
-                        }
-                    }
-                    if (lineBuffer.size >= max) {
-                        throw TooLongLineException("Line exceeds limit of $max characters")
-                    }
-
-                    awaitContent()
-                }
-
-                return (lineBuffer.size > 0).also { remaining ->
-                    if (remaining) {
-                        out.append(lineBuffer.readWindows1252String())
-                    }
-                }
-            }
-        }
+        return receiveChannel.readWindows1252Line()
     }
 
     override suspend fun readAvailable(min: Int): String? {
         check(::receiveChannel.isInitialized) { "Socket not connected" }
-        receiveChannel.awaitContent(min)
-        val len = receiveChannel.readAvailable(buffer)
-        if (len < 0) return null
-        return buffer.decodeWindows1252(0, len)
+        return receiveChannel.readWindows1252Available(buffer, min)
     }
 
     override fun ready(): Boolean {
@@ -154,34 +69,7 @@ class NetworkSocket(
     override fun close() {
         logger.d { "Closing connection" }
         closed = true
-        closeConnection?.invoke()
-        closeConnection = null
         socket?.close()
         selector.close()
     }
-}
-
-private const val CR: Byte = '\r'.code.toByte()
-private const val LF: Byte = '\n'.code.toByte()
-
-private fun Buffer.readWindows1252String(): String = readWindows1252(size)
-
-@OptIn(UnsafeIoApi::class)
-private fun Buffer.readWindows1252(byteCount: Long): String {
-    // Invariant: byteCount was request()'ed into this buffer beforehand
-    if (byteCount == 0L) return ""
-
-    UnsafeBufferOperations.forEachSegment(this) { ctx, segment ->
-        if (segment.size >= byteCount) {
-            var result: String
-            ctx.withData(segment) { data, pos, limit ->
-                result = data.decodeWindows1252(pos, min(limit, pos + byteCount.toInt()))
-                skip(byteCount)
-                return result
-            }
-        }
-        // If the string spans multiple segments, delegate to readBytes()
-        return readByteArray(byteCount.toInt()).decodeWindows1252()
-    }
-    error("Unreacheable")
 }

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WarlockWebSocket.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WarlockWebSocket.kt
@@ -1,0 +1,120 @@
+package warlockfe.warlock3.wrayth.network
+
+import co.touchlab.kermit.Logger
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.availableForRead
+import io.ktor.utils.io.writeFully
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import warlockfe.warlock3.core.client.WarlockSocket
+import warlockfe.warlock3.core.util.encodeWindows1252
+
+/**
+ * A [WarlockSocket] that carries the game stream over a WebSocket instead of a raw TCP socket.
+ *
+ * The MUD Mobile router serves both on the same port, and the protocol above the transport is
+ * identical: the first line is the game key, then bytes flow untouched in both directions. So
+ * everything above this class — the handshake, the parser, the client — is the same code either
+ * way. WebSocket is what iOS and a browser can actually reach, which is why the MUD Mobile path
+ * uses it rather than [NetworkSocket].
+ *
+ * [httpClient] must have the `WebSockets` plugin installed. Do not wrap this in a reconnect loop:
+ * after the key line the router holds the connection open while the cloud machine boots (~25-60s,
+ * up to ~105s), and reconnecting fights that hold.
+ */
+class WarlockWebSocket(
+    private val httpClient: HttpClient,
+    dispatcher: CoroutineDispatcher,
+    // False only for the router's plaintext endpoint (ws://); the API normally hands us tls=true.
+    private val secure: Boolean = true,
+) : WarlockSocket {
+    private val logger = Logger.withTag("WarlockWebSocket")
+    private val scope = CoroutineScope(dispatcher + SupervisorJob())
+
+    // Frames are a transport detail, never a message boundary: the game is one byte stream, so
+    // every frame's payload is appended here and read back exactly as a TCP stream is.
+    private val receiveChannel = ByteChannel(autoFlush = true)
+    private val buffer = ByteArray(4096)
+    private var session: DefaultClientWebSocketSession? = null
+    private var closed = false
+
+    // The stream being over is what callers mean by closed, and that is the receive channel running
+    // dry after the pump closed it — not the session's job finishing, which lands a moment later.
+    override val isClosed: Boolean
+        get() = closed || receiveChannel.isClosedForRead || session?.isActive == false
+
+    override suspend fun connect(
+        host: String,
+        port: Int,
+    ) {
+        val url = "${if (secure) "wss" else "ws"}://$host:$port/"
+        logger.d { "Connecting to $url" }
+        try {
+            val session = httpClient.webSocketSession(url)
+            this.session = session
+            scope.launch { receiveFrames(session) }
+        } catch (e: Throwable) {
+            close()
+            throw e
+        }
+    }
+
+    /** Drains the session's frames into [receiveChannel] until the peer or we close the connection. */
+    private suspend fun receiveFrames(session: DefaultClientWebSocketSession) {
+        try {
+            for (frame in session.incoming) {
+                when (frame) {
+                    is Frame.Binary -> receiveChannel.writeFully(frame.data)
+
+                    // The router sends binary, because windows-1252 is not valid UTF-8 and a text
+                    // frame is UTF-8 by definition. Decode one as that if it ever arrives, rather
+                    // than passing its bytes through as if they were the game's charset.
+                    is Frame.Text -> receiveChannel.writeFully(frame.readText().encodeWindows1252())
+
+                    // Ping, pong, and close are the session's business, not the game's.
+                    else -> Unit
+                }
+            }
+        } catch (e: Exception) {
+            logger.d(e) { "WebSocket read failed" }
+        } finally {
+            // EOF for whoever is reading: readLine()/readAvailable() return null and the client
+            // disconnects, exactly as when a TCP peer goes away.
+            receiveChannel.close()
+        }
+    }
+
+    override suspend fun readLine(): String? = receiveChannel.readWindows1252Line()
+
+    override suspend fun readAvailable(min: Int): String? = receiveChannel.readWindows1252Available(buffer, min)
+
+    override fun ready(): Boolean = receiveChannel.availableForRead > 0
+
+    override suspend fun write(text: String) {
+        val session = checkNotNull(session) { "Socket not connected" }
+        // Binary, not text: we already hold windows-1252 bytes, and raw high bytes in a text frame
+        // are invalid UTF-8, which drops the connection mid-session.
+        session.send(Frame.Binary(fin = true, data = text.encodeWindows1252()))
+        session.flush()
+    }
+
+    override fun close() {
+        logger.d { "Closing connection" }
+        closed = true
+        // Cancelling the session tears down the underlying connection; closing the channel wakes a
+        // reader that is waiting on bytes that are never coming now.
+        session?.cancel()
+        session = null
+        receiveChannel.close()
+        scope.cancel()
+    }
+}

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WarlockWebSocket.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/WarlockWebSocket.kt
@@ -13,10 +13,12 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.launch
+import kotlinx.io.IOException
 import warlockfe.warlock3.core.client.WarlockSocket
 import warlockfe.warlock3.core.util.encodeWindows1252
+import kotlin.concurrent.Volatile
 
 /**
  * A [WarlockSocket] that carries the game stream over a WebSocket instead of a raw TCP socket.
@@ -44,13 +46,21 @@ class WarlockWebSocket(
     // every frame's payload is appended here and read back exactly as a TCP stream is.
     private val receiveChannel = ByteChannel(autoFlush = true)
     private val buffer = ByteArray(4096)
+
+    // Written on whichever thread closes the socket and read from the frame pump and the client's
+    // read loop, so both are published rather than left to be seen whenever.
+    @Volatile
     private var session: DefaultClientWebSocketSession? = null
+
+    @Volatile
     private var closed = false
 
-    // The stream being over is what callers mean by closed, and that is the receive channel running
-    // dry after the pump closed it — not the session's job finishing, which lands a moment later.
+    // Only our own close counts, exactly as it does for a TCP socket. The peer going away is not
+    // reported here: a client reads until a read comes back null and calls its disconnected handler
+    // then, so a socket that reported itself closed the moment the stream ran dry would end that
+    // loop through its `while (!isClosed)` guard instead, and the disconnect would go unannounced.
     override val isClosed: Boolean
-        get() = closed || receiveChannel.isClosedForRead || session?.isActive == false
+        get() = closed
 
     override suspend fun connect(
         host: String,
@@ -93,28 +103,50 @@ class WarlockWebSocket(
         }
     }
 
-    override suspend fun readLine(): String? = receiveChannel.readWindows1252Line()
+    override suspend fun readLine(): String? {
+        checkConnected()
+        return receiveChannel.readWindows1252Line()
+    }
 
-    override suspend fun readAvailable(min: Int): String? = receiveChannel.readWindows1252Available(buffer, min)
+    override suspend fun readAvailable(min: Int): String? {
+        checkConnected()
+        return receiveChannel.readWindows1252Available(buffer, min)
+    }
 
-    override fun ready(): Boolean = receiveChannel.availableForRead > 0
+    override fun ready(): Boolean {
+        checkConnected()
+        return receiveChannel.availableForRead > 0
+    }
 
     override suspend fun write(text: String) {
         val session = checkNotNull(session) { "Socket not connected" }
-        // Binary, not text: we already hold windows-1252 bytes, and raw high bytes in a text frame
-        // are invalid UTF-8, which drops the connection mid-session.
-        session.send(Frame.Binary(fin = true, data = text.encodeWindows1252()))
-        session.flush()
+        // Writing to a socket that has gone away is an IOException here as it is on TCP, where the
+        // byte channel raises one. Callers already treat that as the connection being over; a raw
+        // channel exception would escape them instead.
+        if (closed) throw IOException("Socket is closed")
+        try {
+            // Binary, not text: we already hold windows-1252 bytes, and raw high bytes in a text
+            // frame are invalid UTF-8, which drops the connection mid-session.
+            session.send(Frame.Binary(fin = true, data = text.encodeWindows1252()))
+            session.flush()
+        } catch (e: ClosedSendChannelException) {
+            throw IOException("Socket is closed", e)
+        }
     }
 
     override fun close() {
         logger.d { "Closing connection" }
         closed = true
-        // Cancelling the session tears down the underlying connection; closing the channel wakes a
-        // reader that is waiting on bytes that are never coming now.
+        // Cancelling the session tears down the connection, which ends the pump. Waiting readers are
+        // woken by cancelling the channel rather than closing it: close() is a write-side operation
+        // that touches the same buffer the pump writes into, and this runs on whatever thread asked
+        // for the close. cancel() only trips an atomic, so the pump keeps sole ownership of the
+        // write side; with no cause it reads as a clean end of stream, so a waiting read returns
+        // null and the client disconnects the same way it does when the peer hangs up.
         session?.cancel()
-        session = null
-        receiveChannel.close()
+        receiveChannel.cancel(null)
         scope.cancel()
     }
+
+    private fun checkConnected() = checkNotNull(session) { "Socket not connected" }
 }

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/Windows1252Channel.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/Windows1252Channel.kt
@@ -1,0 +1,116 @@
+package warlockfe.warlock3.wrayth.network
+
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.charsets.TooLongLineException
+import io.ktor.utils.io.discard
+import io.ktor.utils.io.exhausted
+import io.ktor.utils.io.peek
+import io.ktor.utils.io.readAvailable
+import io.ktor.utils.io.readByte
+import kotlinx.io.Buffer
+import kotlinx.io.UnsafeIoApi
+import kotlinx.io.readByteArray
+import kotlinx.io.unsafe.UnsafeBufferOperations
+import kotlinx.io.unsafe.withData
+import warlockfe.warlock3.core.util.decodeWindows1252
+import kotlin.math.min
+
+// The game speaks windows-1252 over whichever transport it arrives on: a TCP socket for
+// [NetworkSocket], WebSocket frames for [WarlockWebSocket]. Both end up as a channel of exactly the
+// same bytes, so the decoding lives here rather than once per transport.
+
+/**
+ * Reads up to the next CR, LF, or CRLF, which is consumed but not returned. Returns null once the
+ * peer is gone and nothing is left; a final unterminated line is returned before that.
+ */
+internal suspend fun ByteReadChannel.readWindows1252Line(max: Int = Int.MAX_VALUE): String? {
+    val result = StringBuilder()
+    val completed = readWindows1252LineTo(result, max)
+    return if (!completed) null else result.toString()
+}
+
+private suspend fun ByteReadChannel.readWindows1252LineTo(
+    out: Appendable,
+    max: Int,
+): Boolean {
+    if (exhausted()) return false
+    if (isClosedForRead) return false
+
+    Buffer().use { lineBuffer ->
+        while (!isClosedForRead) {
+            while (!exhausted()) {
+                when (val b = readByte()) {
+                    CR -> {
+                        // Check if LF follows CR after awaiting
+                        awaitContent()
+                        val nextByte = peek(1) ?: return true
+                        if (nextByte[0] == LF) {
+                            discard(1)
+                        }
+                        out.append(lineBuffer.readWindows1252String())
+                        return true
+                    }
+
+                    LF -> {
+                        out.append(lineBuffer.readWindows1252String())
+                        return true
+                    }
+
+                    else -> {
+                        lineBuffer.writeByte(b)
+                    }
+                }
+            }
+            if (lineBuffer.size >= max) {
+                throw TooLongLineException("Line exceeds limit of $max characters")
+            }
+
+            awaitContent()
+        }
+
+        return (lineBuffer.size > 0).also { remaining ->
+            if (remaining) {
+                out.append(lineBuffer.readWindows1252String())
+            }
+        }
+    }
+}
+
+/**
+ * Reads whatever has arrived, waiting for at least [min] bytes, into [buffer]. Null once the peer is
+ * gone and there is nothing left to read, as with [readWindows1252Line].
+ */
+internal suspend fun ByteReadChannel.readWindows1252Available(
+    buffer: ByteArray,
+    min: Int,
+): String? {
+    awaitContent(min)
+    val len = readAvailable(buffer)
+    if (len < 0) return null
+    return buffer.decodeWindows1252(0, len)
+}
+
+private const val CR: Byte = '\r'.code.toByte()
+private const val LF: Byte = '\n'.code.toByte()
+
+private fun Buffer.readWindows1252String(): String = readWindows1252(size)
+
+@OptIn(UnsafeIoApi::class)
+private fun Buffer.readWindows1252(byteCount: Long): String {
+    // Invariant: byteCount was request()'ed into this buffer beforehand
+    if (byteCount == 0L) return ""
+
+    UnsafeBufferOperations.forEachSegment(this) { ctx, segment ->
+        if (segment.size >= byteCount) {
+            var result: String
+            ctx.withData(segment) { data, pos, limit ->
+                result = data.decodeWindows1252(pos, min(limit, pos + byteCount.toInt()))
+                skip(byteCount)
+                return result
+            }
+        }
+        // If the string spans multiple segments, delegate to readBytes()
+        return readByteArray(byteCount.toInt()).decodeWindows1252()
+    }
+    error("Unreacheable")
+}

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/Windows1252Channel.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/Windows1252Channel.kt
@@ -41,10 +41,9 @@ private suspend fun ByteReadChannel.readWindows1252LineTo(
             while (!exhausted()) {
                 when (val b = readByte()) {
                     CR -> {
-                        // CR is only half a terminator until the next byte says otherwise, so wait
-                        // for one. There may be none - the peer can hang up on the CR - and the line
-                        // it ended is still a line either way.
-                        awaitContent()
+                        // CR is only half a terminator until the next byte says otherwise, so look
+                        // for one - peek waits for it to arrive. There may be none, since the peer
+                        // can hang up on the CR, and the line it ended is still a line either way.
                         if (peek(1)?.get(0) == LF) {
                             discard(1)
                         }

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/Windows1252Channel.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/network/Windows1252Channel.kt
@@ -41,10 +41,11 @@ private suspend fun ByteReadChannel.readWindows1252LineTo(
             while (!exhausted()) {
                 when (val b = readByte()) {
                     CR -> {
-                        // Check if LF follows CR after awaiting
+                        // CR is only half a terminator until the next byte says otherwise, so wait
+                        // for one. There may be none - the peer can hang up on the CR - and the line
+                        // it ended is still a line either way.
                         awaitContent()
-                        val nextByte = peek(1) ?: return true
-                        if (nextByte[0] == LF) {
+                        if (peek(1)?.get(0) == LF) {
                             discard(1)
                         }
                         out.append(lineBuffer.readWindows1252String())

--- a/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.kt
+++ b/wrayth/src/commonMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.kt
@@ -17,15 +17,3 @@ expect suspend fun openPlainSocket(
     port: Int,
     coroutineContext: CoroutineContext,
 ): TLSSocketConnection
-
-/**
- * Opens a TLS socket that verifies the server certificate against the system's default trust store
- * (i.e. a normal CA-valid cert), unlike [openTLSSocket] which pins a custom certificate. Used for
- * the MUD Mobile router, whose edge presents a standard public certificate.
- */
-expect suspend fun openDefaultTlsSocket(
-    selectorManager: SelectorManager,
-    host: String,
-    port: Int,
-    coroutineContext: CoroutineContext,
-): TLSSocketConnection

--- a/wrayth/src/commonTest/kotlin/Windows1252ChannelTests.kt
+++ b/wrayth/src/commonTest/kotlin/Windows1252ChannelTests.kt
@@ -1,0 +1,70 @@
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.test.runTest
+import warlockfe.warlock3.wrayth.network.readWindows1252Available
+import warlockfe.warlock3.wrayth.network.readWindows1252Line
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+// The reads every game connection goes through, whichever transport delivered the bytes: a TCP
+// socket for NetworkSocket, WebSocket frames for WarlockWebSocket.
+class Windows1252ChannelTests {
+    private suspend fun channelOf(vararg bytes: Int) =
+        ByteChannel(autoFlush = true).also { channel ->
+            channel.writeFully(ByteArray(bytes.size) { bytes[it].toByte() })
+            channel.close()
+        }
+
+    private suspend fun channelOf(text: String) = channelOf(*text.map { it.code }.toIntArray())
+
+    @Test
+    fun linesAreSplitOnEitherTerminatorOrBoth() =
+        runTest {
+            val channel = channelOf("lf\ncr\rcrlf\r\nlast")
+
+            assertEquals("lf", channel.readWindows1252Line())
+            assertEquals("cr", channel.readWindows1252Line())
+            assertEquals("crlf", channel.readWindows1252Line())
+            assertEquals("last", channel.readWindows1252Line())
+        }
+
+    @Test
+    fun theEndOfTheStreamIsNullRatherThanAnEmptyLine() =
+        runTest {
+            val channel = channelOf("only line\n")
+
+            assertEquals("only line", channel.readWindows1252Line())
+            assertNull(channel.readWindows1252Line())
+        }
+
+    @Test
+    fun anEmptyLineIsStillALine() =
+        runTest {
+            val channel = channelOf("\n\n")
+
+            assertEquals("", channel.readWindows1252Line())
+            assertEquals("", channel.readWindows1252Line())
+            assertNull(channel.readWindows1252Line())
+        }
+
+    @Test
+    fun highBytesDecodeAsWindows1252RatherThanLatin1() =
+        runTest {
+            // 0x97 and 0x92 are an em dash and a right quote in windows-1252; in latin-1 - which is
+            // what a byte-for-byte pass-through would give - they are unprintable controls.
+            val channel = channelOf('a'.code, 0x97, 'b'.code, 0x92, 's'.code, '\n'.code)
+
+            assertEquals("a—b’s", channel.readWindows1252Line())
+        }
+
+    @Test
+    fun readAvailableTakesWhateverArrivedAndThenReportsTheEnd() =
+        runTest {
+            val channel = channelOf("half a li")
+            val buffer = ByteArray(4096)
+
+            assertEquals("half a li", channel.readWindows1252Available(buffer, min = 1))
+            assertNull(channel.readWindows1252Available(buffer, min = 1))
+        }
+}

--- a/wrayth/src/commonTest/kotlin/Windows1252ChannelTests.kt
+++ b/wrayth/src/commonTest/kotlin/Windows1252ChannelTests.kt
@@ -49,6 +49,17 @@ class Windows1252ChannelTests {
         }
 
     @Test
+    fun aLineTheStreamEndsRightAfterACarriageReturnIsStillReturned() =
+        runTest {
+            // CR is only half a terminator until the next byte says otherwise, and here there is no
+            // next byte: the peer hung up on the CR. The line before it is still a line.
+            val channel = channelOf("text\r")
+
+            assertEquals("text", channel.readWindows1252Line())
+            assertNull(channel.readWindows1252Line())
+        }
+
+    @Test
     fun highBytesDecodeAsWindows1252RatherThanLatin1() =
         runTest {
             // 0x97 and 0x92 are an em dash and a right quote in windows-1252; in latin-1 - which is

--- a/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
+++ b/wrayth/src/iosMain/kotlin/warlockfe/warlock3/wrayth/util/SocketHelpers.ios.kt
@@ -120,16 +120,6 @@ actual suspend fun openPlainSocket(
     coroutineContext: CoroutineContext,
 ): TLSSocketConnection = openNetworkSocket(host, port, coroutineContext, useTls = false)
 
-actual suspend fun openDefaultTlsSocket(
-    selectorManager: SelectorManager,
-    host: String,
-    port: Int,
-    coroutineContext: CoroutineContext,
-): TLSSocketConnection =
-    // No TLS configuration of our own, so the system evaluates the chain against its own trust
-    // store -- which is what the MUD Mobile edge needs; it presents an ordinary public certificate.
-    openNetworkSocket(host, port, coroutineContext, useTls = true)
-
 actual suspend fun openTLSSocket(
     selectorManager: SelectorManager,
     host: String,

--- a/wrayth/src/jvmTest/kotlin/WarlockWebSocketTests.kt
+++ b/wrayth/src/jvmTest/kotlin/WarlockWebSocketTests.kt
@@ -1,0 +1,127 @@
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.server.application.install
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.Frame
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import warlockfe.warlock3.wrayth.network.WarlockWebSocket
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import io.ktor.server.cio.CIO as ServerCIO
+import io.ktor.server.websocket.WebSockets as ServerWebSockets
+
+// The MUD Mobile transport, against a real WebSocket server. What matters is that the game's byte
+// stream survives the trip in both directions: frames are not message boundaries, and the bytes are
+// windows-1252 rather than the UTF-8 a text frame would imply.
+class WarlockWebSocketTests {
+    /**
+     * Serves a WebSocket that pushes [push], one frame each, then either waits for the client
+     * ([keepOpen]) or hangs up. [firstReceived] completes with the first frame the client sends.
+     */
+    private fun withServer(
+        push: List<ByteArray> = emptyList(),
+        keepOpen: Boolean = true,
+        pushAfterMillis: Long = 0,
+        test: suspend (socket: WarlockWebSocket, firstReceived: CompletableDeferred<Frame>) -> Unit,
+    ) = runBlocking {
+        val firstReceived = CompletableDeferred<Frame>()
+        val server =
+            embeddedServer(ServerCIO, port = 0) {
+                install(ServerWebSockets)
+                routing {
+                    webSocket("/") {
+                        if (pushAfterMillis > 0) delay(pushAfterMillis)
+                        push.forEach { send(Frame.Binary(fin = true, data = it)) }
+                        if (keepOpen) {
+                            for (frame in incoming) firstReceived.complete(frame)
+                        }
+                    }
+                }
+            }.start(wait = false)
+        val client =
+            HttpClient(CIO) {
+                install(WebSockets)
+                // Mirrors the app's client (see AppContainer), with the bound made small enough to
+                // fail this test in seconds if it ever started applying to the game stream.
+                install(HttpTimeout) { requestTimeoutMillis = REQUEST_TIMEOUT_MILLIS }
+            }
+        val socket = WarlockWebSocket(client, Dispatchers.IO, secure = false)
+        try {
+            val port =
+                server.engine
+                    .resolvedConnectors()
+                    .first()
+                    .port
+            socket.connect("127.0.0.1", port)
+            test(socket, firstReceived)
+        } finally {
+            socket.close()
+            client.close()
+            server.stop(gracePeriodMillis = 0, timeoutMillis = 1000)
+        }
+    }
+
+    @Test
+    fun whatIsWrittenLeavesAsWindows1252BytesInABinaryFrame() =
+        withServer { socket, firstReceived ->
+            socket.write("say —\n")
+
+            val frame = firstReceived.await()
+            assertTrue(frame is Frame.Binary, "the game stream is not UTF-8, so it must not be a text frame")
+            // 0x97 is the em dash in windows-1252; UTF-8 would have made it three bytes.
+            assertContentEquals(
+                "say ".encodeToByteArray() + byteArrayOf(0x97.toByte(), '\n'.code.toByte()),
+                frame.data,
+            )
+        }
+
+    @Test
+    fun whatArrivesIsReadBackAsLinesNoMatterHowItWasFramed() {
+        val push =
+            listOf(
+                // One line split across two frames, the second of which also carries a whole line.
+                "<pushBold/>You see a ".encodeToByteArray(),
+                byteArrayOf(0x97.toByte()) + "wolf<popBold/>\r\nand a rock\r\n".encodeToByteArray(),
+            )
+        withServer(push = push) { socket, _ ->
+            assertEquals("<pushBold/>You see a —wolf<popBold/>", socket.readLine())
+            assertEquals("and a rock", socket.readLine())
+        }
+    }
+
+    @Test
+    fun theApiRequestTimeoutDoesNotReachTheGameStream() {
+        // The router holds a connection for up to ~105s while the cloud machine boots, and a bridged
+        // session is then legitimately idle for long stretches. Ktor exempts WebSocket requests from
+        // the request timeout in both the plugin and the CIO engine; this is that promise, tested.
+        withServer(
+            push = listOf("late\r\n".encodeToByteArray()),
+            pushAfterMillis = REQUEST_TIMEOUT_MILLIS * 4,
+        ) { socket, _ ->
+            assertEquals("late", socket.readLine())
+        }
+    }
+
+    @Test
+    fun theServerHangingUpEndsTheStreamRatherThanHanging() {
+        withServer(push = listOf("bye\r\n".encodeToByteArray()), keepOpen = false) { socket, _ ->
+            assertEquals("bye", socket.readLine())
+            assertNull(socket.readLine())
+            assertTrue(socket.isClosed)
+        }
+    }
+
+    private companion object {
+        const val REQUEST_TIMEOUT_MILLIS = 250L
+    }
+}

--- a/wrayth/src/jvmTest/kotlin/WarlockWebSocketTests.kt
+++ b/wrayth/src/jvmTest/kotlin/WarlockWebSocketTests.kt
@@ -11,10 +11,14 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.IOException
 import warlockfe.warlock3.wrayth.network.WarlockWebSocket
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import io.ktor.server.cio.CIO as ServerCIO
@@ -76,7 +80,7 @@ class WarlockWebSocketTests {
         withServer { socket, firstReceived ->
             socket.write("say —\n")
 
-            val frame = firstReceived.await()
+            val frame = withTimeout(AWAIT_TIMEOUT_MILLIS) { firstReceived.await() }
             assertTrue(frame is Frame.Binary, "the game stream is not UTF-8, so it must not be a text frame")
             // 0x97 is the em dash in windows-1252; UTF-8 would have made it three bytes.
             assertContentEquals(
@@ -117,11 +121,38 @@ class WarlockWebSocketTests {
         withServer(push = listOf("bye\r\n".encodeToByteArray()), keepOpen = false) { socket, _ ->
             assertEquals("bye", socket.readLine())
             assertNull(socket.readLine())
+        }
+    }
+
+    @Test
+    fun theServerHangingUpDoesNotReportTheSocketClosed() {
+        // A client reads until a read returns null and announces the disconnect there. It also loops
+        // on `while (!socket.isClosed)`, so a socket that called itself closed as soon as the stream
+        // ran dry would end that loop first and the disconnect would never be announced - no message,
+        // no reconnect banner, no teardown. Closed means we closed it, as it does for a TCP socket.
+        withServer(push = listOf("bye\r\n".encodeToByteArray()), keepOpen = false) { socket, _ ->
+            assertEquals("bye", socket.readLine())
+            assertNull(socket.readLine())
+            assertFalse(socket.isClosed, "the peer hanging up is not this socket being closed")
+
+            socket.close()
             assertTrue(socket.isClosed)
+        }
+    }
+
+    @Test
+    fun writingToAClosedSocketRaisesIoExceptionAsItDoesOnTcp() {
+        // WraythClient's write path catches IOException and reports the failed command; anything else
+        // escapes it and takes the caller down with it - which is what stopped a window from closing.
+        withServer { socket, _ ->
+            socket.close()
+
+            assertFailsWith<IOException> { socket.write("say hello\n") }
         }
     }
 
     private companion object {
         const val REQUEST_TIMEOUT_MILLIS = 250L
+        const val AWAIT_TIMEOUT_MILLIS = 10_000L
     }
 }


### PR DESCRIPTION
MUD Mobile's router now serves WebSocket alongside raw TCP on the same port ([router #3](https://github.com/sproctor/mud-mobile/pull/3)), and this takes Warlock over to it, so Desktop, Android, and iOS all reach the game through one code path instead of iOS needing a second implementation of the same connection.

## Carry the game stream over a WebSocket

Nothing above the socket changes: the protocol over the two transports is identical — key line first, then bytes untouched — so the handshake, the parser, and the client are the same either way. `WarlockWebSocket` is a `WarlockSocket` like `NetworkSocket`, and the two now share the windows-1252 reads that used to live inside `NetworkSocket`.

- Frames are never a message boundary. The game is one byte stream, so each frame's payload is appended to a channel and read back exactly as a TCP stream is.
- Both directions are binary. windows-1252 is not valid UTF-8 and a text frame is UTF-8 by definition, so raw high bytes in one are corrupted or close the connection with 1007 mid-session.
- No new jar: the WebSockets plugin ships inside `ktor-client-core`, which the REST API client already pulls in.
- No reconnect loop, and no request timeout. Neither the timeout plugin nor the CIO engine applies one to a WebSocket, which is what lets the router hold the connection through the cloud machine's ~25–105s cold boot.

`openDefaultTlsSocket` and its three implementations go with the old path — the router was their only caller. That includes the hand-written SecureTransport socket that existed because Ktor's TCP+TLS could not do this on iOS.

## Report a failed connect

Connecting while MUD Mobile was down looked like a hang: the connecting dialog sat on "Starting your cloud session…" for two request timeouts back to back, closed itself, and left the reason as a line of text on the dashboard behind it. A failed attempt now opens a **Connection failed** dialog with the reason and an OK, and stays up until it is acknowledged. Direct logins use it too — their reason was only rendered after the attempt ended.

The wait ahead of it is shorter: the character-profile upsert is a nicety for the picker, so it runs after the session call rather than before it, and an unreachable service costs one timeout rather than two. API calls are now bounded explicitly rather than by the engine default that logged `request_timeout=unknown ms`.

## Close the window even if teardown throws

A throw from the "quit" the view model sends on close took the window with it — the close never reached the point of removing the game, so each further attempt just tried again.

## Testing

`./gradlew check -PlintSkip=true` green, **including the iOS targets** (`iosSkip` defaults to false since #293), so the transport this change is for is covered by the ordinary check.

New tests: 5 over the shared windows-1252 decoder, and 4 driving `WarlockWebSocket` against a real embedded WebSocket server — the round trip stays windows-1252 in both directions, framing does not leak into what the client reads, a hangup ends the stream, and the API request timeout does not reach the game stream. That last one is the guard on this PR's riskiest interaction; writing it turned up a real defect, where `isClosed` was keyed on the session's job finishing rather than the stream ending, and briefly reported a dead connection as live.

Not verified by me: the Connection failed dialog on screen, which needs a failing login against a real account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent connection-failure dialogs for direct and MUD Mobile connections, displaying the reason until dismissed.
  * Improved MUD Mobile router connectivity with WebSockets, secure connections, and binary data handling.
* **Bug Fixes**
  * Session setup no longer waits for profile refresh, improving connection responsiveness.
  * Added connection and request timeouts for more predictable failures.
  * Improved cleanup when closing game windows or connections encounters errors.
  * Improved Windows-1252 text handling and disconnected-stream behavior.
  * Long alert messages can now be scrolled.
* **Documentation**
  * Updated dashboard and MUD Mobile integration specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->