### PR TITLE
Take lua-kmp 0.1.1 for its 16 KB page size fix

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ ksp = "2.3.11"
 ktlint-gradle = "14.2.0"
 ktlint-compose-rules = "0.6.4"
 ktor = "3.5.2"
-lua-kmp = "0.1.0"
+lua-kmp = "0.1.1"
 lwjgl = "3.4.2"
 # Also arrives transitively via Coil; pinned here because ZipReader depends on it directly.
 okio = "3.17.0"


### PR DESCRIPTION
> [!IMPORTANT]
> Draft: blocked on sproctor/lua-kmp#11 being merged and released to Maven Central. Until then `com.seanproctor:lua-kmp:0.1.1` does not resolve and CI will fail.

## Why

lua-kmp 0.1.0 shipped `libluakmp.so` with 4 KB-aligned `LOAD` segments. 64-bit Android 15+ devices run a 16 KB page size and refuse to `dlopen` a library aligned below it, so the app fails on those devices.

It was the only offender of the five native libraries the app packages:

```
arm64-v8a / x86_64            LOAD align
  libandroidx.graphics.path.so   0x4000  ok
  libsentry.so / -android.so     0x4000  ok
  libsqliteJni.so                0x4000  ok
  libluakmp.so                   0x1000  <- 4 KB
```

Zip-level alignment in the APK was already fine (`zipalign -c -P 16` passes), so this was purely ELF segment alignment.

## What changed

One line. 0.1.1 also splits the JNI binaries into a second coordinate, `com.seanproctor:lua-kmp-android-jni`, but that resolves transitively through `lua-kmp-android`, so nothing else here needs to move.

## Verified

Built against 0.1.1 from mavenLocal: the app resolves `lua-kmp -> lua-kmp-android -> lua-kmp-android-jni`, and every 64-bit `.so` in the merged native libs is `0x4000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)