### PR TITLE
Stop spending 27 minutes to build the iOS app

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,14 +77,14 @@ jobs:
             **/build/test-results/**
           if-no-files-found: ignore
 
-  # The Linux job above builds with -PiosSkip=true, because it cannot compile Apple targets. That
-  # left the iOS build unexercised, and it rotted: JVM-only calls reached commonMain, the Xcode
-  # build phase stopped passing -PiosSkip=false, and the IDE build path silently shipped an app
-  # with no Compose resources. This job is what catches that class of breakage.
-  ios:
-    name: Build iOS app
+  # Runs the shared commonTest suites against the Kotlin/Native target, which the Linux job only
+  # ever runs on the JVM. Separate from the app build below rather than a step in it: the two share
+  # no outputs - one compiles for the simulator, the other for a device - so sequencing them only
+  # added their times together.
+  ios-tests:
+    name: Run iOS tests
     runs-on: macos-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
@@ -100,26 +100,8 @@ jobs:
         with:
           cache-provider: basic
 
-      # Runs the shared commonTest suites against the Kotlin/Native target, which the Linux job
-      # only ever runs on the JVM.
       - name: iOS tests
         run: ./gradlew iosSimulatorArm64Test -PiosSkip=false -PlintSkip=true --stacktrace
-
-      # The whole chain the Gradle tasks alone do not cover: the Xcode build phase, the Compose
-      # resource sync into the bundle, Swift Package resolution for Sentry, and linking the app.
-      # Unsigned, so it needs no certificates.
-      #
-      # Release, not Debug: the Sentry startup in iOSApp.swift sits behind `#if !DEBUG`, so a Debug
-      # build never compiles it. That is not hypothetical -- a Sentry API change broke exactly that
-      # call and a Debug build stayed green.
-      - name: Build the app with Xcode
-        run: |
-          xcodebuild -project iosApp/iosApp.xcodeproj \
-            -scheme iosApp \
-            -configuration Release \
-            -destination 'generic/platform=iOS' \
-            CODE_SIGNING_ALLOWED=NO \
-            build
 
       - name: Upload iOS test reports
         if: always()
@@ -131,3 +113,51 @@ jobs:
             **/build/reports/tests/**
             **/build/test-results/**
           if-no-files-found: ignore
+
+  # The Linux job above builds with -PiosSkip=true, because it cannot compile Apple targets. That
+  # left the iOS build unexercised, and it rotted: JVM-only calls reached commonMain, the Xcode
+  # build phase stopped passing -PiosSkip=false, and the IDE build path silently shipped an app
+  # with no Compose resources. This job is what catches that class of breakage.
+  ios:
+    name: Build iOS app
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JBR
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'jetbrains'
+          java-version: '25'
+
+      # See the note on cache-provider in the build job.
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
+
+      # The whole chain the Gradle tasks alone do not cover: the Xcode build phase, the Compose
+      # resource sync into the bundle, Swift Package resolution for Sentry, and linking the app.
+      # Unsigned, so it needs no certificates.
+      #
+      # Release, not Debug: the Sentry startup in iOSApp.swift sits behind `#if !DEBUG`, so a Debug
+      # build never compiles it. That is not hypothetical -- a Sentry API change broke exactly that
+      # call and a Debug build stayed green.
+      #
+      # The Kotlin framework is the exception, via KOTLIN_FRAMEWORK_CONFIGURATION (see
+      # Config.xcconfig). Linking it optimized took about three quarters of this job - 18 of its 27
+      # minutes - and proves nothing about the Swift half that Release is here for. What is left is
+      # everything this job was added to catch: that commonMain still compiles for iOS, that the
+      # build phase runs, that the resources land, and that the app links. Release-only Kotlin/Native
+      # link failures are what this gives up; no workflow builds those, so they surface when the app
+      # is archived in Xcode, which follows the app's configuration like any other local build.
+      - name: Build the app with Xcode
+        run: |
+          xcodebuild -project iosApp/iosApp.xcodeproj \
+            -scheme iosApp \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            KOTLIN_FRAMEWORK_CONFIGURATION=Debug \
+            build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Nothing here writes to the repository; it checks out, builds, and uploads artifacts (which use
+# their own runtime token). Without this the jobs take whatever the repository default is.
+permissions:
+  contents: read
+
 env:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
@@ -19,6 +24,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up JBR
         uses: actions/setup-java@v5
@@ -87,6 +94,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up JBR
         uses: actions/setup-java@v5
@@ -124,6 +133,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up JBR
         uses: actions/setup-java@v5

--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -5,3 +5,10 @@ PRODUCT_BUNDLE_IDENTIFIER=warlockfe.warlock3
 
 CURRENT_PROJECT_VERSION=1
 MARKETING_VERSION=1.0
+
+// What the Kotlin framework is built as. It follows the Xcode configuration, so a Release build of
+// the app links a Release framework, and nothing changes for a developer or an archive. CI passes
+// Debug on the xcodebuild command line: it builds the app Release for the Swift half - the Sentry
+// startup sits behind `#if !DEBUG` - but an optimized Kotlin framework proves nothing there, and
+// linking it takes about three quarters of the job.
+KOTLIN_FRAMEWORK_CONFIGURATION = $(CONFIGURATION)

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -161,7 +161,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\n# Without set -e a failed sync still reaches `exit 0`, Xcode calls the phase a success, and\n# the app ships with missing Compose resources -- the exact bug this branch fixes.\nset -e\nif [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  # The IDE (IntelliJ/Android Studio) builds and embeds the framework itself, so the\n  # embedAndSign task is skipped -- but nothing else copies the Compose resources into\n  # the bundle, and the app crashes on the first Res.readBytes. Run just that task.\n  ./gradlew :compose:syncComposeResourcesForIos -PiosSkip=false\n  exit 0\nfi\n./gradlew :compose:embedAndSignAppleFrameworkForXcode -PiosSkip=false\n";
+			shellScript = "cd \"$SRCROOT/..\"\n# Without set -e a failed sync still reaches `exit 0`, Xcode calls the phase a success, and\n# the app ships with missing Compose resources -- the exact bug this branch fixes.\nset -e\nif [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  # The IDE (IntelliJ/Android Studio) builds and embeds the framework itself, so the\n  # embedAndSign task is skipped -- but nothing else copies the Compose resources into\n  # the bundle, and the app crashes on the first Res.readBytes. Run just that task.\n  ./gradlew :compose:syncComposeResourcesForIos -PiosSkip=false\n  exit 0\nfi\n# The Kotlin plugin takes its build type from $CONFIGURATION, so this is how the framework\n# follows KOTLIN_FRAMEWORK_CONFIGURATION (see Config.xcconfig) rather than the app's own\n# configuration. Unset, they are the same thing.\nCONFIGURATION=${KOTLIN_FRAMEWORK_CONFIGURATION:-$CONFIGURATION} ./gradlew :compose:embedAndSignAppleFrameworkForXcode -PiosSkip=false\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -309,7 +309,7 @@
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../compose/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+					"$(SRCROOT)/../compose/build/xcode-frameworks/$(KOTLIN_FRAMEWORK_CONFIGURATION)/$(SDK_NAME)",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
@@ -345,7 +345,7 @@
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../compose/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+					"$(SRCROOT)/../compose/build/xcode-frameworks/$(KOTLIN_FRAMEWORK_CONFIGURATION)/$(SDK_NAME)",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;


### PR DESCRIPTION
The `Build iOS app` job takes ~27 minutes and gates every PR. Profiled on a green run ([job 96215348082](https://github.com/sproctor/warlock3/actions/runs/32298435042)):

| phase | time |
|---|---|
| `iosSimulatorArm64Test` | 6m 20s |
| xcodebuild startup + Swift Package resolution | 1m 20s |
| **"Compile Kotlin Framework" phase** (`:compose:embedAndSignAppleFrameworkForXcode`) | **17m 53s** |
| Swift compile + link the app | 25s |

Xcode is not the slow part. It's `:compose:linkReleaseFrameworkIosArm64`, on a runner the log describes as having three processors. The `core` and `scripting` klibs already come back `FROM-CACHE`, so the Gradle cache is doing its job; link tasks aren't cacheable.

## Run the tests in their own job

They compile for the simulator; the app build compiles for a device. No shared outputs, so sequencing them only added their times together. Same runner minutes, ~7 minutes off the wall clock.

## Build the Kotlin framework as Debug in CI

`KOTLIN_FRAMEWORK_CONFIGURATION` (new, in `Config.xcconfig`) defaults to `$(CONFIGURATION)`, so a developer's build and an archive are unchanged — only CI passes `Debug` on the xcodebuild command line.

The app is still built **Release**, which is the reason Release was chosen: the Sentry startup in `iOSApp.swift` is behind `#if !DEBUG`, and a Debug build of the app never compiles it. An *unoptimized Kotlin framework* has no bearing on that. What the job was added to catch is all still caught — commonMain compiling for iOS, the build phase running, the Compose resources landing in the bundle, the app linking.

It has to reach two places to stay consistent, which is why the diff touches the project file:
- the Kotlin plugin reads its build type from `$CONFIGURATION`, so the script phase passes the override through to Gradle;
- `FRAMEWORK_SEARCH_PATHS` interpolates the configuration into the path it looks in, so it has to look where Gradle was told to write.

**Given up:** Release-only Kotlin/Native link failures. No workflow builds those today (the release workflow builds Android and desktop only), so they surface when the app is archived in Xcode.

## Verification

The pbxproj edit is checked structurally (quoted strings all close, braces balance) but I have no macOS here — **this PR's own CI run is the test**. If `Build iOS app` goes green and lands well under 27 minutes, the wiring is right; if the framework search path and the script phase disagree, it fails at the app link step, loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added dedicated macOS testing for iOS simulator coverage.
  - Test reports are now uploaded separately for improved visibility.
  - Streamlined iOS validation by removing duplicate test and reporting steps.

- **Chores**
  - Improved consistency between iOS app and framework build configurations.
  - Reduced the iOS build job timeout to 45 minutes.
  - Added clearer documentation for iOS build configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->