### PR TITLE
Fix the Android pre-14 launch crash and add an Android lint/test CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,9 +100,10 @@ jobs:
   # the build job drops lint with -PlintSkip=true, so it lives here.
   #
   # The tests are the commonTest suites of the KMP modules compiled against the Android target
-  # and run on the host JVM (testAndroidHostTest), plus the app's unit tests. They exercise the
-  # androidMain actuals rather than the jvmMain ones, but they run on the host JDK, so they
-  # cannot catch an API-level problem like the one above - that is lint's job.
+  # and run on the host JVM (testAndroidHostTest). They exercise the androidMain actuals rather
+  # than the jvmMain ones, but they run on the host JDK, so they cannot catch an API-level
+  # problem like the one above - that is lint's job. The app's own unit tests stay with `check`
+  # in the build job, which already runs them.
   android:
     name: Android lint and tests
     runs-on: ubuntu-latest
@@ -130,7 +131,7 @@ jobs:
       # Still runs when lint fails, so one push reports both.
       - name: Android tests
         if: ${{ !cancelled() }}
-        run: ./gradlew testAndroidHostTest :androidApp:testDebugUnitTest -PiosSkip=true --stacktrace
+        run: ./gradlew testAndroidHostTest -PiosSkip=true --stacktrace
 
       - name: Upload lint and test reports
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,8 +125,12 @@ jobs:
         with:
           cache-provider: basic
 
+      # lintAndroidMain (every KMP module) plus the app's lint, rather than the `lint` umbrella:
+      # that also runs each module's lintJvm, which compiles the JVM targets the build job
+      # already compiles and has no Android context to check against. Time is the whole
+      # reason this job exists apart from `check`.
       - name: Android lint
-        run: ./gradlew lint -PiosSkip=true --stacktrace
+        run: ./gradlew lintAndroidMain :androidApp:lint -PiosSkip=true --stacktrace
 
       # Still runs when lint fails, so one push reports both.
       - name: Android tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,8 +76,10 @@ jobs:
           fi
           echo "potassium actions and catalog agree on $version"
 
+      # Lint and the Android-target test suites have their own job below; -x prunes the host
+      # tests and everything only they need, so they do not run twice per push.
       - name: Checks
-        run: ./gradlew check -PiosSkip=true -PlintSkip=true --stacktrace
+        run: ./gradlew check -PiosSkip=true -PlintSkip=true -x testAndroidHostTest --stacktrace
 
       - name: Upload test reports
         if: always()
@@ -86,6 +88,58 @@ jobs:
           name: test-reports
           retention-days: 3
           path: |
+            **/build/reports/tests/**
+            **/build/test-results/**
+          if-no-files-found: ignore
+
+  # Android Lint plus the test suites compiled for the Android target. Lint is the one check
+  # that knows which Java APIs Android lacks: Path.of is Java 11 but only reached Android in
+  # API 34, and v3.1.0 shipped it in a shared JVM+Android source set and crashed on launch on
+  # every device before Android 14, with ktlint, the compiler and every test green. The KMP
+  # modules only get lint tasks once com.android.lint is applied (see their build files), and
+  # the build job drops lint with -PlintSkip=true, so it lives here.
+  #
+  # The tests are the commonTest suites of the KMP modules compiled against the Android target
+  # and run on the host JVM (testAndroidHostTest), plus the app's unit tests. They exercise the
+  # androidMain actuals rather than the jvmMain ones, but they run on the host JDK, so they
+  # cannot catch an API-level problem like the one above - that is lint's job.
+  android:
+    name: Android lint and tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      # See the note on cache-provider in the build job.
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
+
+      - name: Android lint
+        run: ./gradlew lint -PiosSkip=true --stacktrace
+
+      # Still runs when lint fails, so one push reports both.
+      - name: Android tests
+        if: ${{ !cancelled() }}
+        run: ./gradlew testAndroidHostTest :androidApp:testDebugUnitTest -PiosSkip=true --stacktrace
+
+      - name: Upload lint and test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-reports
+          retention-days: 3
+          path: |
+            **/build/reports/lint-results*.html
             **/build/reports/tests/**
             **/build/test-results/**
           if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,9 @@ Warlock is a multi-platform front-end client for the Simutronics Game Engine (SG
 # What CI's main job runs (iOS targets, Android Lint and the Android host tests have their own jobs)
 ./gradlew check -PiosSkip=true -PlintSkip=true -x testAndroidHostTest
 
-# What CI's Android job runs: lint on every module (the only check that knows which Java APIs
-# Android lacks) and the commonTest suites compiled against the Android target
-./gradlew lint -PiosSkip=true
+# What CI's Android job runs: Android lint on every module (the only check that knows which
+# Java APIs Android lacks) and the commonTest suites compiled against the Android target
+./gradlew lintAndroidMain :androidApp:lint -PiosSkip=true
 ./gradlew testAndroidHostTest -PiosSkip=true
 
 # Run all tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,13 @@ Warlock is a multi-platform front-end client for the Simutronics Game Engine (SG
 # Build everything
 ./gradlew build
 
-# What CI runs (Android Lint and iOS targets are skipped there)
-./gradlew check -PiosSkip=true -PlintSkip=true
+# What CI's main job runs (iOS targets, Android Lint and the Android host tests have their own jobs)
+./gradlew check -PiosSkip=true -PlintSkip=true -x testAndroidHostTest
+
+# What CI's Android job runs: lint on every module (the only check that knows which Java APIs
+# Android lacks) and the commonTest suites compiled against the Android target
+./gradlew lint -PiosSkip=true
+./gradlew testAndroidHostTest :androidApp:testDebugUnitTest -PiosSkip=true
 
 # Run all tests
 ./gradlew allTests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Warlock is a multi-platform front-end client for the Simutronics Game Engine (SG
 # What CI's Android job runs: lint on every module (the only check that knows which Java APIs
 # Android lacks) and the commonTest suites compiled against the Android target
 ./gradlew lint -PiosSkip=true
-./gradlew testAndroidHostTest :androidApp:testDebugUnitTest -PiosSkip=true
+./gradlew testAndroidHostTest -PiosSkip=true
 
 # Run all tests
 ./gradlew allTests

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.kmp.library) apply false
+    alias(libs.plugins.android.lint) apply false
     alias(libs.plugins.compose) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.compose.hot.reload) apply false
@@ -54,9 +55,11 @@ subprojects {
 val Project.libs: org.gradle.accessors.dm.LibrariesForLibs
     get() = extensions.getByType()
 
-// CI passes -PlintSkip=true to drop Android Lint from the `check` graph — its model
-// generation + analyze tasks cost ~50s and most of what it catches in this Kotlin-only
-// Compose project is already covered by ktlint or the Kotlin compiler.
+// CI's main job passes -PlintSkip=true to drop Android Lint from the `check` graph — its model
+// generation + analyze tasks cost ~50s — and the `android` job in ci.yaml runs `lint` on its
+// own. Lint is the only check that knows which Java APIs Android lacks: Path.of shipped in
+// v3.1.0 and crashed every device before Android 14 while ktlint, the compiler and every
+// test stayed green.
 if ((findProperty("lintSkip") as? String)?.toBoolean() == true) {
     allprojects {
         afterEvaluate {

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.compose)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.android.kmp.library)
+    alias(libs.plugins.android.lint)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlin.allopen)
     alias(libs.plugins.kotlinx.benchmark)
@@ -40,6 +41,8 @@ kotlin {
             libs.versions.minSdk
                 .get()
                 .toInt()
+        // Run commonTest against the Android target too, on the host JVM (testAndroidHostTest).
+        withHostTest {}
         androidResources.enable = true
     }
     if (!skipIos) {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.kmp.library)
+    alias(libs.plugins.android.lint)
     alias(libs.plugins.ksp)
     alias(libs.plugins.room.schema)
     alias(libs.plugins.antlr.kotlin)
@@ -75,6 +76,8 @@ kotlin {
             libs.versions.minSdk
                 .get()
                 .toInt()
+        // Run commonTest against the Android target too, on the host JVM (testAndroidHostTest).
+        withHostTest {}
     }
     if (!skipIos) {
         listOf(

--- a/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigWatcher.jvmAndroid.kt
+++ b/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/prefs/config/ConfigWatcher.jvmAndroid.kt
@@ -11,6 +11,7 @@ import java.nio.file.ClosedWatchServiceException
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.nio.file.StandardWatchEventKinds.ENTRY_CREATE
 import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
 import java.nio.file.StandardWatchEventKinds.OVERFLOW
@@ -18,7 +19,8 @@ import java.nio.file.WatchKey
 
 internal actual fun watchConfigChanges(rootDir: String): Flow<String> =
     callbackFlow {
-        val root = Path.of(rootDir)
+        // Paths.get, not Path.of: the latter is Java 11 and only reached Android in API 34.
+        val root = Paths.get(rootDir)
         runCatching { Files.createDirectories(root) }
         val watchService = FileSystems.getDefault().newWatchService()
         val keys = HashMap<WatchKey, Path>()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@
 
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-kmp-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
+android-lint = { id = "com.android.lint", version.ref = "agp" }
 antlr-kotlin = { id = "com.strumenta.antlr-kotlin", version.ref = "antlr-kotlin" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Applies to every module: lint reads lint.xml from the module directory and each parent. -->
+<lint>
+    <!-- Room's KSP output calls androidx-internal APIs by design. Lint cannot tell it is
+         generated, because KSP registers its output as an ordinary source directory, so the
+         check reported 1339 errors against DAO implementations and nothing against our code. -->
+    <issue id="RestrictedApi">
+        <ignore regexp="[/\\]build[/\\]generated[/\\]" />
+    </issue>
+</lint>

--- a/scripting/build.gradle.kts
+++ b/scripting/build.gradle.kts
@@ -2,6 +2,7 @@ import com.strumenta.antlrkotlin.gradle.AntlrKotlinTask
 
 plugins {
     alias(libs.plugins.android.kmp.library)
+    alias(libs.plugins.android.lint)
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.antlr.kotlin)
 }
@@ -49,6 +50,8 @@ kotlin {
             libs.versions.minSdk
                 .get()
                 .toInt()
+        // Run commonTest against the Android target too, on the host JVM (testAndroidHostTest).
+        withHostTest {}
     }
     jvm()
     if (!skipIos) {
@@ -101,4 +104,10 @@ kotlin {
         optIn.add("kotlin.concurrent.atomics.ExperimentalAtomicApi")
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
+}
+
+// The Android artifact of lua-kmp carries libluakmp.so for Android ABIs only, so the Lua tests
+// cannot load it on the host JVM. They still run on the JVM target (jvmTest) and on iOS.
+tasks.withType<Test>().matching { it.name == "testAndroidHostTest" }.configureEach {
+    filter { excludeTestsMatching("warlockfe.warlock3.scripting.lua.*") }
 }

--- a/wrayth/build.gradle.kts
+++ b/wrayth/build.gradle.kts
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.kmp.library)
+    alias(libs.plugins.android.lint)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.antlr.kotlin)
     alias(libs.plugins.kotlin.allopen)
@@ -70,6 +71,8 @@ kotlin {
             libs.versions.minSdk
                 .get()
                 .toInt()
+        // Run commonTest against the Android target too, on the host JVM (testAndroidHostTest).
+        withHostTest {}
     }
 
     if (!skipIos) {


### PR DESCRIPTION
## Summary

- **Fixes the Android launch crash** (Sentry DESKTOP-3R, `NoSuchMethodError: Path.of`). The config watcher used `Path.of`, a Java 11 API that Android only added in API 34. With minSdk 26 every device on Android 8 through 13 crashed at startup, in every build since v3.1.0-beta.7 including v3.1.0. `Paths.get` is the API 26 equivalent.
- **Adds an `android` CI job** that runs Android Lint on every module and the test suites compiled against the Android target. Lint is the only check that knows which Java APIs Android lacks; with the fix reverted, `:core:lintAndroidMain` reports the crash as a `NewApi` error.

## Why lint was not catching this

The main job passes `-PlintSkip=true`, and even without it the app's lint never looks at the KMP library modules: AGP's KMP task manager only creates lint tasks for a module once `com.android.lint` is applied to it (`checkDependencies` in the app does nothing for them). This applies the plugin to core, compose, wrayth and scripting.

Room's KSP output tripped `RestrictedApi` 1339 times because lint cannot tell it is generated, so a root `lint.xml` excludes `build/generated` from that check. A path-based ignore was not honored, hence the regexp.

## Android tests

`withHostTest {}` on the KMP modules adds `testAndroidHostTest`, which runs commonTest compiled against the Android target on the host JVM, exercising the `androidMain` actuals. The Lua tests are excluded there: lua-kmp's Android artifact only ships `libluakmp.so` for Android ABIs, so the host JVM cannot load it. They still run under `jvmTest` and on iOS. The main job passes `-x testAndroidHostTest` so the suites do not run twice per push.

Note these tests run on the host JDK, so they would not have caught this class of bug either. That is lint's job, and the job comments say so.

## Verification

| Command | Result |
|---|---|
| `./gradlew lint -PiosSkip=true` | 0 errors in every module, warnings only |
| `./gradlew testAndroidHostTest :androidApp:testDebugUnitTest -PiosSkip=true` | compose 143, wrayth 99, scripting 207 passed |
| `./gradlew check -PiosSkip=true -PlintSkip=true -x testAndroidHostTest` | passed |
| `./gradlew :androidApp:bundleRelease -PiosSkip=true -PlintSkip=true` | AAB built |

The fix is its own commit so it can be cherry-picked for a hotfix release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Em1dvUJFi5xj6Lyx9SVFmR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android compatibility by avoiding APIs unavailable on supported Java versions.
  - Excluded Lua package tests that cannot run in the Android host environment.

- **Tests**
  - Added Android host-side test coverage across supported modules.
  - Updated CI to run targeted Android lint checks and host tests, with reports uploaded.

- **Chores**
  - Added Android lint validation and project-wide lint configuration for generated code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->