### PR TITLE
Route slf4j into Kermit instead of shipping a second logging backend

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -124,9 +124,6 @@ dependencies {
     // Splash screen compatibility pre-android 12
     implementation(libs.androidx.core.splashscreen)
 
-    implementation(libs.slf4j.api)
-    implementation(libs.slf4j.android)
-
     implementation(libs.filekit.dialogs)
 
     // Leak detection

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -132,11 +132,24 @@ kotlin {
                 implementation(libs.antlr.kotlin.runtime)
             }
         }
+        getByName("commonJvmAndroidMain") {
+            dependencies {
+                // Not for our own logging (that is Kermit): this source set carries the slf4j
+                // provider that routes ktor's and dbus-java's logging into Kermit. See
+                // KermitSlf4jProvider.
+                implementation(libs.slf4j.api)
+            }
+        }
         jvmMain {
             dependencies {
                 // Desktop audio output (DesktopSoundPlayer); the matching natives are added below.
                 implementation(libs.lwjgl.core)
                 implementation(libs.lwjgl.openal)
+            }
+        }
+        getByName("commonJvmAndroidTest") {
+            dependencies {
+                implementation(kotlin("test"))
             }
         }
         jvmTest {

--- a/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/logging/KermitSlf4jProvider.kt
+++ b/core/src/commonJvmAndroidMain/kotlin/warlockfe/warlock3/core/logging/KermitSlf4jProvider.kt
@@ -1,0 +1,129 @@
+package warlockfe.warlock3.core.logging
+
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import org.slf4j.ILoggerFactory
+import org.slf4j.IMarkerFactory
+import org.slf4j.Marker
+import org.slf4j.event.Level
+import org.slf4j.helpers.BasicMDCAdapter
+import org.slf4j.helpers.BasicMarkerFactory
+import org.slf4j.helpers.LegacyAbstractLogger
+import org.slf4j.helpers.MessageFormatter
+import org.slf4j.spi.MDCAdapter
+import org.slf4j.spi.SLF4JServiceProvider
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Routes slf4j into Kermit, so that libraries logging through slf4j land wherever the app has
+ * pointed [Logger] and obey the same [Logger.setMinSeverity] as our own logging.
+ *
+ * We do not log through slf4j ourselves, but we cannot avoid it either: ktor declares slf4j-api
+ * across all of its modules, and dbus-java pulls it in behind FileKit's file dialogs on Linux.
+ * Without a provider on the classpath slf4j 2.x prints a "No SLF4J providers were found" banner
+ * and silently drops everything those libraries have to say. Binding it here instead of to
+ * slf4j-simple means one severity setting and one destination for the whole app rather than two.
+ *
+ * Registered via `META-INF/services/org.slf4j.spi.SLF4JServiceProvider`; nothing references it
+ * by name, so it is loaded reflectively by [org.slf4j.LoggerFactory].
+ */
+class KermitSlf4jProvider : SLF4JServiceProvider {
+    private val loggerFactory = KermitLoggerFactory()
+    private val markerFactory = BasicMarkerFactory()
+
+    // Markers and MDC are accepted and then ignored: nothing in the app sets them, and Kermit has
+    // nowhere to put them. They still need working implementations rather than nulls, because
+    // MDC and MarkerFactory hand these straight to callers - kotlinx-coroutines-slf4j's MDCContext
+    // rides in on ktor and would touch the adapter if anyone ever used it.
+    private val mdcAdapter = BasicMDCAdapter()
+
+    override fun getLoggerFactory(): ILoggerFactory = loggerFactory
+
+    override fun getMarkerFactory(): IMarkerFactory = markerFactory
+
+    override fun getMDCAdapter(): MDCAdapter = mdcAdapter
+
+    override fun getRequestedApiVersion(): String = REQUESTED_API_VERSION
+
+    override fun initialize() {
+        // Kermit needs no start-up; Logger is usable from its defaults before the app configures it.
+    }
+
+    private companion object {
+        /**
+         * The slf4j API series this provider is written against, which is what
+         * `LoggerFactory.versionSanityCheck()` compares against its own `{"2.0"}` compatibility
+         * list - not the version of slf4j-api we happen to resolve. Mismatches only warn, but they
+         * warn on stderr at first use, which is exactly the noise this provider exists to remove.
+         */
+        const val REQUESTED_API_VERSION = "2.0.99"
+    }
+}
+
+internal class KermitLoggerFactory : ILoggerFactory {
+    private val loggers = ConcurrentHashMap<String, org.slf4j.Logger>()
+
+    override fun getLogger(name: String): org.slf4j.Logger = loggers.computeIfAbsent(name) { KermitSlf4jLogger(it) }
+}
+
+/**
+ * One slf4j logger, forwarding to the global Kermit [Logger].
+ *
+ * [LegacyAbstractLogger] does the tedious half of the `org.slf4j.Logger` interface for us: it
+ * funnels all thirty-odd overloads through [handleNormalizedLoggingCall], having already checked
+ * the matching `isXxxEnabled()`, so arguments are only formatted for messages that will be logged.
+ */
+internal class KermitSlf4jLogger(
+    name: String,
+) : LegacyAbstractLogger() {
+    init {
+        // AbstractLogger.getName() reads this protected field.
+        this.name = name
+    }
+
+    override fun isTraceEnabled(): Boolean = isEnabled(Severity.Verbose)
+
+    override fun isDebugEnabled(): Boolean = isEnabled(Severity.Debug)
+
+    override fun isInfoEnabled(): Boolean = isEnabled(Severity.Info)
+
+    override fun isWarnEnabled(): Boolean = isEnabled(Severity.Warn)
+
+    override fun isErrorEnabled(): Boolean = isEnabled(Severity.Error)
+
+    /** Only used by back-ends that walk the stack for the caller's location. Kermit does not. */
+    override fun getFullyQualifiedCallerName(): String? = null
+
+    override fun handleNormalizedLoggingCall(
+        level: Level,
+        marker: Marker?,
+        messagePattern: String?,
+        arguments: Array<out Any?>?,
+        throwable: Throwable?,
+    ) {
+        Logger.log(
+            severity = level.toSeverity(),
+            tag = name,
+            throwable = throwable,
+            // basicArrayFormat returns null back for a null pattern, which slf4j permits: callers
+            // may log a bare throwable. Kermit wants a message, and a logging call is the last
+            // place that should be able to throw.
+            message = MessageFormatter.basicArrayFormat(messagePattern, arguments).orEmpty(),
+        )
+    }
+}
+
+/**
+ * The severity is read from the global Kermit config on every call rather than captured, so that
+ * a later [Logger.setMinSeverity] applies to loggers a library has already cached.
+ */
+private fun isEnabled(severity: Severity): Boolean = Logger.config.minSeverity <= severity
+
+private fun Level.toSeverity(): Severity =
+    when (this) {
+        Level.TRACE -> Severity.Verbose
+        Level.DEBUG -> Severity.Debug
+        Level.INFO -> Severity.Info
+        Level.WARN -> Severity.Warn
+        Level.ERROR -> Severity.Error
+    }

--- a/core/src/commonJvmAndroidMain/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
+++ b/core/src/commonJvmAndroidMain/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
@@ -1,0 +1,1 @@
+warlockfe.warlock3.core.logging.KermitSlf4jProvider

--- a/core/src/commonJvmAndroidTest/kotlin/warlockfe/warlock3/core/logging/KermitSlf4jProviderTest.kt
+++ b/core/src/commonJvmAndroidTest/kotlin/warlockfe/warlock3/core/logging/KermitSlf4jProviderTest.kt
@@ -1,0 +1,155 @@
+package warlockfe.warlock3.core.logging
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import org.slf4j.LoggerFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class KermitSlf4jProviderTest {
+    private class Entry(
+        val severity: Severity,
+        val message: String,
+        val tag: String,
+        val throwable: Throwable?,
+    )
+
+    private class RecordingWriter : LogWriter() {
+        val entries = mutableListOf<Entry>()
+
+        override fun log(
+            severity: Severity,
+            message: String,
+            tag: String,
+            throwable: Throwable?,
+        ) {
+            entries += Entry(severity, message, tag, throwable)
+        }
+    }
+
+    /** Kermit's [Logger] is process-wide state, so put it back the way we found it. */
+    private fun recording(
+        minSeverity: Severity = Severity.Verbose,
+        block: (RecordingWriter) -> Unit,
+    ) {
+        val previousWriters = Logger.mutableConfig.logWriterList
+        val previousSeverity = Logger.mutableConfig.minSeverity
+        try {
+            val writer = RecordingWriter()
+            Logger.setLogWriters(writer)
+            Logger.setMinSeverity(minSeverity)
+            block(writer)
+        } finally {
+            Logger.mutableConfig.logWriterList = previousWriters
+            Logger.mutableConfig.minSeverity = previousSeverity
+        }
+    }
+
+    @Test
+    fun slf4jResolvesToTheKermitProvider() {
+        // Nothing references the provider by name; if this fails, META-INF/services did not make it
+        // onto the classpath and slf4j has fallen back to its no-op logger.
+        assertIs<KermitLoggerFactory>(LoggerFactory.getILoggerFactory())
+        assertIs<KermitSlf4jLogger>(LoggerFactory.getLogger("io.ktor.client.HttpClient"))
+    }
+
+    @Test
+    fun loggersAreCachedByName() {
+        assertSame(LoggerFactory.getLogger("repeated.name"), LoggerFactory.getLogger("repeated.name"))
+    }
+
+    @Test
+    fun levelsMapOntoKermitSeverities() {
+        recording { writer ->
+            val logger = LoggerFactory.getLogger("levels")
+            logger.trace("t")
+            logger.debug("d")
+            logger.info("i")
+            logger.warn("w")
+            logger.error("e")
+
+            assertEquals(
+                listOf(Severity.Verbose, Severity.Debug, Severity.Info, Severity.Warn, Severity.Error),
+                writer.entries.map { it.severity },
+            )
+        }
+    }
+
+    @Test
+    fun theLoggerNameBecomesTheTag() {
+        recording { writer ->
+            LoggerFactory.getLogger("io.ktor.client.HttpClient").info("hello")
+
+            assertEquals("io.ktor.client.HttpClient", writer.entries.single().tag)
+        }
+    }
+
+    @Test
+    fun placeholdersAreFormatted() {
+        recording { writer ->
+            LoggerFactory.getLogger("format").info("connecting to {}:{}", "example.com", 1234)
+
+            assertEquals("connecting to example.com:1234", writer.entries.single().message)
+        }
+    }
+
+    @Test
+    fun aTrailingThrowableIsPassedThroughRatherThanFormatted() {
+        val boom = IllegalStateException("boom")
+
+        recording { writer ->
+            LoggerFactory.getLogger("throwing").error("failed on {}", "attempt 2", boom)
+
+            val entry = writer.entries.single()
+            assertEquals("failed on attempt 2", entry.message)
+            assertSame(boom, entry.throwable)
+        }
+    }
+
+    @Test
+    fun aBareThrowableWithNoMessageDoesNotBlowUp() {
+        // slf4j allows a null message, and a logging call is the last place that should throw.
+        val boom = IllegalStateException("boom")
+
+        recording { writer ->
+            LoggerFactory.getLogger("messageless").error(null, boom)
+
+            val entry = writer.entries.single()
+            assertEquals("", entry.message)
+            assertSame(boom, entry.throwable)
+        }
+    }
+
+    @Test
+    fun minSeverityGatesSlf4jLoggingToo() {
+        recording(minSeverity = Severity.Info) { writer ->
+            val logger = LoggerFactory.getLogger("gated")
+            assertFalse(logger.isDebugEnabled)
+            assertTrue(logger.isWarnEnabled)
+
+            logger.debug("dropped")
+            logger.warn("kept")
+
+            assertEquals(listOf("kept"), writer.entries.map { it.message })
+        }
+    }
+
+    @Test
+    fun aLaterMinSeverityChangeReachesAlreadyCachedLoggers() {
+        // Libraries hold onto the logger they fetched at class-init time, which for anything
+        // touched during start-up is before the app has configured Kermit.
+        val logger = LoggerFactory.getLogger("cached.before.configuration")
+
+        recording(minSeverity = Severity.Warn) {
+            assertFalse(logger.isInfoEnabled)
+        }
+        recording(minSeverity = Severity.Verbose) {
+            assertTrue(logger.isInfoEnabled)
+        }
+    }
+}

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -37,8 +37,8 @@ dependencies {
     implementation(libs.kotlinx.coroutines.swing)
     implementation(libs.kotlinx.serialization.json)
 
-    // Logging. Crash reporting comes from :compose (see SentryInit.kt).
-    implementation(libs.slf4j.simple)
+    // No logging dependency: Kermit comes from :core, which also carries the slf4j provider that
+    // routes slf4j-using libraries into it. Crash reporting comes from :compose (see SentryInit.kt).
 
     // In-app updates
     implementation(libs.potassium.updater)

--- a/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
+++ b/desktopApp/src/main/kotlin/warlockfe/warlock3/app/Main.kt
@@ -85,7 +85,6 @@ import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.window.DecoratedWindow
 import org.jetbrains.jewel.window.styling.LocalTitleBarStyle
 import org.jetbrains.jewel.window.utils.DesktopPlatform
-import org.slf4j.simple.SimpleLogger.DEFAULT_LOG_LEVEL_KEY
 import warlockfe.warlock3.app.updater.ChannelUpdater
 import warlockfe.warlock3.app.updater.channelsToCheck
 import warlockfe.warlock3.compose.AppContainer
@@ -571,8 +570,9 @@ private class WarlockCommand : CliktCommand() {
         if (!isDev) {
             version?.let { initializeSentry(platform = "desktop", version = it) }
         }
+        // This governs third-party logging too: libraries that log through slf4j (ktor, and
+        // dbus-java behind the file dialogs on Linux) are routed into Kermit by KermitSlf4jProvider.
         if (debug || isDev) {
-            System.setProperty(DEFAULT_LOG_LEVEL_KEY, "DEBUG")
             Logger.setMinSeverity(Severity.Debug)
         } else {
             Logger.setMinSeverity(Severity.Info)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,7 +72,6 @@ potassium = "0.6.0"
 room = "3.0.2"
 sentryKotlin = "0.27.0"
 slf4j = "2.0.18"
-slf4jAndroid = "2.0.17-0"
 uri = "0.0.21"
 xmlutil = "1.0.2.1"
 
@@ -137,9 +136,7 @@ reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reo
 room-compiler = { module = "androidx.room3:room3-compiler", version.ref = "room" }
 room-runtime = { module = "androidx.room3:room3-runtime", version.ref = "room" }
 sentry-kotlin = { module = "io.sentry:sentry-kotlin-multiplatform", version.ref = "sentryKotlin" }
-slf4j-android = { module = "uk.uuid.slf4j:slf4j-android", version.ref = "slf4jAndroid" }
 slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
-slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "androidxSqlite" }
 tomlkt = { module = "com.seanproctor:tomlkt", version.ref = "tomlkt" }
 uri = { module = "com.eygraber:uri-kmp", version.ref = "uri" }


### PR DESCRIPTION
We stopped logging through slf4j when `kotlin-logging` — an slf4j facade — was replaced with Kermit in f2890e71. The slf4j dependencies came along untouched, and have been sitting there since.

They cannot simply be deleted. `slf4j-api` is on the runtime classpath no matter what we do: every `ktor-*` module declares it, `dbus-java-core` and `-transport-native-unixsocket` arrive via `filekit-dialogs` (the XDG portal file chooser on Linux), and `kotlinx-coroutines-slf4j` rides along with ktor. What we were actually choosing was the **binding** — `slf4j-simple` on desktop, `uk.uuid.slf4j:slf4j-android` on Android — and drop that with nothing in its place and slf4j 2.x prints its three-line `No SLF4J providers were found / Defaulting to no-operation (NOP) logger` banner on first use, then discards whatever those libraries had to say.

So the wart was never the dependency. It was that third-party logs went somewhere else, under a different knob: `slf4j-simple` wrote everything to stderr at a level set by a system property, while Kermit's `SystemWriter` writes stdout below Error and stderr at Error, gated by `Logger.setMinSeverity`. Two controls, two streams, and Sentry only ever positioned to see one side.

## One provider, both platforms

`KermitSlf4jProvider` replaces both bindings. It lives in `:core`, which already has the `commonJvmAndroid` source set and already exposes Kermit, so desktop and Android pick it up transitively with no per-app wiring — `androidApp` and `desktopApp` each lose a dependency rather than gain one.

`LegacyAbstractLogger` does the tedious half of `org.slf4j.Logger` for us: it funnels all thirty-odd overloads into a single `handleNormalizedLoggingCall`, having already checked the matching `isXxxEnabled()`, so `{}` arguments are only formatted for messages that will actually be logged. Levels map `TRACE`→`Verbose` through `ERROR`→`Error`, and the slf4j logger name becomes the Kermit tag — the full name, which is what every other slf4j backend prints and what users of these libraries grep for.

Enablement reads `Logger.config.minSeverity` on **every** call rather than capturing it. Libraries hold onto the logger they fetched at class-init time, which for anything touched during start-up is before the app has configured Kermit; capturing would freeze those loggers at the default. There is a test for exactly that.

Markers and MDC are accepted and ignored — nothing here sets them and Kermit has nowhere to put them — but they get working implementations rather than nulls, since `MDC` and `MarkerFactory` hand them straight to callers.

The upshot in `Main.kt` is that the separate `System.setProperty(DEFAULT_LOG_LEVEL_KEY, "DEBUG")` goes away. `Logger.setMinSeverity` now governs ktor and dbus-java too.

## A crash slf4j-simple was absorbing

slf4j permits a null message — `log.error(null, throwable)`, a bare throwable — and `MessageFormatter.basicArrayFormat` returns null straight back for a null pattern. That NPEs on the way into Kermit's non-null `message`. `slf4j-simple` swallowed it and rendered `"null"`; we would have thrown, from inside a logging call, which is the last place that should be able to take the app down.

Guarded. `aBareThrowableWithNoMessageDoesNotBlowUp` fails with an NPE without the guard — checked, rather than assumed.

## Verified

Nine tests in `commonJvmAndroidTest`, green on both `jvmTest` and `testAndroidHostTest`. The first asserts `LoggerFactory.getILoggerFactory()` really is ours, so it fails loudly if the `META-INF/services` entry ever stops being packaged for either target — which is the failure mode that would otherwise be silent.

All three CI jobs pass locally: `check`, `lintAndroidMain :androidApp:lint`, `testAndroidHostTest`.

Per CLAUDE.md, the packaged app and not just CI. `createDistributable` then `--version` exits 0 with no SLF4J banner, and a probe run against the packaged `pathing-classpath.jar` confirms the binding survives the collapsed classpath:

```
ILoggerFactory = warlockfe.warlock3.core.logging.KermitLoggerFactory
logger = warlockfe.warlock3.core.logging.KermitSlf4jLogger
Warn: (probe.PackagedApp) hello from slf4j inside the packaged app
```

The Android release APK needed checking too, since the provider is only ever reached reflectively. R8 renames `SLF4JServiceProvider` to `fx3` and the service file to `META-INF/services/fx3`, rewriting the contents to match — the wiring holds through minification. I had added a keep rule, then rebuilt without it to see whether it was load-bearing; R8's ServiceLoader handling covers this on its own, so the rule is not in this PR. `proguard-rules.pro` is untouched.

## One behaviour change worth a look

Android never sets a min severity, so Kermit defaults to `Verbose` there. Third-party slf4j output will now reach logcat in release builds, where `slf4j-android` gated it at INFO. It matches what our own logging already does on Android, and ktor says almost nothing without the `Logging` plugin installed, so I left it rather than widen the scope here — but `MainActivity` setting a severity from `BuildConfig.DEBUG` would be a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyXrGSWJVhReqTrHo7Sb2S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified third-party library logging with the app’s Kermit logging system on Android, JVM, and desktop.
  * Preserved log severity levels, logger names as tags, placeholder formatting, and throwable details.
  * Logging responds to current minimum-severity settings, including changes made at runtime.

* **Bug Fixes**
  * Improved handling of exception-only log messages, including exceptions without messages.

* **Tests**
  * Added coverage for provider discovery, severity filtering, formatting, tagging, caching, and exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->