### PR TITLE
Build CI under Temurin, and stop making it fetch a JetBrains Runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,12 @@ permissions:
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+  # Nothing here runs or packages the desktop app, so it does not need JetBrains Runtime - and
+  # asking for one made every job depend on setup-java's JBR lookup, an unauthenticated GitHub API
+  # call rate-limited per runner IP that was failing roughly a quarter of the time. Set as an
+  # ORG_GRADLE_PROJECT_ env var rather than a -P flag so it also reaches the Gradle that the Xcode
+  # build phase starts, which this workflow does not invoke directly.
+  ORG_GRADLE_PROJECT_jbrSkip: "true"
 
 jobs:
   build:
@@ -27,11 +33,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up JBR
+      - name: Set up Java
         uses: actions/setup-java@v5
         with:
-          distribution: 'jetbrains'
-          java-version: '25'
+          distribution: 'temurin'
+          java-version: '21'
 
       # cache-provider: basic is required, not a tuning knob. v6 extracted caching into
       # gradle-actions-caching, a proprietary component outside the action's MIT license whose
@@ -97,11 +103,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up JBR
+      - name: Set up Java
         uses: actions/setup-java@v5
         with:
-          distribution: 'jetbrains'
-          java-version: '25'
+          distribution: 'temurin'
+          java-version: '21'
 
       # See the note on cache-provider in the build job.
       - name: Setup Gradle
@@ -136,11 +142,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up JBR
+      - name: Set up Java
         uses: actions/setup-java@v5
         with:
-          distribution: 'jetbrains'
-          java-version: '25'
+          distribution: 'temurin'
+          java-version: '21'
 
       # See the note on cache-provider in the build job.
       - name: Setup Gradle

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -84,15 +84,25 @@ tasks.withType<AbstractComposeHotRun>().configureEach {
     javaLauncher = jbrRuntime
 }
 
+// Potassium's javaHome is a plain String, so reading it resolves the JBR toolchain during
+// configuration - on every build that configures this project, whether or not it will ever run or
+// package the app. That made a JBR install a prerequisite for merely compiling, so CI had to fetch
+// one for all three jobs, and setup-java resolves JBR through an unauthenticated GitHub API call
+// that is rate-limited per runner IP. CI passes -PjbrSkip=true and builds under Temurin instead;
+// nothing it runs packages the app. Anything that does package needs a real JBR, so leave it unset.
+val skipJbr = (findProperty("jbrSkip") as? String)?.toBoolean() == true
+
 potassium {
     mainClass = "warlockfe.warlock3.app.MainKt"
 
     // Run + package under JBR 25 even though the rest of the build uses
     // Temurin 21 (see toolchain config above).
-    javaHome =
-        jbrRuntime
-            .get()
-            .metadata.installationPath.asFile.absolutePath
+    if (!skipJbr) {
+        javaHome =
+            jbrRuntime
+                .get()
+                .metadata.installationPath.asFile.absolutePath
+    }
 
     // SQLite calls a restricted method
     jvmArgs += "--enable-native-access=ALL-UNNAMED"

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -3,6 +3,7 @@ import com.seanproctor.potassium.dsl.MacOSTargetFormat
 import com.seanproctor.potassium.dsl.ReleaseChannel
 import com.seanproctor.potassium.dsl.ReleaseType
 import com.seanproctor.potassium.dsl.WindowsTargetFormat
+import com.seanproctor.potassium.tasks.AbstractPotassiumTask
 import org.jetbrains.compose.reload.gradle.AbstractComposeHotRun
 
 plugins {
@@ -76,6 +77,16 @@ val jbrRuntime =
         vendor = JvmVendorSpec.JETBRAINS
     }
 
+// Potassium's javaHome is a plain String, so reading it resolves the JBR toolchain during
+// configuration - on every build that configures this project, whether or not it will ever run or
+// package the app. That made a JBR install a prerequisite for merely compiling, so CI had to fetch
+// one for all three jobs, and setup-java resolves JBR through a GitHub API call that goes out
+// unauthenticated unless GITHUB_TOKEN is in the environment, rate-limited per runner IP.
+//
+// CI sets ORG_GRADLE_PROJECT_jbrSkip (not -PjbrSkip, which would not reach the Gradle that the
+// Xcode build phase starts) and builds under Temurin instead. Nothing it runs packages the app.
+val skipJbr = (findProperty("jbrSkip") as? String)?.toBoolean() == true
+
 // Compose Hot Reload launches the app itself, and defaults to whatever JetBrains Runtime it
 // finds rather than the one the app is built against - which lands on JBR 21 here and dies with
 // "JewelTheme has been compiled by a more recent version of the Java Runtime (class file 69.0)".
@@ -84,13 +95,21 @@ tasks.withType<AbstractComposeHotRun>().configureEach {
     javaLauncher = jbrRuntime
 }
 
-// Potassium's javaHome is a plain String, so reading it resolves the JBR toolchain during
-// configuration - on every build that configures this project, whether or not it will ever run or
-// package the app. That made a JBR install a prerequisite for merely compiling, so CI had to fetch
-// one for all three jobs, and setup-java resolves JBR through an unauthenticated GitHub API call
-// that is rate-limited per runner IP. CI passes -PjbrSkip=true and builds under Temurin instead;
-// nothing it runs packages the app. Anything that does package needs a real JBR, so leave it unset.
-val skipJbr = (findProperty("jbrSkip") as? String)?.toBoolean() == true
+// Left unset, potassium's javaHome silently falls back to the JVM Gradle is running on, so a
+// packaging task under this flag would build an installer around Temurin 21 for an app compiled to
+// class file 69 and die on launch for every user - the v3.1.0-beta.21 failure. Refuse instead of
+// shipping that, since the flag exists only so builds that never touch the app can skip the JBR.
+if (skipJbr) {
+    tasks.withType<AbstractPotassiumTask>().configureEach {
+        doFirst {
+            error(
+                "$name runs or packages the desktop app, which must happen under JBR 25, but " +
+                    "jbrSkip left potassium's javaHome unset. Drop -PjbrSkip / " +
+                    "ORG_GRADLE_PROJECT_jbrSkip for anything that runs or packages the app.",
+            )
+        }
+    }
+}
 
 potassium {
     mainClass = "warlockfe.warlock3.app.MainKt"


### PR DESCRIPTION
## The failure

The `Set up JBR` step was failing roughly a quarter of the time:

```
##[error]Java setup process failed due to: API rate limit exceeded for 13.105.49.125.
```

`actions/setup-java`'s `jetbrains` distribution **always** lists every JBR release from `api.github.com/repos/JetBrains/JetBrainsRuntime/releases?per_page=100` to resolve a version — there is no short-circuit for a fully-qualified one, so pinning an exact version would not have helped.

In v5 it authenticates that request from the **`GITHUB_TOKEN` environment variable**, *not* from the `token` input:

```typescript
const requestHeaders: OutgoingHttpHeaders = {};
if (bearerToken) {
  requestHeaders['Authorization'] = `Bearer ${bearerToken}`;
}
```

That is why the step log shows `token: ***` and the request still went out unauthenticated — the error names an IP rather than a user, which is the per-IP limit, and hosted runners share addresses.

`release.yaml` already sets `GITHUB_TOKEN` at the job level, so releases were never exposed to this. `ci.yaml` set nothing.

## Why not just add the env var

That would have worked, but nothing CI runs needs JBR at all. Compilation happens under the Temurin 21 toolchain; JBR is a runtime and packaging concern. Authenticating would have kept a JBR download on the critical path of every job for no reason.

The reason all three jobs installed one is that potassium's `javaHome` is a plain `String`, not a lazy `Property`, so assigning it resolves the JBR toolchain **while `:desktopApp` is being configured** — which every Gradle invocation does, including the two iOS jobs that never build the desktop app.

## The change

- `-PjbrSkip=true` leaves `javaHome` unset, following the existing `-PiosSkip` / `-PlintSkip` idiom.
- CI installs **Temurin 21** instead of JBR 25, in all three jobs.
- The flag is set via `ORG_GRADLE_PROJECT_jbrSkip` at workflow level rather than as a `-P` flag, because the `Build iOS app` job reaches Gradle through `xcodebuild`'s build phase, which this workflow never invokes directly.

Local builds and `release.yaml` are untouched: both still resolve and package under JBR.

## Verification

Proved the gate rather than assuming it. Temporarily changing the request to an unsatisfiable `JavaLanguageVersion.of(99)`:

- without the flag — `Cannot find a Java installation ... matching: {languageVersion=99, vendor=JetBrains ...}`
- with `ORG_GRADLE_PROJECT_jbrSkip=true` — configures cleanly

With JBR 25 restored, `check -PiosSkip=true -PlintSkip=true` passes both with and without the flag, and `:desktopApp:createDistributable` still resolves JBR when the flag is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
