### PR TITLE
Fix the crash on the first logged line of a session

### DIFF
--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ClientSettingRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/ClientSettingRepository.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.withContext
 import warlockfe.warlock3.core.prefs.CompassStyle
 import warlockfe.warlock3.core.prefs.ReleaseChannelSetting
 import warlockfe.warlock3.core.prefs.ThemeSetting
+import warlockfe.warlock3.core.prefs.config.ClientConfig
 import warlockfe.warlock3.core.prefs.config.ClientConfigStore
 import warlockfe.warlock3.core.prefs.dao.ClientSettingDao
 import warlockfe.warlock3.core.prefs.models.ClientSettingEntity
@@ -87,14 +88,17 @@ class ClientSettingRepository(
 
     fun observeSkinFile(): Flow<String?> = clientConfigStore.observeClient().map { it.skinFile }
 
-    fun observeLogSettings(): Flow<LogSettings> =
-        clientConfigStore.observeClient().map { config ->
-            LogSettings(
-                basePath = config.logPath ?: warlockDirs.logDir,
-                type = config.logType?.let { runCatching { LogType.valueOf(it) }.getOrNull() } ?: LogType.SIMPLE,
-                logTimestamps = config.logTimestamps,
-            )
-        }
+    fun observeLogSettings(): Flow<LogSettings> = clientConfigStore.observeClient().map { it.toLogSettings() }
+
+    /** The settings as they stand right now, for callers that can't wait for the flow to emit. */
+    fun getLogSettings(): LogSettings = clientConfigStore.currentClient().toLogSettings()
+
+    private fun ClientConfig.toLogSettings(): LogSettings =
+        LogSettings(
+            basePath = logPath ?: warlockDirs.logDir,
+            type = logType?.let { runCatching { LogType.valueOf(it) }.getOrNull() } ?: LogType.SIMPLE,
+            logTimestamps = logTimestamps,
+        )
 
     fun observeMaxScrollLines(): Flow<Int> = clientConfigStore.observeClient().map { it.scrollback ?: DEFAULT_MAX_SCROLL_LINES }
 

--- a/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/LoggingRepository.kt
+++ b/core/src/commonMain/kotlin/warlockfe/warlock3/core/prefs/repositories/LoggingRepository.kt
@@ -16,6 +16,13 @@ class LoggingRepository(
 ) {
     private val mutex = Mutex()
 
+    // Declared before [loggingSettings]: the sharing coroutine that flow starts touches this map,
+    // and it runs on another thread, so anything it reads has to be assigned before it is launched.
+    private val loggers = mutableMapOf<String, FileLogger?>()
+
+    // Seeded with the settings as they stand rather than with null: the sharing coroutine is
+    // dispatched, so a log line can arrive before it has collected anything, and the settings have a
+    // usable value (the defaults, until client.toml is read) from the start.
     private val loggingSettings =
         clientSettingRepository
             .observeLogSettings()
@@ -24,9 +31,7 @@ class LoggingRepository(
                     loggers.forEach { (_, logger) -> logger?.close() }
                     loggers.clear()
                 }
-            }.stateIn(externalScope, SharingStarted.Eagerly, null)
-
-    private val loggers = mutableMapOf<String, FileLogger?>()
+            }.stateIn(externalScope, SharingStarted.Eagerly, clientSettingRepository.getLogSettings())
 
     suspend fun logSimple(
         name: String,
@@ -47,7 +52,7 @@ class LoggingRepository(
         name: String,
         message: () -> String,
     ) {
-        val settings = loggingSettings.value ?: error("Attempted to print log before settings were loaded")
+        val settings = loggingSettings.value
         if (settings.type == type) {
             val logger = getLogger(settings.basePath, name)
             logger?.write(message(), settings.logTimestamps, settings.type)

--- a/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/repositories/LoggingRepositoryTest.kt
+++ b/core/src/jvmTest/kotlin/warlockfe/warlock3/core/prefs/repositories/LoggingRepositoryTest.kt
@@ -1,0 +1,152 @@
+package warlockfe.warlock3.core.prefs.repositories
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import warlockfe.warlock3.core.prefs.config.ClientConfigStore
+import warlockfe.warlock3.core.prefs.dao.ClientSettingDao
+import warlockfe.warlock3.core.prefs.models.ClientSettingEntity
+import warlockfe.warlock3.core.util.WarlockDirs
+import java.io.File
+import java.nio.file.Files
+import kotlin.coroutines.CoroutineContext
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * The settings a [LoggingRepository] logs under are shared into a StateFlow on a scope of the
+ * caller's choosing, and a game line can arrive before that sharing coroutine has had a chance to
+ * run. These cover the two ways that used to leave the repository with no settings at all, each of
+ * which turned the next logged line into a crash ("Attempted to print log before settings were
+ * loaded") that took the client down mid-session.
+ */
+class LoggingRepositoryTest {
+    private lateinit var dir: Path
+    private lateinit var configDir: String
+    private lateinit var logDir: String
+
+    @BeforeTest
+    fun setUp() {
+        dir = Path(Files.createTempDirectory("logging-test").toAbsolutePath().toString())
+        configDir = Path(dir, "config").toString()
+        logDir = Path(dir, "logs").toString()
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        java.nio.file.Path
+            .of(dir.toString())
+            .deleteRecursively()
+    }
+
+    /**
+     * The sharing coroutine is dispatched rather than started in place, so on a busy dispatcher it
+     * can sit queued behind other work while the game is already sending lines. [NeverDispatched] is
+     * that delay taken to its limit: the coroutine never runs, and logging still has to work.
+     */
+    @Test
+    fun logsBeforeTheSharingCoroutineHasRun() {
+        val scope = CoroutineScope(SupervisorJob() + NeverDispatched)
+        try {
+            val repository = LoggingRepository(newClientSettings(), scope)
+            runBlocking { repository.logSimple("gs4_tholan") { "You are stunned." } }
+            assertLogged("gs4_tholan", "You are stunned.")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    /**
+     * Under an unconfined dispatcher the sharing coroutine starts inside the constructor, before the
+     * rest of the object's properties are assigned. Its first act is to clear the map of open
+     * loggers, so that map has to already exist; when it didn't, the coroutine died of a NPE and the
+     * settings were never published at all.
+     */
+    @Test
+    fun startingTheSharingCoroutineDuringConstructionDoesNotFail() {
+        val failures = mutableListOf<Throwable>()
+        val handler = CoroutineExceptionHandler { _, throwable -> failures.add(throwable) }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined + handler)
+        try {
+            val repository = LoggingRepository(newClientSettings(), scope)
+            assertTrue(failures.isEmpty(), "sharing coroutine failed: ${failures.firstOrNull()}")
+            runBlocking { repository.logSimple("gs4_tholan") { "You are stunned." } }
+            assertLogged("gs4_tholan", "You are stunned.")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    private fun newClientSettings(): ClientSettingRepository =
+        ClientSettingRepository(
+            clientSettingDao = LoggingTestClientSettingDao,
+            clientConfigStore = ClientConfigStore(configDir, SystemFileSystem),
+            warlockDirs =
+                WarlockDirs(
+                    homeDir = dir.toString(),
+                    dataDir = dir.toString(),
+                    configDir = configDir,
+                    logDir = logDir,
+                ),
+        )
+
+    /** Log lines carry a leading timestamp by default, so only the tail of the line is compared. */
+    private fun assertLogged(
+        name: String,
+        message: String,
+    ) {
+        val line = awaitLoggedLine(name)
+        assertTrue(line != null && line.endsWith(message), "expected a line ending in \"$message\", got $line")
+    }
+
+    /** [FileLogger] writes on a thread of its own, so the line lands a moment after logging it. */
+    private fun awaitLoggedLine(name: String): String? {
+        val directory = File(logDir, name)
+        val deadline = TimeSource.Monotonic.markNow() + 10.seconds
+        while (true) {
+            val line =
+                directory
+                    .listFiles()
+                    ?.firstOrNull()
+                    ?.readText()
+                    ?.trim()
+            if (!line.isNullOrEmpty()) return line
+            if (deadline.hasPassedNow()) return null
+            Thread.sleep(20)
+        }
+    }
+}
+
+/** Accepts work and never runs it, standing in for a dispatcher that hasn't gotten to it yet. */
+private object NeverDispatched : CoroutineDispatcher() {
+    override fun dispatch(
+        context: CoroutineContext,
+        block: Runnable,
+    ) = Unit
+}
+
+private object LoggingTestClientSettingDao : ClientSettingDao {
+    override suspend fun getAll(): List<ClientSettingEntity> = error("unused")
+
+    override suspend fun getByKey(key: String): String? = error("unused")
+
+    override fun observeByKey(key: String): Flow<String?> = flowOf(null)
+
+    override suspend fun removeByKey(key: String) = error("unused")
+
+    override suspend fun save(entity: ClientSettingEntity) = error("unused")
+}


### PR DESCRIPTION
Fixes the production crash `IllegalStateException: Attempted to print log before settings were loaded` (DESKTOP-3W, desktop@3.1.0).

## Root cause

`LoggingRepository` declared its settings flow *before* the map that flow uses:

```kotlin
private val loggingSettings = ...onEach { loggers.forEach { ... } }
    .stateIn(externalScope, SharingStarted.Eagerly, null)

private val loggers = mutableMapOf<String, FileLogger?>()   // assigned second
```

`stateIn` with `SharingStarted.Eagerly` launches with `CoroutineStart.DEFAULT` — dispatched, not started in place. The sharing coroutine ran on an IO thread while the constructor was still executing, and its first act (clearing open loggers on the initial emission) dereferenced `loggers` while it was still null. The NPE killed the sharing coroutine for good, so `loggingSettings.value` stayed at its `null` seed forever and every line the game logged afterwards hit `error("Attempted to print log before settings were loaded")`, taking the client down.

That is why it lands at login rather than at startup: `WraythClient` buffers log lines until the `<app>` event names the character, then replays them (`WraythClient.kt:403` → `:1080`), so the first real call into the repository is the one that kills the connection.

## The fix

- Declare `loggers` before `loggingSettings`, so it is assigned before anything is launched — that also gives a real happens-before edge rather than just luckier ordering.
- Seed `stateIn` with `clientSettingRepository.getLogSettings()` instead of `null`. The config store is a `MutableStateFlow` with a default, so there is always a value to read; a line arriving ahead of the first emission now logs under the current settings instead of throwing. The `error(...)` is gone — a logging hiccup should never be fatal.
- Added `ClientSettingRepository.getLogSettings()`, sharing the mapping with `observeLogSettings()`.

## Verification

`LoggingRepositoryTest` covers both halves. Reverting just `LoggingRepository.kt` reproduces the original failures exactly:

```
sharing coroutine failed: java.lang.NullPointerException: Cannot invoke "java.util.Map.entrySet()" because "$this$forEach$iv" is null
java.lang.IllegalStateException: Attempted to print log before settings were loaded
```

Both pass with the fix, and `./gradlew check -PiosSkip=true -PlintSkip=true` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWiQAWnC8ZUoqQvwhrfvYS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logging initialization so logging works reliably before settings are fully loaded.
  - Prevented startup failures when logging settings begin sharing during application construction.
  - Ensured reactive and synchronous access use consistent log-settings values.

- **Tests**
  - Added coverage for early logging and logging initialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->