### PR TITLE
Keep a busy system clipboard from crashing the desktop app

### DIFF
--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/ui/game/GameViewModel.kt
@@ -70,6 +70,7 @@ import warlockfe.warlock3.compose.ui.window.WindowSelectionController
 import warlockfe.warlock3.compose.ui.window.WindowUiState
 import warlockfe.warlock3.compose.ui.window.getStyle
 import warlockfe.warlock3.compose.util.LatestValueWriter
+import warlockfe.warlock3.compose.util.SafeClipboard
 import warlockfe.warlock3.compose.util.clipEntryOf
 import warlockfe.warlock3.compose.util.insertReplacingSelection
 import warlockfe.warlock3.compose.util.openUrl
@@ -1177,6 +1178,9 @@ class GameViewModel(
     private suspend fun copyToClipboard(text: String): Boolean {
         val entry = clipEntryOf(text) ?: return false
         val clipboard = windowSelectionController.clipboard ?: return false
+        // A SafeClipboard has swallowed a failed write by the time setClipEntry returns, so ask it
+        // for the outcome rather than assume one: {cut} deletes what this copies.
+        if (clipboard is SafeClipboard) return clipboard.trySetClipEntry(entry)
         clipboard.setClipEntry(entry)
         return true
     }

--- a/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/SafeClipboard.kt
+++ b/compose/src/commonMain/kotlin/warlockfe/warlock3/compose/util/SafeClipboard.kt
@@ -19,12 +19,17 @@ import kotlin.time.Duration.Companion.milliseconds
  * Windows lets one process hold the clipboard open at a time and AWT does not wait its turn: while
  * something else has it - another app's copy, a clipboard manager's poll, a remote desktop session
  * syncing it - `setContents` throws `IllegalStateException: cannot open system clipboard`. Compose
- * copies from a coroutine with nothing to catch that (`SelectionContainer`, every text field), so
- * it reaches the uncaught handler and takes the app down, which is what DESKTOP-2G was.
+ * copies from a coroutine with nothing to catch that (`SelectionContainer`, every text field), so it
+ * reached the uncaught handler instead: a fatal crash report and a copy that silently did nothing,
+ * which is what DESKTOP-2G was.
  *
  * Whoever holds the lock is normally finishing a clipboard operation of their own, so a retry a
  * moment later usually gets it. A copy that never lands is logged and dropped: the user is no worse
- * off than with the copy that failed, minus the crash.
+ * off than with the copy that failed, minus the crash. Our own callers, who cannot see that through
+ * [setClipEntry], ask [trySetClipEntry] instead.
+ *
+ * Nothing here is platform-specific, but [ProvideSafeClipboard] is only applied over the desktop
+ * windows: this is an AWT failure mode, and the mobile clipboards do not share it.
  */
 class SafeClipboard(
     private val delegate: Clipboard,
@@ -34,8 +39,21 @@ class SafeClipboard(
     override suspend fun getClipEntry(): ClipEntry? = retrying("read") { delegate.getClipEntry() }
 
     override suspend fun setClipEntry(clipEntry: ClipEntry?) {
-        retrying("write") { delegate.setClipEntry(clipEntry) }
+        trySetClipEntry(clipEntry)
     }
+
+    /**
+     * Puts [clipEntry] on the clipboard, reporting whether it got there.
+     *
+     * [setClipEntry] cannot say: it returns nothing, and by the time it does this class has already
+     * absorbed the failure. A cut deletes what it copied, and a caller that tells the user the copy
+     * worked should only do so when it did.
+     */
+    suspend fun trySetClipEntry(clipEntry: ClipEntry?): Boolean =
+        retrying("write") {
+            delegate.setClipEntry(clipEntry)
+            true
+        } == true
 
     // Compose's own desktop code still reads this one - the context menu asks the native clipboard
     // whether it holds text - and the interface's default implementation throws.
@@ -75,11 +93,11 @@ class SafeClipboard(
 }
 
 /** Wraps [this] unless it already is one, so nested providers don't multiply the retries. */
-fun Clipboard.asSafeClipboard(): Clipboard = this as? SafeClipboard ?: SafeClipboard(this)
+fun Clipboard.asSafeClipboard(): SafeClipboard = this as? SafeClipboard ?: SafeClipboard(this)
 
 /** The scene's clipboard, wrapped so a busy system clipboard cannot crash the app. */
 @Composable
-fun rememberSafeClipboard(): Clipboard {
+fun rememberSafeClipboard(): SafeClipboard {
     val clipboard = LocalClipboard.current
     return remember(clipboard) { clipboard.asSafeClipboard() }
 }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/shim/WarlockDialog.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/shim/WarlockDialog.kt
@@ -21,6 +21,7 @@ import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.Text
 import warlockfe.warlock3.compose.generated.resources.Res
 import warlockfe.warlock3.compose.generated.resources.app_icon
+import warlockfe.warlock3.compose.util.ProvideSafeClipboard
 
 @Suppress("ktlint:compose:modifier-missing-check")
 @Composable
@@ -38,14 +39,18 @@ fun WarlockDialog(
         icon = painterResource(Res.drawable.app_icon),
         state = rememberDialogState(width = width, height = height),
     ) {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(JewelTheme.globalColors.panelBackground)
-                    .padding(16.dp),
-        ) {
-            content()
+        // A dialog is its own Compose scene, so it provides its own clipboard and does not inherit
+        // the safe one the app window is running under; see [SafeClipboard].
+        ProvideSafeClipboard {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(JewelTheme.globalColors.panelBackground)
+                        .padding(16.dp),
+            ) {
+                content()
+            }
         }
     }
 }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/game/DesktopGameView.kt
@@ -62,6 +62,7 @@ import warlockfe.warlock3.compose.ui.game.TabActivityDot
 import warlockfe.warlock3.compose.ui.game.rememberGameDockState
 import warlockfe.warlock3.compose.ui.game.rememberGameKeyHandler
 import warlockfe.warlock3.compose.util.LocalBaseStyle
+import warlockfe.warlock3.compose.util.ProvideSafeClipboard
 import warlockfe.warlock3.compose.util.toColor
 import warlockfe.warlock3.core.text.isSpecified
 import warlockfe.warlock3.core.text.toWarlockColor
@@ -192,7 +193,12 @@ fun DesktopGameView(
                 val windowContent =
                     remember(viewModel) {
                         @Composable { window: OpenGameWindow ->
-                            DockedWindow(viewModel = viewModel, window = window)
+                            // Here rather than around the game screen because a detached window is
+                            // its own Compose scene, opened from the application scope, and provides
+                            // its own clipboard: this lambda is the only part of it that is ours.
+                            ProvideSafeClipboard {
+                                DockedWindow(viewModel = viewModel, window = window)
+                            }
                         }
                     }
                 val tabActions =

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsDialog.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/desktop/ui/settings/DesktopSettingsDialog.kt
@@ -37,6 +37,7 @@ import warlockfe.warlock3.compose.generated.resources.app_icon
 import warlockfe.warlock3.compose.ui.settings.SettingsGroup
 import warlockfe.warlock3.compose.ui.settings.SettingsPage
 import warlockfe.warlock3.compose.ui.settings.WindowSettingsLiveContext
+import warlockfe.warlock3.compose.util.ProvideSafeClipboard
 import warlockfe.warlock3.core.client.GameCharacter
 import warlockfe.warlock3.core.prefs.repositories.AccountRepository
 import warlockfe.warlock3.core.prefs.repositories.ActionRepository
@@ -87,67 +88,71 @@ fun DesktopSettingsDialog(
     ) {
         var page: SettingsPage by remember { mutableStateOf(initialPage) }
 
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(JewelTheme.globalColors.panelBackground),
-        ) {
-            Row(modifier = Modifier.fillMaxSize()) {
-                Column(
-                    modifier =
-                        Modifier
-                            // 180 fits the longest label plus its leading icon
-                            .width(180.dp)
-                            .fillMaxHeight()
-                            .padding(vertical = 8.dp),
-                ) {
-                    SettingsGroup.entries.forEach { group ->
-                        if (group.title.isNotEmpty()) {
-                            Text(
-                                text = group.title,
-                                style = JewelTheme.defaultTextStyle.copy(fontWeight = FontWeight.Bold),
-                                modifier = Modifier.padding(start = 8.dp, top = 12.dp, bottom = 2.dp),
-                            )
-                        }
-                        SettingsPage.entries.filter { it.group == group }.forEach { entry ->
-                            SettingsNavItem(
-                                label = entry.title,
-                                icon = entry.icon,
-                                selected = page == entry,
-                                onClick = { page = entry },
-                            )
+        // A dialog is its own Compose scene, so it provides its own clipboard and does not inherit
+        // the safe one the app window is running under; see [SafeClipboard].
+        ProvideSafeClipboard {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(JewelTheme.globalColors.panelBackground),
+            ) {
+                Row(modifier = Modifier.fillMaxSize()) {
+                    Column(
+                        modifier =
+                            Modifier
+                                // 180 fits the longest label plus its leading icon
+                                .width(180.dp)
+                                .fillMaxHeight()
+                                .padding(vertical = 8.dp),
+                    ) {
+                        SettingsGroup.entries.forEach { group ->
+                            if (group.title.isNotEmpty()) {
+                                Text(
+                                    text = group.title,
+                                    style = JewelTheme.defaultTextStyle.copy(fontWeight = FontWeight.Bold),
+                                    modifier = Modifier.padding(start = 8.dp, top = 12.dp, bottom = 2.dp),
+                                )
+                            }
+                            SettingsPage.entries.filter { it.group == group }.forEach { entry ->
+                                SettingsNavItem(
+                                    label = entry.title,
+                                    icon = entry.icon,
+                                    selected = page == entry,
+                                    onClick = { page = entry },
+                                )
+                            }
                         }
                     }
-                }
-                Divider(orientation = Orientation.Vertical, modifier = Modifier.fillMaxHeight())
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(16.dp),
-                ) {
-                    DesktopSettingsContent(
-                        page = page,
-                        currentCharacter = currentCharacter,
-                        characterSettingsRepository = characterSettingsRepository,
-                        characterRepository = characterRepository,
-                        scriptDirRepository = scriptDirRepository,
-                        variableRepository = variableRepository,
-                        macroRepository = macroRepository,
-                        highlightRepository = highlightRepository,
-                        nameRepository = nameRepository,
-                        ignoreRepository = ignoreRepository,
-                        presetRepository = presetRepository,
-                        aliasRepository = aliasRepository,
-                        actionRepository = actionRepository,
-                        alterationRepository = alterationRepository,
-                        clientSettingRepository = clientSettingRepository,
-                        accountRepository = accountRepository,
-                        windowSettingRepository = windowSettingRepository,
-                        initialWindowTarget = initialWindowTarget,
-                        windowLiveContext = windowLiveContext,
-                    )
+                    Divider(orientation = Orientation.Vertical, modifier = Modifier.fillMaxHeight())
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .padding(16.dp),
+                    ) {
+                        DesktopSettingsContent(
+                            page = page,
+                            currentCharacter = currentCharacter,
+                            characterSettingsRepository = characterSettingsRepository,
+                            characterRepository = characterRepository,
+                            scriptDirRepository = scriptDirRepository,
+                            variableRepository = variableRepository,
+                            macroRepository = macroRepository,
+                            highlightRepository = highlightRepository,
+                            nameRepository = nameRepository,
+                            ignoreRepository = ignoreRepository,
+                            presetRepository = presetRepository,
+                            aliasRepository = aliasRepository,
+                            actionRepository = actionRepository,
+                            alterationRepository = alterationRepository,
+                            clientSettingRepository = clientSettingRepository,
+                            accountRepository = accountRepository,
+                            windowSettingRepository = windowSettingRepository,
+                            initialWindowTarget = initialWindowTarget,
+                            windowLiveContext = windowLiveContext,
+                        )
+                    }
                 }
             }
         }

--- a/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/util/SafeClipboard.kt
+++ b/compose/src/jvmMain/kotlin/warlockfe/warlock3/compose/util/SafeClipboard.kt
@@ -1,0 +1,100 @@
+package warlockfe.warlock3.compose.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.NativeClipboard
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * A [Clipboard] that survives the system clipboard being unavailable.
+ *
+ * Windows lets one process hold the clipboard open at a time and AWT does not wait its turn: while
+ * something else has it - another app's copy, a clipboard manager's poll, a remote desktop session
+ * syncing it - `setContents` throws `IllegalStateException: cannot open system clipboard`. Compose
+ * copies from a coroutine with nothing to catch that (`SelectionContainer`, every text field), so
+ * it reaches the uncaught handler and takes the app down, which is what DESKTOP-2G was.
+ *
+ * Whoever holds the lock is normally finishing a clipboard operation of their own, so a retry a
+ * moment later usually gets it. A copy that never lands is logged and dropped: the user is no worse
+ * off than with the copy that failed, minus the crash.
+ */
+class SafeClipboard(
+    private val delegate: Clipboard,
+    private val attempts: Int = 4,
+    private val retryDelay: Duration = 50.milliseconds,
+) : Clipboard {
+    override suspend fun getClipEntry(): ClipEntry? = retrying("read") { delegate.getClipEntry() }
+
+    override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+        retrying("write") { delegate.setClipEntry(clipEntry) }
+    }
+
+    // Compose's own desktop code still reads this one - the context menu asks the native clipboard
+    // whether it holds text - and the interface's default implementation throws.
+    @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
+    override val nativeClipboard: NativeClipboard
+        get() = delegate.nativeClipboard
+
+    private suspend fun <T> retrying(
+        operation: String,
+        block: suspend () -> T,
+    ): T? {
+        repeat(attempts) { attempt ->
+            try {
+                return block()
+            } catch (e: CancellationException) {
+                // On the JVM this is an IllegalStateException, and swallowing it would leave a
+                // cancelled coroutine believing it still has work to do.
+                throw e
+            } catch (e: IllegalStateException) {
+                if (attempt == attempts - 1) {
+                    logger.w(e) { "Clipboard $operation gave up after $attempts attempts" }
+                    return null
+                }
+                delay(retryDelay)
+            } catch (e: Exception) {
+                // Not the clipboard being busy, so there is nothing to wait for.
+                logger.w(e) { "Clipboard $operation failed" }
+                return null
+            }
+        }
+        return null
+    }
+
+    private companion object {
+        val logger = Logger.withTag("SafeClipboard")
+    }
+}
+
+/** Wraps [this] unless it already is one, so nested providers don't multiply the retries. */
+fun Clipboard.asSafeClipboard(): Clipboard = this as? SafeClipboard ?: SafeClipboard(this)
+
+/** The scene's clipboard, wrapped so a busy system clipboard cannot crash the app. */
+@Composable
+fun rememberSafeClipboard(): Clipboard {
+    val clipboard = LocalClipboard.current
+    return remember(clipboard) { clipboard.asSafeClipboard() }
+}
+
+/**
+ * Runs [content] with a [SafeClipboard] in [LocalClipboard].
+ *
+ * Every Compose scene provides its own clipboard - a dialog or a detached window is a new scene,
+ * and the locals it provides override whatever the parent composition provided - so this belongs
+ * inside each window rather than once around the whole app.
+ */
+@Composable
+fun ProvideSafeClipboard(content: @Composable () -> Unit) {
+    CompositionLocalProvider(
+        LocalClipboard provides rememberSafeClipboard(),
+        content = content,
+    )
+}

--- a/compose/src/jvmTest/kotlin/warlockfe/warlock3/compose/util/SafeClipboardTest.kt
+++ b/compose/src/jvmTest/kotlin/warlockfe/warlock3/compose/util/SafeClipboardTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.test.runTest
 import java.io.IOException
 import java.util.concurrent.Callable
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -27,6 +28,7 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -59,6 +61,24 @@ class SafeClipboardTest {
 
             assertEquals(3, fake.writes)
             assertNull(fake.entry)
+        }
+
+    @Test
+    fun aWriteThatLandsIsReportedToCallersThatAsk() =
+        runTest {
+            val fake = FakeClipboard(failures = 2)
+
+            // What {cut} checks before it deletes the text it copied, and what the memory dialog
+            // says it did.
+            assertTrue(SafeClipboard(fake).trySetClipEntry(clipEntryOf("copy me")))
+        }
+
+    @Test
+    fun aDroppedWriteIsReportedToCallersThatAsk() =
+        runTest {
+            val fake = FakeClipboard(failures = Int.MAX_VALUE)
+
+            assertFalse(SafeClipboard(fake, attempts = 2).trySetClipEntry(clipEntryOf("copy me")))
         }
 
     @Test
@@ -133,7 +153,8 @@ class SafeClipboardTest {
     fun aSelectionContainerCopySurvivesABusyClipboard() {
         val composeThread = Executors.newSingleThreadExecutor { runnable -> Thread(runnable, "compose-test") }
         try {
-            val failures = mutableListOf<Throwable>()
+            // Written from the compose thread's two handlers, read from this one.
+            val failures = CopyOnWriteArrayList<Throwable>()
             val copied = CountDownLatch(1)
             val clipboard = FakeClipboard(failures = 2, onWrite = { copied.countDown() })
             val state = SelectionState()

--- a/compose/src/jvmTest/kotlin/warlockfe/warlock3/compose/util/SafeClipboardTest.kt
+++ b/compose/src/jvmTest/kotlin/warlockfe/warlock3/compose/util/SafeClipboardTest.kt
@@ -1,0 +1,220 @@
+package warlockfe.warlock3.compose.util
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.text.selection.SelectionState
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.NativeClipboard
+import androidx.compose.ui.unit.Density
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.runTest
+import java.io.IOException
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * The crash this guards against (DESKTOP-2G): AWT throws
+ * `IllegalStateException: cannot open system clipboard` whenever another process has the Windows
+ * clipboard open, and Compose's copy handlers run in a coroutine that nothing catches, so a copy
+ * during that moment reached the uncaught handler and killed the app.
+ */
+class SafeClipboardTest {
+    @Test
+    fun aBusyClipboardIsRetriedUntilItLetsGo() =
+        runTest {
+            val fake = FakeClipboard(failures = 2)
+            val entry = clipEntryOf("copy me")!!
+
+            SafeClipboard(fake).setClipEntry(entry)
+
+            assertEquals(3, fake.writes)
+            assertSame(entry, fake.entry)
+        }
+
+    @Test
+    fun aClipboardThatNeverFreesUpIsDroppedRatherThanThrown() =
+        runTest {
+            val fake = FakeClipboard(failures = Int.MAX_VALUE)
+
+            SafeClipboard(fake, attempts = 3).setClipEntry(clipEntryOf("copy me"))
+
+            assertEquals(3, fake.writes)
+            assertNull(fake.entry)
+        }
+
+    @Test
+    fun aBusyClipboardIsRetriedOnTheWayBackToo() =
+        runTest {
+            val fake = FakeClipboard(failures = 1).apply { entry = clipEntryOf("paste me") }
+
+            val read = SafeClipboard(fake).getClipEntry()
+
+            assertEquals(2, fake.reads)
+            assertEquals("paste me", read?.plainText())
+        }
+
+    @Test
+    fun aReadThatNeverGetsThroughYieldsNothing() =
+        runTest {
+            val fake = FakeClipboard(failures = Int.MAX_VALUE).apply { entry = clipEntryOf("paste me") }
+
+            assertNull(SafeClipboard(fake, attempts = 2).getClipEntry())
+            assertEquals(2, fake.reads)
+        }
+
+    @Test
+    fun cancellationIsNotMistakenForABusyClipboard() =
+        runTest {
+            // java.util.concurrent.CancellationException *is* an IllegalStateException, so a
+            // cancelled copy would otherwise be retried and then swallowed.
+            val fake = FakeClipboard(failures = Int.MAX_VALUE, failure = { CancellationException("cancelled") })
+
+            assertFailsWith<CancellationException> { SafeClipboard(fake).setClipEntry(clipEntryOf("copy me")) }
+            assertEquals(1, fake.writes)
+        }
+
+    @Test
+    fun aFailureThatIsNotTheClipboardLockIsNotWaitedOut() =
+        runTest {
+            val fake = FakeClipboard(failures = Int.MAX_VALUE, failure = { IOException("gone") })
+
+            SafeClipboard(fake).setClipEntry(clipEntryOf("copy me"))
+
+            assertEquals(1, fake.writes)
+        }
+
+    @Test
+    fun wrappingAnAlreadySafeClipboardChangesNothing() {
+        val safe = FakeClipboard(failures = 0).asSafeClipboard()
+
+        assertSame(safe, safe.asSafeClipboard())
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun theNativeClipboardIsTheDelegatesOwn() {
+        val fake = FakeClipboard(failures = 0)
+
+        // Compose's desktop context menu reads this to ask whether there is text to paste; the
+        // interface's default implementation throws.
+        assertSame(fake.nativeClipboard, fake.asSafeClipboard().nativeClipboard)
+    }
+
+    /**
+     * The production path, end to end: Compose's own copy handler, reached by the key event, with a
+     * clipboard that is busy the first two times it is asked.
+     *
+     * This is what pins the fix in place - the copy is Compose's, not ours, and the only way in is
+     * the [LocalClipboard] the container reads. Without [ProvideSafeClipboard] around it the
+     * `IllegalStateException` lands in the scene's exception handler, which is where the app had
+     * nothing at all.
+     */
+    @OptIn(ExperimentalComposeUiApi::class, InternalComposeUiApi::class)
+    @Test
+    fun aSelectionContainerCopySurvivesABusyClipboard() {
+        val composeThread = Executors.newSingleThreadExecutor { runnable -> Thread(runnable, "compose-test") }
+        try {
+            val failures = mutableListOf<Throwable>()
+            val copied = CountDownLatch(1)
+            val clipboard = FakeClipboard(failures = 2, onWrite = { copied.countDown() })
+            val state = SelectionState()
+            val dispatcher = composeThread.asCoroutineDispatcher()
+
+            fun <T> call(block: () -> T): T = composeThread.submit(Callable(block)).get()
+
+            val scene =
+                call {
+                    // Where the app's crash surfaced, and where a coroutine's failure goes when
+                    // nothing in its context takes it.
+                    Thread.currentThread().setUncaughtExceptionHandler { _, t -> failures += t }
+                    ImageComposeScene(
+                        width = 200,
+                        height = 100,
+                        density = Density(1f),
+                        coroutineContext = dispatcher + CoroutineExceptionHandler { _, t -> failures += t },
+                    )
+                }
+            try {
+                call {
+                    scene.setContent {
+                        // Standing in for the window's platform clipboard, which is the one the
+                        // scene provides and the one that throws.
+                        CompositionLocalProvider(LocalClipboard provides clipboard) {
+                            ProvideSafeClipboard {
+                                SelectionContainer(state = state) {
+                                    BasicText("copy me")
+                                }
+                            }
+                        }
+                    }
+                    scene.render()
+                }
+                // Selecting also takes focus, which is what puts the key event in front of the
+                // container's copy handler.
+                call {
+                    state.selectAll()
+                    scene.render()
+                }
+                val handled = call { scene.sendKeyEvent(KeyEvent(Key.Copy, KeyEventType.KeyDown)) }
+
+                assertTrue(handled, "the selection container handled the copy key")
+                assertTrue(copied.await(5, TimeUnit.SECONDS), "the copy landed on the clipboard")
+                assertEquals(3, call { clipboard.writes })
+                assertEquals("copy me", call { clipboard.entry?.plainText() })
+                assertTrue(failures.isEmpty(), "no failure escaped: $failures")
+            } finally {
+                call { scene.close() }
+            }
+        } finally {
+            composeThread.shutdown()
+        }
+    }
+
+    /** Busy for its first [failures] calls, in the way the Windows clipboard is. */
+    private class FakeClipboard(
+        private val failures: Int,
+        private val failure: () -> Exception = { IllegalStateException("cannot open system clipboard") },
+        private val onWrite: () -> Unit = {},
+    ) : Clipboard {
+        var entry: ClipEntry? = null
+        var reads = 0
+        var writes = 0
+        val native = Any()
+
+        override suspend fun getClipEntry(): ClipEntry? {
+            reads++
+            if (reads <= failures) throw failure()
+            return entry
+        }
+
+        override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+            writes++
+            if (writes <= failures) throw failure()
+            entry = clipEntry
+            onWrite()
+        }
+
+        @Suppress("OVERRIDE_DEPRECATION")
+        override val nativeClipboard: NativeClipboard
+            get() = native
+    }
+}

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -95,6 +96,7 @@ import warlockfe.warlock3.compose.openPrefsDatabase
 import warlockfe.warlock3.compose.util.LocalSkin
 import warlockfe.warlock3.compose.util.LocalWindowComponent
 import warlockfe.warlock3.compose.util.initializeSentry
+import warlockfe.warlock3.compose.util.rememberSafeClipboard
 import warlockfe.warlock3.core.client.JavaProxy
 import warlockfe.warlock3.core.client.WarlockSocket
 import warlockfe.warlock3.core.prefs.PrefsDatabase
@@ -332,6 +334,9 @@ private class WarlockCommand : CliktCommand() {
                                 LocalSkin provides skin,
                                 LocalTitleBarStyle provides titleBarStyle,
                                 LocalDesktopDockHost provides dockHost,
+                                // A copy that cannot open the system clipboard must not take the
+                                // app down with it; see [SafeClipboard].
+                                LocalClipboard provides rememberSafeClipboard(),
                             ) {
                                 RegisterGameDockWindow(dockHost)
                                 WarlockApp(

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/MemoryUsageDialog.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/MemoryUsageDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
@@ -39,10 +40,9 @@ import warlockfe.warlock3.compose.desktop.shim.WarlockOutlinedButton
 import warlockfe.warlock3.compose.desktop.shim.WarlockScrollableColumn
 import warlockfe.warlock3.compose.model.GameScreen
 import warlockfe.warlock3.compose.model.GameState
+import warlockfe.warlock3.compose.util.clipEntryOf
 import warlockfe.warlock3.compose.util.createPlatformDialogSettings
 import warlockfe.warlock3.core.window.WindowMemoryUsage
-import java.awt.Toolkit
-import java.awt.datatransfer.StringSelection
 import java.io.File
 import java.lang.management.ManagementFactory
 import kotlin.time.Duration.Companion.seconds
@@ -100,6 +100,8 @@ fun MemoryUsageDialog(
         width = 760.dp,
         height = 600.dp,
     ) {
+        // The dialog's own clipboard, which WarlockDialog has already made safe to write to.
+        val clipboard = LocalClipboard.current
         Column(Modifier.fillMaxSize()) {
             val snapshot = report
             if (snapshot == null) {
@@ -147,8 +149,13 @@ fun MemoryUsageDialog(
                 WarlockOutlinedButton(
                     onClick = {
                         val text = report?.toText() ?: return@WarlockOutlinedButton
-                        Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(text), null)
-                        status = "Report copied to the clipboard."
+                        // Through the window's clipboard rather than AWT's: the dialog is running
+                        // under a [SafeClipboard], and a busy system clipboard used to throw out of
+                        // here straight into the uncaught handler.
+                        scope.launch {
+                            clipEntryOf(text)?.let { entry -> clipboard.setClipEntry(entry) }
+                            status = "Report copied to the clipboard."
+                        }
                     },
                     text = "Copy report",
                     enabled = report != null && !busy,

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/MemoryUsageDialog.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/MemoryUsageDialog.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
@@ -42,6 +41,7 @@ import warlockfe.warlock3.compose.model.GameScreen
 import warlockfe.warlock3.compose.model.GameState
 import warlockfe.warlock3.compose.util.clipEntryOf
 import warlockfe.warlock3.compose.util.createPlatformDialogSettings
+import warlockfe.warlock3.compose.util.rememberSafeClipboard
 import warlockfe.warlock3.core.window.WindowMemoryUsage
 import java.io.File
 import java.lang.management.ManagementFactory
@@ -101,7 +101,7 @@ fun MemoryUsageDialog(
         height = 600.dp,
     ) {
         // The dialog's own clipboard, which WarlockDialog has already made safe to write to.
-        val clipboard = LocalClipboard.current
+        val clipboard = rememberSafeClipboard()
         Column(Modifier.fillMaxSize()) {
             val snapshot = report
             if (snapshot == null) {
@@ -149,12 +149,17 @@ fun MemoryUsageDialog(
                 WarlockOutlinedButton(
                     onClick = {
                         val text = report?.toText() ?: return@WarlockOutlinedButton
-                        // Through the window's clipboard rather than AWT's: the dialog is running
-                        // under a [SafeClipboard], and a busy system clipboard used to throw out of
-                        // here straight into the uncaught handler.
+                        // Through the window's clipboard rather than AWT's: a busy system clipboard
+                        // used to throw out of here straight into the uncaught handler. Says so only
+                        // when the write actually landed, since the retries can run out.
                         scope.launch {
-                            clipEntryOf(text)?.let { entry -> clipboard.setClipEntry(entry) }
-                            status = "Report copied to the clipboard."
+                            val entry = clipEntryOf(text)
+                            status =
+                                if (entry != null && clipboard.trySetClipEntry(entry)) {
+                                    "Report copied to the clipboard."
+                                } else {
+                                    "Could not copy the report to the clipboard."
+                                }
                         }
                     },
                     text = "Copy report",


### PR DESCRIPTION
Fixes DESKTOP-2G (`IllegalStateException: cannot open system clipboard`, fatal, 3.1.0).

## What was happening

Windows lets one process hold the clipboard open at a time and AWT does not wait its turn: `setContents` throws whenever something else has it — another app's copy, a clipboard manager's poll, a remote desktop session syncing it. Compose's `SelectionContainer` runs its copy in `launch(UNDISPATCHED) { clipboard.setClipEntry(...) }` with nothing to catch that, and every text field does the same, so the throw went straight to the uncaught handler and took the client down.

## The fix

The only way into Compose's own copy is the `LocalClipboard` it reads, so `SafeClipboard` decorates the platform one: retry a busy clipboard (4 attempts, 50 ms apart — whoever holds the lock is normally mid-operation), then log and drop. `CancellationException` is rethrown ahead of the retry, since on the JVM it *is* an `IllegalStateException` and swallowing it would strand a cancelled coroutine, and the deprecated `nativeClipboard` is delegated because Compose's desktop context menu still reads it.

It is provided per Compose scene, because a dialog or a detached window is a new scene whose own `ProvideCommonCompositionLocals` overrides whatever the parent composition provided:

- `Main.kt` — the main window: game windows, entry field, dashboard, in-window popups
- `DesktopGameView.windowContent` — detached game windows, whose scene the docking library opens from the application scope; that lambda is the only part of it that is ours
- `WarlockDialog` — every dialog built on the shim (import results, about, memory, character select, alerts)
- `DesktopSettingsDialog` — its own `DialogWindow`, full of text fields

`MemoryUsageDialog`'s "copy report" reached `Toolkit.getDefaultToolkit().systemClipboard` directly and could throw off the event thread the same way, so it goes through the window's clipboard now too.

Android and iOS are left alone: this is an AWT failure mode, and their clipboards are different implementations. `UpdateDialog` is left alone as well — no selectable text, no clipboard use.

## Tests

`SafeClipboardTest` covers retry-then-succeed in both directions, giving up, cancellation not being mistaken for a busy clipboard, non-lock failures not being waited out, idempotent wrapping, and the delegated native clipboard.

The last test drives the production path rather than the wrapper: a `SelectionContainer` in an `ImageComposeScene`, `selectAll()`, a copy key event, against a clipboard that is busy twice. The text lands and nothing reaches the scene's exception handler — and taking `ProvideSafeClipboard` back out makes it fail, so it pins the fix rather than the fake.

`./gradlew check -PiosSkip=true -PlintSkip=true` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RkdXBG9uKnWyVaLW3Qz7k


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard reliability across the desktop app by retrying temporary clipboard failures.
  * Prevented clipboard errors from disrupting dialogs, docked windows, selection copying, and other copy/cut actions.
  * Copying memory usage reports now clearly indicates whether the clipboard write succeeded or failed.
  * Preserved cancellation behavior and avoided retrying unrelated clipboard errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->